### PR TITLE
Add "How to use" to README and a transport-representation skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,51 @@ in its own folder with a `SKILL.md`, a `README.md`, and supporting reference fil
 |---|---|
 | [`planning-document-search/`](planning-document-search/) | Retrieve the documents attached to a UK planning application from the council's **public** online planning portal, given the application reference and council. Covers the major portal vendors (Idox, Northgate, Civica, Ocella, Agile, NEC, TerraQuest, StatMap, DEF Atrium…) with a tested per-vendor recipe and a council→portal→vendor registry. |
 | [`ecological-objection/`](ecological-objection/) | Evaluate the ecological evidence submitted with a planning application, map each deficiency to the national law/policy/guidance it engages, and draft a concise, well-founded objection — or advise that no sustainable objection exists. England-focused. |
+| [`transport-representation/`](transport-representation/) | Evaluate the transport/highways evidence (Transport Assessment/Statement, Travel Plan, parking, street layout, and mitigation secured at outline), map each deficiency to the national/local transport policy and guidance it engages, and draft a concise representation — or advise that none is warranted. England-focused. |
 
-The two are designed to chain: `planning-document-search` fetches the documents that
-`ecological-objection` then critiques.
+The skills chain: `planning-document-search` fetches the documents that a representation
+skill (`ecological-objection`, `transport-representation`) then critiques.
+
+## How to use
+
+These are **skills for Claude** — instruction sets Claude follows when you ask it to do
+the corresponding task. There are two ways to use them.
+
+### 1. In a chat with Claude — no setup
+
+Point Claude at this repo (or paste a skill's `SKILL.md`) and ask in plain language.
+Examples:
+
+- *"Using the planning-document-search skill, find and download the documents for
+  application [ref] at [council]."*
+- *"Use the ecological-objection skill on this application — read the ecology reports,
+  tell me if there's a sustainable objection, and draft one."*
+
+Give Claude the **application reference and the council**, or the **documents themselves**.
+The skills chain: `planning-document-search` fetches the documents, then a representation
+skill critiques them.
+
+### 2. Install so they trigger automatically (Claude Code)
+
+Copy a skill's folder to where Claude Code discovers skills, and it will trigger by its
+`description` without being named:
+
+- **Personal (all your projects):** `~/.claude/skills/<skill-name>/`
+- **Project (shared via a repo):** `<project>/.claude/skills/<skill-name>/`
+
+Each skill already has the `SKILL.md` frontmatter (`name`, `description`) that discovery
+needs — so it's just a copy. After that, a prompt like *"object to this application on
+ecology grounds"* invokes the skill automatically.
+
+### Before you rely on the output
+
+Read the disclaimer at the top: **not legal advice, no warranty, and the output needs
+human review.** Anything you submit to a council is normally published on its portal in
+your name.
 
 ## Principles
 
-Both skills share a posture set out in their own `SKILL.md`:
+The skills share a posture set out in their own `SKILL.md`:
 
 - **Public records, retrieved as a member of the public would** — targeted retrieval, not
   bulk harvesting; never defeat a bot challenge (stop and use a browser); identify
@@ -35,7 +73,7 @@ Both skills share a posture set out in their own `SKILL.md`:
 
 ## Freshness
 
-Portal assignments and the ecology guidance catalogue were web-verified in **August 2026**.
+Portal assignments and the ecology and transport guidance catalogues were web-verified in **August 2026**.
 Portals migrate and guidance editions turn over, so each skill re-resolves/re-verifies at
 run time; items flagged in the reference files are time-sensitive.
 

--- a/transport-representation/CHANGELOG.md
+++ b/transport-representation/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog — transport-representation
+
+Design decisions per revision, newest first. See `../CLAUDE.md` for the format and the
+house rules. The **_Why_** lines record the rationale so a future editor understands the
+intent.
+
+## 0.1.0 — 2026-08-14 — Initial release
+
+First version, built to the same pattern as the ecological-objection skill: a skill that
+(1) evaluates the transport/highways evidence submitted with a UK planning application,
+(2) maps each deficiency to the national/local transport policy and guidance it engages, and
+(3) drafts a concise representation — or advises that none is warranted. Structure:
+`SKILL.md` + `references/` (`deficiency-catalogue.md`, `national-guidance.md`,
+`house-style.md`, `objection-template.md`). Key design decisions:
+
+### Added
+- **The integrity principle plus two transport-specific framing rules.** _Why:_ (a) only
+  object where the evidence is genuinely inadequate — "don't object" is a valid output; (b)
+  **don't fight the settled parts** — on reserved-matters/s73 the principle and access are
+  fixed, so the fight is over *delivery* of the secured mitigation; (c) **pick the winnable
+  test** — capacity/congestion refusal needs a "severe" residual cumulative impact (a high
+  bar), so aim at sustainable-transport, active-travel, inclusive-design and evidence-
+  adequacy grounds instead. These three rules are what keep transport objections credible.
+- **Deficiency catalogue** distilled from worked representations: accessibility measured from
+  the access not the dwellings; inflated walking benchmarks; no route-quality or external
+  connectivity audit; no LTN 1/20 analysis / no forecast flows; public transport unassessed;
+  dated/selective trip data and monitoring from part-built sites; cycle parking double-counted
+  with car parking; opportunistic and inequitable parking; shared-surface/inclusive-design
+  gaps; failure to deliver outline mitigation; s73 loosening of banked infrastructure
+  triggers; internal inconsistencies; and the decision-maker's own duty.
+- **The "spine" argument as a distinct, reusable ground:** a highway-authority "no objection"
+  addresses safety and capacity only; transportational sustainability is the LPA's
+  responsibility as decision-maker. _Why:_ this recurs across strong representations and is
+  the point most often missing from officer reports.
+- **House style + annotated template** matching the ecology skill: measured expert voice,
+  material-considerations-only, quote-the-assessment-against-itself, accept the settled parts,
+  numbered summary of requests, and an optional "if minded to approve" set of enforceable
+  safeguards (milestone-linked caps, works secured up front, monitoring with teeth, committee
+  determination).
+
+### Changed / Security
+- **Scoped to transport, England-focused, explicitly not legal advice; no warranty; human
+  review required; public-document-in-your-name flag.** _Why:_ honest bounds and the same
+  user-protection disclaimers carried by the other skills — the tool drafts something a user
+  may submit to a public body in their own name.
+- **Built generic and public-safe from the start.** No case-, campaign-, consultant- or
+  place-specific fingerprints; local policy references left as `[insert …]` placeholders and
+  any "named inquiry against the same applicant/consultancy" framing kept only as generic
+  *guidance to exclude* it. _Why:_ per the repo house rules, the skill must be a reusable,
+  neutral tool that identifies no real dispute, applicant or consultant.

--- a/transport-representation/CHANGELOG.md
+++ b/transport-representation/CHANGELOG.md
@@ -4,6 +4,18 @@ Design decisions per revision, newest first. See `../CLAUDE.md` for the format a
 house rules. The **_Why_** lines record the rationale so a future editor understands the
 intent.
 
+## Unreleased
+
+### Changed
+- **Enforced the bullet / lettered-sub-point drafting discipline** in `house-style.md` and
+  the `objection-template.md` worked example (bulleted framework list; bulleted list of
+  omissions in the worked point 1; explicit rule to use `(a)/(b)/(c)` for multi-limb points
+  and to avoid semicolon-chained lists). _Why:_ a live test draft came out noticeably denser
+  than the ecology skill's output — long paragraphs, semicolon-run lists, no bullets. The
+  house style always intended "break dense material out," but the template's worked example
+  modelled the denser style, so the skill reproduced it. Fixing the exemplar and the rule
+  makes the cleaner layout the default, not a matter of luck.
+
 ## 0.1.0 — 2026-08-14 — Initial release
 
 First version, built to the same pattern as the ecological-objection skill: a skill that

--- a/transport-representation/LICENSE
+++ b/transport-representation/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ian Howard
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/transport-representation/README.md
+++ b/transport-representation/README.md
@@ -1,0 +1,58 @@
+# Transport Representation
+
+A skill for producing a rigorous, credible representation on the **transport/highways**
+merits of a UK planning application — or advising that no sustainable objection exists.
+England-focused.
+
+> **Not legal advice. No warranty.** Output is a draft aid provided "as is". **A human must
+> review and check it before submitting.** Note that a UK planning representation is
+> normally **published on the council's portal in the submitter's name** and kept on the
+> record — include only personal details you're content to make public.
+
+It does three things:
+
+1. **Evaluate** the applicant's transport evidence (Transport Assessment/Statement, Travel
+   Plan, parking schedules, street-layout drawings, and the mitigation secured at outline)
+   against current policy and design guidance, and identify the material deficiencies.
+2. **Map** each deficiency to the specific national and local transport policy and guidance
+   it engages.
+3. **Draft** the representation in clear, precise, concise language — to the house style of
+   a strong representation.
+
+## Contents
+
+| File | What it is |
+|---|---|
+| `SKILL.md` | The skill: workflow, the integrity principle and two transport framing rules, and pointers to the references. **Start here.** |
+| `references/deficiency-catalogue.md` | Function 1 — the evaluation checklist: recurring, defensible grounds, each with the tell, why it matters, what it breaches, and the ask. |
+| `references/national-guidance.md` | Function 2 — the policy/guidance catalogue with citations and superseded-edition traps. |
+| `references/house-style.md` | Function 3 — how a strong representation reads. |
+| `references/objection-template.md` | Skeleton + annotated worked example. |
+| `CHANGELOG.md` | Design decisions and their rationale, per revision. |
+
+## Two things that define this skill
+
+- **Aim at the winnable tests.** Refusal on capacity/congestion needs a **"severe"** residual
+  cumulative impact (a high bar); the stronger, usually-weaker-evidenced grounds are
+  sustainable-transport and active-travel compliance, inclusive design, and the adequacy of
+  the evidence — and the point that a highway-authority "no objection" is not an assessment of
+  transportational sustainability, which is the LPA's job.
+- **Don't fight the settled parts.** On reserved-matters or s73 applications, accept the
+  principle of development and the site access; press whether the layout *delivers* the
+  mitigation secured at outline.
+
+## Pairs with
+
+The **planning-document-search** skill retrieves the application documents (from a reference +
+council) that this skill then critiques.
+
+## Freshness
+
+The guidance catalogue was web-verified **August 2026**. Policy and design-guidance editions
+change (NPPF paragraph numbers, Manual for Streets, LTN status, Active Travel England's role);
+items flagged ⏳ in `national-guidance.md` are time-sensitive — **re-verify at the point of
+drafting.**
+
+## License
+
+MIT — see [`LICENSE`](LICENSE). Provided as-is, with no warranty; not legal advice.

--- a/transport-representation/SKILL.md
+++ b/transport-representation/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: transport-representation
+description: >-
+  Evaluate the transport/highways evidence submitted with a UK planning
+  application (Transport Assessment/Statement, Travel Plan, parking schedules,
+  street-layout drawings, and mitigation secured at outline), identify the
+  national and local transport policy/guidance it engages, and draft a concise,
+  well-founded objection (or advise that no sustainable objection exists).
+  England-focused. Not legal advice; no warranty; output requires human review.
+license: MIT
+---
+
+# Transport representation on a planning application
+
+Help a member of the public produce a rigorous, credible representation on the
+**transport/highways** merits of a planning application — the kind a case officer can act
+on and lift into the officer report. The skill does three things:
+
+1. **Evaluate** the applicant's transport evidence against current policy and design
+   guidance and identify the material deficiencies.
+2. **Map** each deficiency to the specific national (and local) transport policy and
+   guidance it engages.
+3. **Draft** the representation in clear, precise, concise language — or advise that the
+   evidence is sound and no sustainable objection exists.
+
+## When to use
+
+The user has a planning application and wants to object (or find out whether they *can*
+object) on transport/highways grounds — walking and cycling connectivity, public transport,
+the Transport Assessment/Statement, trip generation and junction modelling, parking, street
+layout and inclusive design, or the delivery of transport mitigation secured at outline.
+Trigger phrases: "object on transport grounds", "is this Transport Assessment any good",
+"critique this TA / Travel Plan", "the cycling/walking assessment looks thin", "they're
+watering down the access road" (s73).
+
+Not this skill: ecology, heritage, flooding, general amenity — separate matters. This skill
+is transport only.
+
+## What you need first
+
+- The **application reference and council** (and, ideally, the documents).
+- The **transport documents themselves** — you cannot critique what you have not read. Get
+  them from the council's planning portal; the companion **planning-document-search** skill
+  retrieves them from the reference + council. Prioritise: the Transport Assessment or
+  Transport Statement, the Travel Plan, parking schedules, the street-layout and visibility
+  drawings, and the **highway authority's consultation response** (often decisive — see the
+  integrity/spine points). On reserved-matters or s73 cases, also the **outline permission's
+  transport conditions and s106 obligations** (what mitigation was secured).
+- The **local plan's** transport and design policies and any local design guide (e.g. a
+  "healthy streets" guide) — cite these alongside national policy.
+
+## The integrity principle and two framing rules (read before drafting)
+
+**Only object where the evidence is genuinely inadequate or the impact genuinely
+unacceptable.** If the assessment measures from the right place, uses current data and
+current guidance, audits route quality, and the layout delivers the walking, cycling and
+public-transport provision policy expects, there is **no sustainable objection** — say so.
+Don't manufacture points from typos when the substance is sound; treat "don't object" as a
+valid output.
+
+Two rules specific to transport:
+- **Don't fight the settled parts.** On a reserved-matters application, the principle of
+  development and the site access are usually fixed by the outline — don't reopen them. The
+  reserved-matters stage is where the layout *delivers or designs out* the mitigation
+  secured at outline; that is the battleground.
+- **Pick the winnable test.** Refusal on *capacity/congestion* alone requires a **"severe"**
+  residual cumulative impact, or an **unacceptable** impact on highway safety (a high bar).
+  Objections are usually far stronger on **sustainable-transport and active-travel
+  compliance, inclusive design, and the adequacy of the evidence.** Aim there.
+
+## Workflow
+
+### Step 1 — Intake and read
+Gather the documents (above). Identify: the proposal and its **stage** (outline / reserved
+matters / full / s73 variation — this changes what is still open and what "deliver the
+mitigation" means); the transport receptors and destinations (schools, shops, centre, stops,
+network); whether an **outline mitigation package** exists to be delivered; and whether the
+**highway authority** has objected, said "no objection", or asked for more information. Read
+the highway authority's response first.
+
+### Step 2 — Evaluate against the deficiency catalogue (function 1)
+Work through [`references/deficiency-catalogue.md`](references/deficiency-catalogue.md)
+against the documents. For each candidate deficiency, confirm it is **actually present** and
+**material**, and capture the *specific* evidence — the document, author, date, and the
+paragraph/table/figure. Quote the assessment's own words (and where its scope promises
+something its body never delivers). Grade findings (decision-critical vs minor) and lead with
+the decision-critical. Apply the integrity principle; drop anything you cannot evidence.
+
+Key cross-cutting tests: Are distances measured **from the dwellings**, not the site access?
+Are walking benchmarks within **guidance**? Is there a **route-quality audit** and **external
+connectivity**? Is cycling tested against **LTN 1/20** with **forecast flows**? Is **public
+transport** actually assessed? Is trip generation on **current data** and representative
+comparators? Is **cycle parking additional** (not double-counted)? Is **inclusive design**
+addressed? Does the layout **deliver the outline mitigation**? And has the **LPA** been asked
+to assess sustainability itself, rather than defer to the highway authority's remit?
+
+### Step 3 — Map to policy and guidance (function 2)
+For every confirmed deficiency, attach the precise instrument from
+[`references/national-guidance.md`](references/national-guidance.md) — NPPF sustainable-
+transport paragraphs and the "severe"/safety tests, PPG, Manual for Streets, LTN 1/20,
+Inclusive Mobility, the National Design Guide / National Model Design Code, Active Travel
+England's role, the Equality Act duty — plus the **local plan** transport/design policies and
+the outline conditions/obligations. Cite specifically, never "best practice" in the abstract.
+Verify a citation you are unsure of rather than guessing.
+
+### Step 4 — Draft (function 3)
+Draft to [`references/house-style.md`](references/house-style.md) and
+[`references/objection-template.md`](references/objection-template.md): header → RE line (note
+the application stage) → opening (consultation status; material considerations; on RM/s73
+state you don't reopen principle/access) → framework list → numbered conclusion-headed points
+(quoted evidence, why it matters, the ask and its timing) → numbered **Summary of requests**
+(include "officers to assess sustainability directly and record it in the report") → optional
+"if minded to approve" safeguards → objection sentence → sign-off. Keep it concise; lead with
+the decision-critical points; aim at the winnable tests.
+
+### Step 5 — Check before sending
+- Every point is evidenced from the documents or cited guidance; nothing asserted.
+- Quotes are accurate and referenced (§/Table/Figure).
+- It reads as material considerations, not "congestion" complaint (unless severity is
+  actually evidenced).
+- On RM/s73, it accepts the settled principle/access and targets delivery.
+- Consultant-/campaign-specific framing excluded unless the user asked and it is defensible
+  on this application's own facts.
+- Requests are concrete and correctly timed to the stage.
+- Deadline: note if consultation has closed; representations remain material while the
+  application is undecided.
+- **Hand back to a human, with the two warnings:** the draft must be read and checked by a
+  person before submission, and submitting it puts a **public document in the user's name**
+  on the council's portal — confirm they're content with the content and the personal
+  details included.
+
+## Reference files
+
+- [`references/deficiency-catalogue.md`](references/deficiency-catalogue.md) — the evaluation
+  checklist: recurring, defensible grounds, each with the tell, why it matters, what it
+  breaches, and the ask.
+- [`references/national-guidance.md`](references/national-guidance.md) — the policy/guidance
+  catalogue, with citations, to map deficiencies to instruments.
+- [`references/house-style.md`](references/house-style.md) — how a strong representation reads.
+- [`references/objection-template.md`](references/objection-template.md) — skeleton +
+  annotated worked example.
+
+## Scope and limitations
+
+- **Not legal advice, and no warranty.** This helps a lay objector marshal evidence and cite
+  policy; it is not a substitute for a solicitor or a transport professional, guarantees no
+  outcome, and is provided "as is" with no warranty of accuracy or fitness for purpose.
+- **Human review is necessary before submitting.** A person must read the draft, check every
+  quote and citation against the actual documents, and confirm the points are correct and
+  fair for this application. Do not submit skill output unread.
+- **A UK planning representation is a public document in your name.** Comments and objections
+  are normally published on the council's planning portal, typically including the submitter's
+  name (and sometimes address), and kept on the record. Tell the user before they submit and
+  let them choose what personal details to include.
+- **England-focused.** The NPPF, PPG and most design guidance cited are England; devolved
+  policy differs in Wales/Scotland/NI — flag when the application is outside England and adjust
+  the citations.
+- **Evidence-bound.** Every point stands or falls on the submitted documents and the cited
+  guidance. Do not invent flows, distances or survey results; where information is missing,
+  that *absence* is itself the point ("no forecast flows are presented"), argued as such.
+- **The honest answer is sometimes "don't object."** Treat that as a valid, valuable output.

--- a/transport-representation/references/deficiency-catalogue.md
+++ b/transport-representation/references/deficiency-catalogue.md
@@ -1,0 +1,226 @@
+# Transport submission — deficiency catalogue
+
+The recurring, defensible grounds on which a planning application's **transport evidence**
+(Transport Assessment / Transport Statement, Travel Plan, parking schedules, street-layout
+and visibility drawings, and — at reserved matters or on a s73 variation — the delivery of
+the transport mitigation secured at outline) can be challenged. Each entry is a *pattern to
+look for*, not a template sentence: find the specific instance in the documents in front of
+you, quote it, and attach the request.
+
+Use this as the evaluation checklist (skill function 1). Cross-references point to
+[`national-guidance.md`](national-guidance.md); cite the specific instrument, not "best
+practice" in the abstract.
+
+> **Integrity rule (read first).** Only raise a deficiency that is actually present and
+> material. If the assessment measures from the right place, uses current data and current
+> guidance, audits route quality, and the layout delivers the active-travel and public-
+> transport provision the policy expects, there is **no sustainable objection** — say so.
+> Don't manufacture points from typos when the substance is sound.
+>
+> **Two framing rules specific to transport:**
+> - **Don't fight the settled parts.** On a *reserved matters* application the principle of
+>   development and the site access are usually fixed by the outline permission — don't try
+>   to reopen them. The reserved-matters stage is where the layout *delivers or designs out*
+>   the mitigation secured at outline; that is the battleground.
+> - **Pick the right test.** Refusal on *capacity/congestion* alone requires a **"severe"**
+>   residual cumulative impact, or an **unacceptable** impact on highway safety (a high bar
+>   — see national-guidance). Objections are usually far stronger on **sustainable-transport
+>   and active-travel compliance, inclusive design, and the adequacy of the evidence** than
+>   on "there will be more traffic." Aim there.
+
+---
+
+## A. Accessibility measured wrong, or not at all
+
+**A1 — Distances measured from the site access, not the dwellings.**
+- *Tell:* every walking/cycling distance (e.g. "X m to the station") is stated "from the
+  site access."
+- *Why it matters:* residents live *behind* the access, not at it, so every journey is
+  understated — and the whole sustainability case rests on these distances.
+- *Ask:* re-state all distances and conclusions from representative dwelling locations.
+
+**A2 — Walking-distance benchmarks stretched beyond guidance.**
+- *Tell:* the assessment adopts inflated "acceptable" walking distances (e.g. from an
+  observed-behaviour study) well beyond the convenience benchmarks in CIHT/MfS/National
+  Design Guide; sometimes justified as "using judgement to modify guidance."
+- *Why it matters:* observed/tolerated distances describe what *some* people put up with,
+  not what *most* find genuinely attractive; on the assessment's own tables, key
+  destinations often fall beyond every guidance distance.
+- *Ask:* re-assess against the recognised walking-distance benchmarks; where destinations
+  lie beyond them, the case must rest on public transport and cycling (which then must be
+  properly assessed — see B).
+
+**A3 — No distances measured at all / no assessment of key destinations.**
+- *Tell:* the document's own scope promises a connectivity assessment, but the section
+  contains none — no distances "to anything," no routes to school, shops, centre, network.
+- *Ask:* an addendum assessing walking/cycling connectivity to each key destination, with
+  distances from dwellings and a plan of every access point.
+
+---
+
+## B. Route quality and active travel not assessed
+
+**B1 — No route-quality audit.** Distance tables but no audit of the routes themselves:
+footway continuity and width, lighting, crossings on desire lines (are they controlled?),
+gradient, severance, personal security after dark. A route that is not safe and convenient
+*in practice* does not provide a genuine choice of modes.
+- *Ask:* a route-quality audit (lighting, footways, crossings, severance), with mitigation
+  where routes fail.
+
+**B2 — External connectivity not assessed.** Assessment stops at the red line; no routes to
+schools, shops, town centre, employment or the wider walking/cycling network; no pedestrian/
+cycle access points shown or related to desire lines and to the off-site active-travel
+infrastructure expected by policy or secured at outline.
+- *Ask:* an external connectivity plan showing every access point and how it connects.
+
+**B3 — No LTN 1/20 assessment for cycling.** Cycling dismissed in a line ("on-street cycling
+is acceptable") with **no forecast link flows** and no test against the LTN 1/20 thresholds
+for inclusive mixed-traffic cycling (motor-traffic volume and speed limits — see
+national-guidance for the figures). Where the spine street carries the whole development's
+traffic, mixed-traffic cycling may not be appropriate and dedicated provision must be
+designed in *now* (at reserved matters) or it never will be.
+- *Ask:* forecast daily flows for each street type; an LTN 1/20 compliance statement; a
+  cycle-connectivity plan to the external network.
+
+**B4 — Public transport not assessed.** The word "bus" barely appears; no walking routes or
+times to the stops (including any funded by a s106 obligation), no crossing provision to
+reach stops across the carriageway, no demonstration that stop locations relate to the
+site's access points.
+- *Ask:* a plan of walking routes/times to each stop with safe crossings, and confirmation
+  the layout does not prejudice secured public-transport infrastructure.
+
+---
+
+## C. Trip generation, data and modelling
+
+**C1 — Trip generation on dated or selectively-chosen data.** Modal split from the **2011
+Census** (or otherwise out of date) feeding trip generation and junction modelling, while
+current (2021) data is used elsewhere in the same document where it helps; or a "sustainable
+area" claim resting on a high car-driver mode share.
+- *Ask:* re-base modal split on current data and re-run the junction assessments if
+  materially changed.
+
+**C2 — Unrepresentative TRICS comparators.** Trip rates drawn from comparator sites that
+don't match this site's type, size or location (e.g. edge-of-town comparators for an urban
+site), or an unstated/opaque site selection.
+- *Ask:* a transparent, representative comparator set.
+
+**C3 — Monitoring data from a partially-built site treated as robust.** Observed trip rates
+from a partly-occupied, partly-constructed site used to argue generation is low and more
+occupation can be absorbed. Early occupations skew demographically, construction suppresses/
+redistributes trips, and post-pandemic baselines flatter the comparison.
+- *Ask:* the officer report to engage explicitly with these limitations; scrutinise any new
+  survey for seasonality and neutrality of the survey period.
+
+**C4 — Selective use of assessment tools.** Relying on the one favourable output of a tool
+(e.g. a connectivity/accessibility tool) while its other outputs, or the tool's own
+guidance, point the other way.
+- *Ask:* the full tool outputs and an assessment consistent with the tool's own guidance.
+
+---
+
+## D. Parking
+
+**D1 — Cycle parking double-counted with car parking.** A garage counted as a **car space**
+in the parking schedule *and* relied on as the dwelling's **cycle parking** — a garage can't
+store both a car and the household's cycles. Guidance treats cycle parking as *additional*,
+secure and conveniently accessible.
+- *Ask:* a schedule identifying cycle parking that is genuinely additional to car parking,
+  dwelling by dwelling.
+
+**D2 — Parking applied opportunistically; over-provision undermines modal shift.** The site
+is classified as "low accessibility" to justify generous maximum parking, in tension with
+the "sustainable location" case made at outline. Provision well above ~2 spaces/dwelling
+actively undermines the travel-plan and car-club modal-shift objectives and the vision-led
+approach.
+- *Ask:* review whether the overall quantum is consistent with the travel-plan objectives.
+
+**D3 — Below-standard parking for affordable tenure; overspill risk.** Standards applied
+generously to private plots but deficiently to affordable plots; the resulting overspill
+concentrates on the narrowest streets/shared surfaces and the local road.
+- *Ask:* provision meeting the adopted standard for *every* tenure, or a reasoned
+  justification plus an overspill-parking assessment.
+
+---
+
+## E. Inclusive design and specific users
+
+**E1 — Shared surfaces / single-sided footways without inclusive-design assessment.**
+Footways that reduce to one side or to a shared surface, with no inclusive-design review.
+Shared surfaces are recognised as posing serious difficulties for blind and partially-
+sighted people (who lose the kerb line), and the authority has its own Equality Act 2010
+duty in approving these details.
+- *Ask:* an inclusive-design review of all shared-surface and single-sided sections
+  demonstrating compliance with Inclusive Mobility, or conventional footways on desire lines.
+
+**E2 — Peripheral users / rural lanes not assessed.** Parts of the scheme (e.g. plots or
+uses reached off a separate lane) get a swept-path drawing and nothing else — no assessment
+of the lane's width, condition, lighting, forward visibility, passing provision, and **no
+pedestrian provision at all** for those residents (who will then walk in the carriageway in
+the dark). Sustainability obligations apply to every user, not just the main dwellings.
+- *Ask:* a suitability and pedestrian-access assessment for the lane, with a safe route onto
+  the internal footway network and onward to schools/stops.
+
+---
+
+## F. Delivery of what was secured at consent (reserved matters & s73)
+
+**F1 — The layout doesn't demonstrate delivery of the outline mitigation.** Outline
+permission was justified on a package of sustainable-transport mitigation (off-site active-
+travel works, access points for pedestrians/cyclists, public-transport contributions, a
+travel plan, a car club). The reserved-matters layout must *connect to and deliver* that
+package; instead the assessment doesn't address it, risking foreclosing it permanently.
+- *Ask:* demonstrate, on plan, how the layout delivers each secured commitment; resolve
+  before the reserved matters are approved.
+
+**F2 — A s73 / condition variation loosens an infrastructure trigger secured at consent.**
+An application seeks to release occupations from an infrastructure trigger (e.g. an access
+road, active-travel works) that the acceptability of the scheme was predicated on —
+substituting lesser interim mitigation of unstated duration. Where acceptability was
+established on infrastructure commitments and those are loosened application-by-application
+once the principle is banked, *the development consulted on is not the development built.*
+- *Ask:* treat the condition trigger as the safeguard it is; if minded to approve, tie
+  occupation caps to construction milestones of the secured infrastructure (see H).
+
+---
+
+## G. Evidence quality and the decision-maker's role
+
+**G1 — Internal inconsistencies.** Contradictory figures that go to the document's
+reliability: a design speed given as two different values in two sections; two tables with
+the same number; an accommodation or parking schedule whose rows don't sum; unexplained
+fractional space counts. Individually minor, collectively they show a document produced
+without adequate checking.
+- *Ask:* the errors reconciled; an internally contradictory evidence base cannot be relied
+  on.
+
+**G2 — "Highways has no objection" is not an assessment of sustainability (the spine).** A
+highway authority's consultation response typically addresses **safety and capacity** only;
+**transportational sustainability** — whether the layout prioritises sustainable modes,
+delivers the active-travel connections, and complies with NPPF sustainable-transport policy
+— is the **local planning authority's** responsibility as decision-maker. A highway-
+authority "no objection" must not be treated as an assessment of the matters you raise.
+- *Ask:* officers to assess the sustainable-transport matters directly and record that
+  assessment in the officer report, rather than deferring to the highway authority's remit.
+
+**G3 — The highway authority itself found the evidence insufficient.** The highway authority
+recommends "more information" / awaits further surveys before a comprehensive response — so
+the evidence the application was consulted on is, by the body best placed to judge,
+inadequate.
+- *Ask:* no determination until the further material is submitted and assessed; and, because
+  the public consulted on the superseded evidence, **full public re-consultation** on the
+  revised material.
+
+---
+
+## H. "If minded to approve" — fallback safeguards
+
+Where an objection may not prevent approval, ask for enforceable safeguards rather than
+leaving matters to good faith:
+- occupation caps tied to **construction milestones** of the secured infrastructure
+  (commencement, earthworks, base course, opening) — not merely a higher dwelling number;
+- the mitigation works **secured up front**, with completion triggers, before the relevant
+  occupations;
+- a **monitoring-and-review** mechanism with teeth — a defined trip threshold at which
+  further occupations pause;
+- **committee determination** where objection volume and strategic significance warrant it.

--- a/transport-representation/references/house-style.md
+++ b/transport-representation/references/house-style.md
@@ -1,0 +1,99 @@
+# House style — how a strong transport representation reads
+
+The goal is a representation a busy case officer can act on: **concise, specific,
+evidenced, and easy to lift into the officer report.** These are the writing rules the
+skill applies at the drafting stage (function 3). They mirror the approach of a good
+ecological representation; the transport-specific moves are flagged.
+
+## Voice and stance
+
+- **Measured and expert, never emotive.** The force comes from specificity — quoting the
+  applicant's own Transport Assessment against itself — not from volume. You are helping
+  the Council apply the tests correctly.
+- **Material considerations only.** Everything must be a planning material consideration:
+  the adequacy of the transport evidence, compliance with national/local transport policy
+  and design guidance, deliverability of the secured mitigation. Not "there'll be more
+  traffic and I don't like it."
+- **Accept what is settled.** On a reserved-matters or s73 application, say at the outset
+  that you are *not* seeking to reopen the principle of development or the site access —
+  they are fixed by the outline. This buys credibility and focuses the officer on the live
+  question: does the layout deliver the sustainable-transport outcomes the outline relied
+  on?
+- **Concede what is sound; don't manufacture.** If the assessment does something right,
+  don't attack it. If the whole thing is sound, advise *not* objecting.
+- **No personal criticism.** Critique the document and the method, not individuals.
+
+## Aim at the winnable tests
+
+Transport objections are often lost when pitched as "congestion." National policy sets a
+high bar for refusal on capacity (a **"severe"** residual cumulative impact) or safety (an
+**unacceptable** impact). Pitch instead — or as well — at the grounds where the bar is
+lower and the evidence is usually weaker:
+
+- **sustainable-transport / active-travel compliance** (the vision-led approach; walking,
+  cycling and public-transport provision);
+- **inclusive design** (shared surfaces, footways; the Equality Act duty);
+- **the adequacy and internal consistency of the evidence** (measured from the wrong place,
+  dated data, no route audit, no LTN 1/20 analysis);
+- **the decision-maker's own duty** — that a highway-authority "no objection" is not an
+  assessment of transportational sustainability.
+
+## Structure
+
+1. **Header block** — your name/address/email, the Council's address, date, case officer if
+   known.
+2. **RE line** — application reference + site + a one-line description (note if it's outline,
+   reserved matters, full, or a s73 variation — this frames everything).
+3. **Opening** — note consultation status; the matters are material considerations while the
+   application is undecided; ask that the representation be placed on the file. On RM/s73,
+   state you don't seek to reopen principle/access.
+4. **Framework list** — a short bulleted list of the transport policy/guidance engaged (see
+   `national-guidance.md`). Signals rigour and anchors every later point.
+5. **Numbered sections** — one deficiency per numbered sub-section, each with a **bold
+   one-line heading that states the point as a conclusion**, then 1–3 tight paragraphs.
+6. **Summary of requests** — a single numbered list of concrete asks, mostly ending "before
+   determination"; include the "officers to assess sustainability directly and record it in
+   the officer report" ask.
+7. **"If minded to approve"** (optional) — enforceable safeguards as a fallback (occupation
+   caps tied to construction milestones, works secured up front, monitoring with teeth,
+   committee determination).
+8. **Objection sentence** + sign-off.
+
+## Each point: the anatomy
+
+1. **Name the defect** in the heading as a conclusion ("Cycling: a one-sentence assessment
+   with no LTN 1/20 analysis").
+2. **Quote the document** — the applicant's own words with the paragraph/table/figure
+   reference (`§4.3.1`, `Table 4.1`). Quoting the assessment against itself is the strongest
+   move. Note where the document's own *scope* promises something its body never delivers.
+3. **Say why it matters** in planning terms — the consequence for the decision and the
+   specific policy/guidance breached, cited precisely (e.g. NPPF sustainable-transport
+   paragraph; LTN 1/20; Manual for Streets; Inclusive Mobility).
+4. **State the ask** — the specific thing to do and *when* ("before determination", "at
+   reserved matters", "secured by condition/obligation").
+
+## Load-bearing arguments (use where they fit)
+
+- **"Resolve by evidence, not condition / not at a later stage."** Serious gaps go to
+  whether the layout is acceptable now; granting first can foreclose the connections
+  permanently.
+- **"The layout delivers or designs out the outline commitments."** The reserved-matters
+  stage is where secured mitigation is delivered — or quietly lost.
+- **"Highways assesses safety and capacity; sustainability is the LPA's job."** A consultee
+  "no objection" is not an assessment of the matters you raise.
+- **"The development consulted on is not the development built."** For s73/condition
+  variations that loosen infrastructure triggers banked at consent.
+
+## Length, formatting, and what to leave out
+
+- **Shorter is stronger.** One point per paragraph; cut throat-clearing; if a sentence
+  doesn't add a fact or a consequence, delete it.
+- Bold sub-section headings; italicise quoted document text; keep bullets parallel.
+- British spelling and legal register ("the Council", "determination", "material
+  consideration"). Spell out an acronym once (TA/TS, LTN 1/20, MfS, ATE).
+- Reference documents precisely by author and date the first time ("the Transport Statement
+  ([consultant], [date])").
+- **Leave out:** anything you can't evidence; consultant- or campaign-specific framing (e.g.
+  cross-referencing other live applications or a named inquiry) — default to omitting it and
+  argue each point on this application's own facts; padding and repetition; and "congestion"
+  complaints that don't meet the "severe" test unless you can actually evidence severity.

--- a/transport-representation/references/house-style.md
+++ b/transport-representation/references/house-style.md
@@ -87,8 +87,18 @@ lower and the evidence is usually weaker:
 ## Length, formatting, and what to leave out
 
 - **Shorter is stronger.** One point per paragraph; cut throat-clearing; if a sentence
-  doesn't add a fact or a consequence, delete it.
-- Bold sub-section headings; italicise quoted document text; keep bullets parallel.
+  doesn't add a fact or a consequence, delete it. Prefer short sentences to long ones
+  chained with semicolons.
+- **Break dense material out — don't run it into prose.** This is what keeps the
+  representation scannable:
+  - where a point lists several things (missing items, destinations, defects), use a
+    **bulleted list**, not a semicolon-run inside a paragraph;
+  - where a point has two or more distinct limbs, use **bold lettered sub-points**
+    `(a)/(b)/(c)`;
+  - present the framework list as bullets;
+  - keep paragraphs short — a busy officer should see each point's structure at a glance.
+- Bold each sub-section heading as a conclusion; italicise quoted document text; keep bullets
+  parallel and short; end each point with a **Request:** line.
 - British spelling and legal register ("the Council", "determination", "material
   consideration"). Spell out an acronym once (TA/TS, LTN 1/20, MfS, ATE).
 - Reference documents precisely by author and date the first time ("the Transport Statement

--- a/transport-representation/references/national-guidance.md
+++ b/transport-representation/references/national-guidance.md
@@ -1,0 +1,246 @@
+# National transport policy and guidance (England)
+
+The framework to cite when mapping a deficiency (skill function 2). **Cite the specific
+instrument and clause, never "best practice" in the abstract.** Each deficiency in
+[`deficiency-catalogue.md`](deficiency-catalogue.md) points here.
+
+> **Compiled and web-verified 14 August 2026 (England).** Several items are time-sensitive
+> — the NPPF is under review and its paragraph numbers shift between editions, Manual for
+> Streets is being updated, and some exact figures need checking in the source PDF.
+> **Re-verify anything marked ⏳ before relying on it**, and confirm the current NPPF
+> paragraph numbers at the date you draft. This is not legal advice.
+>
+> **Scope:** the NPPF, PPG and most design guidance below are **England**. For Wales /
+> Scotland / NI, substitute the devolved policy and flag it.
+
+---
+
+## Part 1 — National planning policy (NPPF)
+
+**NPPF — December 2024 edition** (MHCLG, published 12 Dec 2024; current). Transport is
+**Chapter 9, "Promoting sustainable transport", paragraphs 109–118.** ⏳ The chapter
+renumbered **+1** from the Dec 2023 edition (it was 108–117), so **older documents and even
+the PPG cite the old numbers** — always confirm the current number. A Dec 2025 consultation
+draft exists but is **not** in force.
+Source: assets.publishing.service.gov.uk/media/67aafe8f3b41f783cca46251/NPPF_December_2024.pdf
+
+- **Para 109 — vision-led approach** *(was 108)*: transport considered from the earliest
+  stages "using a vision-led approach to identify transport solutions that deliver
+  well-designed, sustainable and popular places"; includes **109(d)** realising
+  opportunities from existing/proposed transport infrastructure and **109(e)** promoting
+  walking, cycling and public transport. ("Vision-led" is new Dec 2024 wording.)
+- **Para 111(d) — networks** *(was 110)*: policies should provide attractive, well-designed
+  walking and cycling networks with supporting facilities such as secure cycle parking,
+  drawing on **Local Cycling and Walking Infrastructure Plans (LCWIPs)**.
+- **Para 112–113 — parking** *(numbering shifts between editions — ⏳ verify)*: local parking
+  standards must reflect accessibility, type/mix of development, public-transport
+  availability, car-ownership and EV charging; maximum standards only with clear and
+  compelling justification. (There is **no national maximum** standard.)
+- **Para 115 — considering proposals** *(was 114)*: **115(a)** sustainable transport modes
+  **prioritised**; **115(b)** **safe and suitable access for all users**; **115(c)** the
+  **design of streets/parking reflects current national guidance, including the National
+  Design Guide and National Model Design Code**; **115(d)** significant network/safety
+  impacts cost-effectively mitigated to an acceptable degree via a vision-led approach.
+- **Para 116 — the refusal tests** *(was 115) — the key hook, and the high bar*: verbatim —
+  "Development should only be prevented or refused on highways grounds if there would be an
+  **unacceptable impact on highway safety, or the residual cumulative impacts on the road
+  network, following mitigation, would be severe**, taking into account all reasonable future
+  scenarios." Two distinct tests; **"severe" is undefined**. *Consequence for objections:*
+  a pure capacity/congestion objection must clear the "severe" bar — usually hard — so lead
+  instead on the sustainable-transport, access, design and evidence grounds below.
+- **Para 117 — priority to sustainable modes and disabled users** *(was 116)*: **117(a)**
+  priority **first to pedestrians and cyclists**, second to public transport; **117(b)**
+  **address the needs of people with disabilities and reduced mobility across all modes**;
+  117(c) minimise conflict; 117(d) servicing/emergency access; 117(e) EV charging.
+- **Para 118 — when a TA/TS and Travel Plan are required** *(was 117)*: "All developments
+  that will generate significant amounts of movement should be required to provide a travel
+  plan, and the application should be supported by a **vision-led transport statement or
+  transport assessment** so that the likely impacts… can be assessed and monitored."
+
+The **National Design Guide** (2019, rev. Jan 2021) "**Movement**" theme (well-connected,
+walkable neighbourhoods prioritising walking/cycling/PT) and the **National Model Design
+Code** (Jan 2021) are the design references para 115(c) points to.
+
+---
+
+## Part 2 — Planning Practice Guidance (PPG)
+
+**"Travel plans, transport assessments and statements"** (category ID 42; paras dated
+06-03-2014 — old but current). gov.uk/guidance/travel-plans-transport-assessments-and-statements
+- **Proportionality — 42-007:** assessment must be "proportionate to the size and scope of
+  the proposed development" — a thin document for a high-impact scheme is non-compliant.
+- **TA vs TS — 42-004:** a Transport Assessment is thorough; a Transport Statement is
+  lighter-touch for limited impacts.
+- **Required content — 42-015:** should cover (proportionately) access/layout, public
+  transport data, trip generation/travel characteristics, accident records, environmental
+  impacts, parking and mitigation — a checklist for exposing gaps.
+- **When required — 42-013:** established as early as possible; triggered by "significant
+  amounts of movement", judged case-by-case including **cumulative impacts**.
+- **Travel Plans — 42-003 / -011 / -012:** long-term management strategies with targets,
+  measures, monitoring and review, secured by condition/obligation.
+- **"Conditions are not a substitute for adequate assessment"** — this is **not** in the
+  transport PPG; anchor it to the **six tests for planning conditions** (NPPF para 56 / PPG
+  "Use of planning conditions", category 21): a condition must be *necessary* and cannot cure
+  a fundamental evidence deficiency.
+
+---
+
+## Part 3 — Active Travel England (ATE) — statutory consultee
+- **Statutory basis:** Town and Country Planning (Development Management Procedure) (England)
+  (Amendment) Order **2023 (SI 2023/142)**, amending the DMPO 2015; ATE is a statutory
+  consultee for applications made **on or after 1 June 2023**.
+- **Thresholds** (LPA must consult ATE): **≥150 dwellings**, **or** ≥**7,500 m²**
+  non-residential floorspace, **or** site area ≥**5 hectares**.
+- **ATE Planning Application Assessment Tool** scores proposals against ~31 criteria drawn
+  from **Manual for Streets, the National Model Design Code, Inclusive Mobility and LTN 1/20**
+  (segregation, crossings, junction assessment, minimum widths, walking/cycling distances).
+  A scheme scoring poorly, or departing from LTN 1/20 without justification, is vulnerable;
+  ATE's response is a material consideration. activetravelengland.gov.uk/planning
+
+---
+
+## Part 4 — The decision-maker vs the highway authority (the "spine")
+- The **local highway authority** (county/unitary) is a statutory consultee under the DMPO
+  2015; its remit is the **highway/traffic impact — safety and network capacity**.
+- **Transportational sustainability** — whether the scheme prioritises sustainable modes,
+  delivers active-travel connections, and meets NPPF para 116's tests — is for the **LPA as
+  decision-maker** (and, on appeal, the Inspector).
+- A consultee's response, **including a "no objection", is advice, not determination**: it
+  must be conscientiously weighed but is not binding, and relying on it uncritically —
+  without grappling with the concerns raised — is challengeable.
+- ⏳ *Caveat:* there is **no single codified NPPF/PPG sentence and no single leading named
+  case** squarely stating the "safety = highway authority / sustainability = LPA" split. It
+  is a structural principle (DMPO remit + para 116 being a decision for the decision-maker +
+  the general public-law rule that consultee responses are advisory). Argue it as such, not
+  as a one-case ratio.
+
+---
+
+## Part 5 — Equality Act 2010 / inclusive access
+- **Public Sector Equality Duty — Equality Act 2010, s.149:** in approving a street layout the
+  authority must have **due regard** to the needs of people with protected characteristics
+  (**disability**, **age**) — "in substance, with rigour and with an open mind", **at the
+  time** of the decision (*R (Bracking) v SSWP* [2013] EWCA Civ 1345). A failure genuinely to
+  consider effects on disabled/older/mobility-impaired people is challengeable.
+- **Shared space is paused:** the DfT **Inclusive Transport Strategy (July 2018)** asked
+  authorities to **pause new shared-space schemes with a level surface**; **LTN 1/11 "Shared
+  Space" was withdrawn (Aug 2018)** and not replaced; a joint ministerial letter (Sept 2018)
+  confirmed the pause and stressed formal crossings for visually-impaired people. A proposed
+  level-surface shared-space scheme runs against this.
+
+---
+
+## Part 6 — Other statutory/policy context
+- **National Highways / strategic road network:** DfT **Circular 01/2022** "The strategic road
+  network and the delivery of sustainable development" (supersedes 02/2013) sets the policy
+  National Highways applies; it is a statutory consultee under the DMPO where the SRN
+  (motorways/trunk roads) may be affected (safety, queuing, access).
+- **Speed limits:** DfT **Circular 01/2013 "Setting Local Speed Limits"** (current; 20 mph
+  guidance updated 17 Mar 2024 — ⏳ re-check for later revision) — the framework for local
+  speed limits and design speed.
+- **Active-travel strategy context:** "**Gear Change**" (DfT, July 2020) and the statutory
+  **Cycling and Walking Investment Strategy** (CWIS 2017; **CWIS2 2022**, under the
+  Infrastructure Act 2015), which underpin LCWIPs and LTN 1/20.
+
+---
+
+## Part 7 — Technical design guidance (what "competent" work follows)
+
+Deviation from the current edition — especially citing a **superseded/withdrawn** one — is a
+core objection ground. Traps are consolidated in Part 8.
+
+### Street design
+- **Manual for Streets (DfT, 2007)** + **Manual for Streets 2 (CIHT, 2010)** — **both current
+  and in force.** Design-led, place-based streets: a user hierarchy putting pedestrians first,
+  **design speeds derived from geometry** (not the reverse), justified (not excessive)
+  visibility splays/forward visibility, connected networks over cul-de-sacs, considered use of
+  shared surfaces. ⏳ An update ("MfS3"/"Manual for Streets 2026") is **drafted but NOT yet
+  published**; CIHT confirms the 2007/2010 advice still stands — don't let a report pre-empt an
+  unpublished edition.
+- **National Design Guide (2019, rev. Jan 2021)** — the "Movement" characteristic
+  (well-connected, walkable, active-travel-prioritising layouts).
+- **National Model Design Code (Jan 2021)** — Parts 1 & 2; movement/street types.
+
+### Cycling
+- **LTN 1/20 "Cycle Infrastructure Design" (DfT, July 2020)** — the national cycle-design
+  standard. ⚠ **Supersedes and withdraws LTN 2/08 (2008)** and LTN 1/12 — a report citing
+  LTN 2/08 relies on withdrawn guidance. Key content:
+  - **Mixed-traffic threshold (para 7.1.1):** the upper limits for cycling in mixed traffic
+    are **20 mph and 2,500 motor vehicles/day**; above either, cyclists should generally be
+    separated/protected. Summary Principle 3: cycle routes shown only by markings/symbols
+    should not be used on roads with high traffic volumes/speeds. ⏳ **Figure 4.1** (speed ×
+    volume decision graph) is the visual tool; some sources read it as unprotected lanes being
+    tolerable up to ~5,000 veh/day at 20 mph — 2,500/day is the inclusivity limit, 5,000 a
+    Figure-4.1 zone reading. **Confirm the exact figure/zone in the source PDF before pinning a
+    number.**
+  - **Five core principles:** coherent, direct, safe, comfortable, attractive.
+  - **Tools:** Cycling Level of Service (**CLoS**) and the **Junction Assessment Tool (JAT)** —
+    absence of a CLoS/JAT assessment for a significant scheme is a recognised gap.
+  - **Cycle parking:** secure, accessible/convenient and **additional** (both trip ends,
+    sufficient quantity, incl. non-standard cycles) — not double-counted with car parking.
+  - PDF: assets.publishing.service.gov.uk/media/5ffa1f96d3bf7f65d9e35825/cycle-infrastructure-design-ltn-1-20.pdf
+
+### Walking / inclusive access
+- **IHT "Guidelines for Providing for Journeys on Foot" (2000)** — still cited for
+  walking-distance benchmarks. **Table 3.2 (metres): town centres** 200 desirable / 400
+  acceptable / **800 preferred maximum**; **commuting/school** 500 / 1,000 / **2,000**;
+  **elsewhere** 400 / 800 / 1,200. **CIHT "Planning for Walking" (2015)** — walkable
+  neighbourhoods with facilities within ~**800 m / ~10 min**. *Key nuance:* an "acceptable"/
+  tolerated maximum is **not** an "attractive" distance — quoting a maximum-tolerance figure to
+  claim a site is "within walking distance" misuses the guidance.
+- **Inclusive Mobility (DfT, Dec 2021)** — current; ⚠ **supersedes the 2002 edition**. Footway
+  clear width **2,000 mm normal minimum**, **1,500 mm** acceptable where constrained (with
+  passing places), **1,000 mm** absolute minimum at an isolated obstacle; tactile paving,
+  dropped kerbs/crossings, gradients; and the **difficulties shared/level surfaces pose for
+  blind and partially-sighted people** (loss of the kerb line). Detailed tactile-paving
+  reference: DfT *Guidance on the Use of Tactile Paving Surfaces* (1998, reprinted 2007).
+
+### Assessment methods & tools
+- **Guidance on Transport Assessment (GTA, 2007)** — ⚠ **WITHDRAWN (Oct 2014)**, replaced by
+  the NPPF + PPG. Reports still cite it as current — it is withdrawn national guidance.
+- **TRICS (current version 8)** + the **TRICS Good Practice Guide** — the trip-generation
+  database. Comparator sites must be genuinely comparable in land use, size, location type and
+  PT accessibility; cherry-picked, unrepresentative, too-small or dated comparator sets breach
+  the Good Practice Guide. **The 2021 Census supersedes the 2011 Census** — a modal-split case
+  on 2011 data is out of date.
+- **DfT Connectivity Tool** and the **Propensity to Cycle Tool** — accessibility/cycling-
+  potential tools; misuse = selectively quoting favourable outputs contrary to the tool's own
+  guidance (e.g. presenting a target/"Go Dutch" scenario as current demand).
+- **Parking:** no national maxima (former PPG13 maxima removed); standards are local, per NPPF.
+  Two recurring objection points: the **tension between a "sustainable/accessible location"
+  claim and a "low accessibility" maximum-parking classification** (a site can't be both), and
+  **cycle parking counted separately, not double-counted** with a car space in a garage.
+
+### Travel Plans
+- Framework: NPPF + PPG (2014). A Travel Plan needs measurable **modal-shift targets**, a
+  defined **measures** package, a **monitoring** regime (baseline + re-surveys), a **review/
+  remedial** mechanism, and **funding/securing** (s106/condition, coordinator, monitoring fee/
+  bond). ⚠ A Travel Plan is **not a substitute for good layout** — behavioural measures cannot
+  cure a car-dependent or poorly-connected design.
+
+---
+
+## Part 8 — Superseded / withdrawn quick reference (citing the old one is an objection ground)
+
+| Topic | Current | Superseded / withdrawn (⚠ if cited as current) |
+|---|---|---|
+| Cycle infrastructure design | **LTN 1/20 (July 2020)** | LTN 2/08 (2008), LTN 1/12 — withdrawn |
+| Transport assessment methodology | **NPPF + PPG (2014)** | Guidance on Transport Assessment (2007) — withdrawn Oct 2014 |
+| Inclusive/pedestrian access | **Inclusive Mobility (Dec 2021)** | Inclusive Mobility (2002) |
+| Shared space | **paused; LTN 1/11 withdrawn (2018)** | LTN 1/11 "Shared Space" (2011) |
+| Modal-split / census data | **2021 Census** | 2011 Census |
+| National Design Guide | **2021 revised** | 2019 original |
+| Street design | **MfS (2007) + MfS2 (2010)** | ⏳ "MfS3" not yet published — don't cite as current |
+
+## Part 9 — ⏳ Verify-before-relying (time-sensitive as of Aug 2026)
+
+- **NPPF paragraph numbers** — Dec 2024 edition used here (chapter renumbered +1 from Dec
+  2023; parking-paragraph numbers vary between editions); a Dec 2025 draft exists. Confirm the
+  live edition and number when you draft.
+- **LTN 1/20 Figure 4.1 exact zone boundaries** — the 2,500 vs ~5,000 veh/day reading;
+  confirm in the source PDF before quoting a precise figure.
+- **Manual for Streets update** — "MfS3"/"2026" drafted but not published; re-check gov.uk.
+- **Active Travel England** — role/thresholds current as of the 2023 order; confirm no change.
+- **Circular 01/2013** — 20 mph wording updated Mar 2024; re-check for later revision.
+- **CLoS/JAT and Inclusive Mobility exact figures** — confirm the precise chapter/section in
+  the source before quoting paragraph numbers.

--- a/transport-representation/references/objection-template.md
+++ b/transport-representation/references/objection-template.md
@@ -68,29 +68,40 @@ Yours [sincerely/faithfully],
 > frames the issue as delivery of the sustainable-transport mitigation the outline relied
 > on.⟩
 
-**The relevant framework includes:** ⟨keep to what is engaged — see national-guidance.md⟩
-the NPPF's sustainable-transport policies (the vision-led approach and the prioritisation
-of walking, cycling and public transport); Manual for Streets; LTN 1/20 (Cycle
-Infrastructure Design); Inclusive Mobility and the Council's Equality Act 2010 duty; the
-National Design Guide and National Model Design Code; **[the Local Plan's transport and
-design policies — insert the specific references]**; and the transport conditions and
-obligations attached to the outline permission.
+**The relevant framework includes:** ⟨keep to what is engaged — see national-guidance.md.
+Present it as a short bulleted list, not a semicolon-run.⟩
+
+- the NPPF's sustainable-transport policies — the vision-led approach and the priority to
+  walking, cycling and public transport;
+- Manual for Streets and Manual for Streets 2;
+- LTN 1/20 (Cycle Infrastructure Design);
+- Inclusive Mobility, and the Council's Equality Act 2010 duty;
+- the National Design Guide and National Model Design Code;
+- **[the Local Plan's transport and design policies — insert the specific references]**;
+- the transport conditions and obligations attached to the outline permission.
 
 ### 1. The assessment does not assess external walking and cycling connectivity at all
-⟨Point the document's own scope at its empty body — a powerful opening.⟩
+⟨Point the document's own scope at its empty body; then bullet the omissions — don't run
+them together with semicolons.⟩
 
 The Transport Statement's own scope states that its Section 3 "presents the development
-proposal, *including the pedestrian and cycle connections*." Section 3 contains an
-accommodation schedule and paragraphs on other matters; nowhere does the document assess
-walking and cycling routes from the dwellings to the adjoining school, local shops or the
-town centre; the location, directness, lighting or security of any external route; the
-pedestrian/cycle access points and how they meet desire lines; crossings of the main road
-to the bus stops; **or any distances whatsoever, to anything.** The reserved matters fix the
-internal layout that must connect to the off-site active-travel infrastructure secured at
-outline; a layout approved without demonstrating those connections risks foreclosing them
-permanently. **Request:** an addendum assessing connectivity to each key destination, with
-distances from representative dwellings, a route-quality and lighting audit, and a plan of
-every access point and how it connects to the secured off-site infrastructure.
+proposal, *including the pedestrian and cycle connections*." It does no such thing. The
+document nowhere assesses:
+
+- walking and cycling routes from the dwellings to the adjoining school, local shops or the
+  town centre;
+- the directness, gradient, lighting or personal security of any external route;
+- the pedestrian and cycle access points, and how they meet desire lines;
+- crossings of the main road to the bus stops; or
+- **any distances whatsoever, to anything.**
+
+The reserved matters fix the internal layout that must connect to the off-site active-travel
+infrastructure secured at outline. A layout approved without demonstrating those connections
+risks foreclosing them permanently.
+
+**Request:** an addendum assessing connectivity to each key destination — distances from
+representative dwellings, a route-quality and lighting audit, and a plan of every access
+point and how it connects to the secured off-site infrastructure.
 
 ### 2. Cycling: a one-sentence assessment with no LTN 1/20 analysis
 ⟨Quote the single sentence; contrast it with the guidance thresholds and the missing data.⟩

--- a/transport-representation/references/objection-template.md
+++ b/transport-representation/references/objection-template.md
@@ -1,0 +1,169 @@
+# Objection template + annotated worked example
+
+A **skeleton** to fill, and a **worked example** showing the house style in practice. Match
+the example's density and tone, not its exact wording — every point must come from the
+documents actually in front of you.
+
+---
+
+## Skeleton
+
+```
+[Your name]
+[Your address]
+[Email]
+
+[Date]
+
+[Planning department / Council name / address]
+[For the attention of [Case Officer], if known]
+
+RE: Application [ref] — [site]
+[One-line description — note whether outline / reserved matters / full / s73 variation]
+
+Dear [Sir or Madam / Mr/Ms Name],
+
+REPRESENTATION ON TRANSPORT AND HIGHWAYS GROUNDS — OBJECTION UNLESS MATTERS RESOLVED
+
+[Opening: consultation status; matters are material considerations while undecided; ask
+that this be placed on the file. On reserved matters / s73, state you do NOT seek to
+reopen the principle of development or the site access — only whether the layout delivers
+the sustainable-transport outcomes the outline relied on.]
+
+[State which documents you address — the Transport Assessment/Statement (author, date),
+the Travel Plan, the parking schedules, the layout drawings — and, on RM/s73, the
+transport mitigation secured at outline.]
+
+The relevant framework includes: [short bulleted list from national-guidance.md — only
+the instruments actually engaged].
+
+## 1. [Point stated as a conclusion]
+[Quote the document (§/Table/Figure). Why it matters for the decision + the guidance/
+policy breached. The ask and its timing.]
+
+## 2. [Next point]
+…
+
+## Summary of requests
+[Numbered, concrete, grouped, mostly "before determination"; include the ask that officers
+assess sustainability directly and record it in the officer report.]
+
+[Optional] If the Council is nonetheless minded to approve: [enforceable safeguards —
+occupation caps tied to construction milestones, works secured up front, monitoring with
+teeth, committee determination].
+
+Unless and until these matters are resolved, I object to [the grant of permission /
+approval of the reserved matters / this s73 variation].
+
+Yours [sincerely/faithfully],
+[Name]
+```
+
+---
+
+## Worked example (condensed — annotations in ⟨…⟩)
+
+> ⟨Header, RE line and opening omitted for brevity — see the skeleton. On a reserved-matters
+> application the opening accepts that principle and access are settled by the outline, and
+> frames the issue as delivery of the sustainable-transport mitigation the outline relied
+> on.⟩
+
+**The relevant framework includes:** ⟨keep to what is engaged — see national-guidance.md⟩
+the NPPF's sustainable-transport policies (the vision-led approach and the prioritisation
+of walking, cycling and public transport); Manual for Streets; LTN 1/20 (Cycle
+Infrastructure Design); Inclusive Mobility and the Council's Equality Act 2010 duty; the
+National Design Guide and National Model Design Code; **[the Local Plan's transport and
+design policies — insert the specific references]**; and the transport conditions and
+obligations attached to the outline permission.
+
+### 1. The assessment does not assess external walking and cycling connectivity at all
+⟨Point the document's own scope at its empty body — a powerful opening.⟩
+
+The Transport Statement's own scope states that its Section 3 "presents the development
+proposal, *including the pedestrian and cycle connections*." Section 3 contains an
+accommodation schedule and paragraphs on other matters; nowhere does the document assess
+walking and cycling routes from the dwellings to the adjoining school, local shops or the
+town centre; the location, directness, lighting or security of any external route; the
+pedestrian/cycle access points and how they meet desire lines; crossings of the main road
+to the bus stops; **or any distances whatsoever, to anything.** The reserved matters fix the
+internal layout that must connect to the off-site active-travel infrastructure secured at
+outline; a layout approved without demonstrating those connections risks foreclosing them
+permanently. **Request:** an addendum assessing connectivity to each key destination, with
+distances from representative dwellings, a route-quality and lighting audit, and a plan of
+every access point and how it connects to the secured off-site infrastructure.
+
+### 2. Cycling: a one-sentence assessment with no LTN 1/20 analysis
+⟨Quote the single sentence; contrast it with the guidance thresholds and the missing data.⟩
+
+Cycling is dealt with in a single line — "on-street cycling is acceptable" — with **no
+forecast link flows presented anywhere.** LTN 1/20 sets thresholds for when mixed-traffic
+cycling is appropriate (motor-traffic volume and speed limits — see national-guidance). The
+spine street will carry the traffic of the whole development; if it exceeds those
+thresholds, dedicated provision (or a demonstrated parallel route) is required — and it must
+be designed in *now*, at reserved matters, or it never will be. **Request:** forecast daily
+flows for each street type; an LTN 1/20 compliance statement; and an external cycle-
+connectivity plan.
+
+### 3. Cycle parking double-counted with car parking
+⟨A crisp, self-evident inconsistency.⟩
+
+The schedule counts each garage as a **car parking space** and simultaneously states that
+**cycle parking** is provided "within the garages." A single garage cannot store a car and
+the household's cycles at once; guidance treats cycle parking as *additional*, secure and
+accessible provision, so counting the same floorspace towards both standards overstates
+compliance with each. **Request:** a revised schedule identifying cycle parking that is
+genuinely additional to car parking, dwelling by dwelling.
+
+### 4. The Council must make its own sustainability assessment
+⟨The spine argument — reserve it as a distinct point so the officer records it.⟩
+
+These are planning matters, not highway-engineering matters. A highway-authority "no
+objection" typically addresses safety and capacity only; whether this layout prioritises
+sustainable modes, delivers the active-travel connections secured at outline, and complies
+with the NPPF's sustainable-transport policy is for the Council as decision-maker. I ask
+that officers assess points 1–3 directly and record that assessment in the officer report,
+rather than treating the highway authority's consultation response as sufficient.
+
+### Summary of requests
+⟨Concrete, numbered, timed. What the officer lifts into the report.⟩
+
+Before determination:
+1. A pedestrian and cycle connectivity addendum: distances from representative dwellings
+   (not the site access), a route-quality and lighting audit, and a plan of all access
+   points connecting to the off-site active-travel infrastructure secured at outline;
+2. A public-transport access plan: walking routes and crossings to each funded stop;
+3. Forecast internal link flows and an LTN 1/20 compliance statement for each street type,
+   with an external cycle-connectivity plan;
+4. Cycle parking demonstrated to be additional to, not shared with, car parking;
+5. A direct assessment by the Council of the sustainable-transport matters above, recorded
+   in the officer report — noting that the highway authority's remit (safety and capacity)
+   does not extend to transportational sustainability.
+
+Unless and until these matters are resolved, I object to the approval of the reserved
+matters.
+
+Yours faithfully,
+[Name]
+
+---
+
+### Notes on adapting the example
+
+- **Frame by application type.** Outline: press the strategic sustainable-transport case and
+  the adequacy of the Transport Assessment. Reserved matters: accept principle/access, press
+  *delivery* of the secured mitigation in the layout. s73 / condition variation: press that
+  an infrastructure trigger banked at consent should not be loosened, and ask for milestone-
+  linked caps if approved.
+- **Pick the winnable tests** (see house-style): sustainable-transport/active-travel
+  compliance, inclusive design, and evidence adequacy — not bare "congestion", which needs a
+  **"severe"** residual cumulative impact to found refusal.
+- **Consultant- or campaign-specific framing is excluded by default** — cross-referencing
+  other live applications, or citing a named public inquiry to attack a particular applicant
+  or consultancy. Raise each point on this application's own facts. (The underlying technical
+  points — measuring from the access, inflated walking distances, no route audit, LTN 1/20
+  non-compliance — are free-standing grounds in `deficiency-catalogue.md`.)
+- **Before submitting:** a person must read and check the draft — every quote and citation
+  against the actual documents — and be aware the representation is normally **published on
+  the council's portal in the submitter's name** and kept on the record, so include only
+  personal details the user is content to make public. This is a draft aid provided with no
+  warranty; it is not legal advice.


### PR DESCRIPTION
Two additions to the repo.

## 1. README "How to use"

A new section on how to actually use the skills:
- **In a chat with Claude (no setup):** point Claude at the repo / a `SKILL.md` and ask in plain language, with example prompts.
- **Install for auto-triggering (Claude Code):** copy a skill folder into `~/.claude/skills/<name>/` (personal) or a project `.claude/skills/<name>/` (shared) — the `SKILL.md` frontmatter handles discovery.
- Plus how the skills chain, and a pointer back to the review/disclaimer reminders.

## 2. New `transport-representation` skill

Built to the same pattern as `ecological-objection`. It (1) evaluates the transport/highways evidence submitted with an application, (2) maps each deficiency to the national/local transport policy and guidance it engages, and (3) drafts a concise representation — or advises that none is warranted.

- `SKILL.md`, `references/deficiency-catalogue.md`, a **web-verified** `references/national-guidance.md` (NPPF Dec 2024 ch.9 paras 109–118 incl. the para 116 "severe"/safety tests; LTN 1/20 thresholds; Manual for Streets; Inclusive Mobility; National Design Guide / NMDC; Active Travel England as statutory consultee; PPG; Equality Act PSED), `references/house-style.md`, an annotated `references/objection-template.md`, plus `README.md`, `LICENSE`, `CHANGELOG.md`.
- Two framing rules baked in: on reserved-matters/s73, do not reopen the settled principle/access — press *delivery* of the mitigation secured at outline; and aim at the winnable tests (sustainable transport, active travel, inclusive design, evidence adequacy) rather than "congestion", which needs a "severe" residual cumulative impact.

## House-rules compliance (per `CLAUDE.md`)

- **Generic and public-safe** — no case/campaign/consultant/place fingerprints (verified across the new files and the whole tree).
- **Not legal advice, no warranty, human review required**, and the "a UK planning representation is published on the council's portal in your name" flag — carried through the SKILL, README and template.
- **CHANGELOG** records the design decisions with rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)