### PR TITLE
Add heritage & flood representation skills and an application-triage router

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,23 @@ in its own folder with a `SKILL.md`, a `README.md`, and supporting reference fil
 
 | Skill | What it does |
 |---|---|
-| [`planning-document-search/`](planning-document-search/) | Retrieve the documents attached to a UK planning application from the council's **public** online planning portal, given the application reference and council. Covers the major portal vendors (Idox, Northgate, Civica, Ocella, Agile, NEC, TerraQuest, StatMap, DEF Atrium…) with a tested per-vendor recipe and a council→portal→vendor registry. |
-| [`ecological-representation/`](ecological-representation/) | Evaluate the ecological evidence submitted with a planning application, map each deficiency to the national law/policy/guidance it engages, and draft a concise, well-founded objection — or advise that no sustainable objection exists. England-focused. |
-| [`transport-representation/`](transport-representation/) | Evaluate the transport/highways evidence (Transport Assessment/Statement, Travel Plan, parking, street layout, and mitigation secured at outline), map each deficiency to the national/local transport policy and guidance it engages, and draft a concise representation — or advise that none is warranted. England-focused. |
+| [`planning-document-search/`](planning-document-search/) | **Retrieve** the documents attached to a UK planning application from the council's **public** online planning portal, given the application reference and council. Covers the major portal vendors (Idox, Northgate, Civica, Ocella, Agile, NEC, TerraQuest, StatMap, DEF Atrium…) with a tested per-vendor recipe and a council→portal→vendor registry. |
+| [`application-triage/`](application-triage/) | **Router.** Given an application, work out which material considerations are engaged, rank them, and route each to the representation skill that handles it — or advise there is no strong ground. Sets aside non-material concerns (loss of view, property values). |
+| [`ecological-representation/`](ecological-representation/) | Evaluate the **ecology / biodiversity** evidence (EcIA, protected-species surveys, BNG), map deficiencies to national law/policy/guidance, and draft a concise objection — or advise none is warranted. |
+| [`transport-representation/`](transport-representation/) | Evaluate the **transport / highways** evidence (Transport Assessment/Statement, Travel Plan, parking, street layout, secured mitigation), map deficiencies to policy/guidance, and draft a representation. |
+| [`heritage-representation/`](heritage-representation/) | Evaluate the **heritage / historic-environment** evidence (Heritage Statement, setting and archaeology assessments) for listed buildings, conservation areas, monuments and non-designated assets, and draft a representation. |
+| [`flood-representation/`](flood-representation/) | Evaluate the **flood-risk and drainage** evidence (Flood Risk Assessment, Drainage/SuDS strategy, Sequential/Exception Tests), map deficiencies to national policy, and draft a representation. |
 
-The skills chain: `planning-document-search` fetches the documents that a representation
-skill (`ecological-representation`, `transport-representation`) then critiques.
+All England-focused. The skills chain:
+
+1. **`planning-document-search`** fetches the application documents;
+2. **`application-triage`** decides which grounds are worth pursuing and routes to —
+3. a **representation** skill (`ecological-`, `transport-`, `heritage-`, `flood-representation`)
+   which evaluates the evidence and drafts the objection.
+
+Considerations without a dedicated skill yet (design, residential amenity, Green Belt,
+landscape, trees, air quality…) are covered by the triage skill's framework map, to argue on
+the application's own facts.
 
 ## How to use
 
@@ -73,7 +84,7 @@ The skills share a posture set out in their own `SKILL.md`:
 
 ## Freshness
 
-Portal assignments and the ecology and transport guidance catalogues were web-verified in **August 2026**.
+Portal assignments and the representation skills' guidance catalogues (ecology, transport, heritage, flood) were web-verified in **August 2026**.
 Portals migrate and guidance editions turn over, so each skill re-resolves/re-verifies at
 run time; items flagged in the reference files are time-sensitive.
 

--- a/application-triage/CHANGELOG.md
+++ b/application-triage/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog — application-triage
+
+Design decisions per revision, newest first. See `../CLAUDE.md` for the format and the
+house rules. The **_Why_** lines record the rationale so a future editor understands the
+intent.
+
+## 0.1.0 — 2026-08-14 — Initial release
+
+First version: the **router** for the representation skills. Given an application, it
+identifies the engaged material considerations, ranks them, and routes each to the skill that
+handles it. Structure: `SKILL.md` + `references/material-considerations.md`. Key design
+decisions:
+
+### Added
+- **A router, not a drafter.** _Why:_ the suite had drafting skills but nothing to answer the
+  lay user's real first question — "what should I object about?" Triage fills that gap and ties
+  the skills together; it hands off rather than drafting.
+- **Detection from the document list and site constraints.** _Why:_ the applicant's own
+  submitted reports (and their telling *absence*) plus the site's constraints
+  (`planning.data.gov.uk`, the EA flood map, the local plan) are the fastest, most reliable
+  signal of which considerations are engaged — more reliable than reading every document first.
+- **An explicit non-material list, with reframes.** _Why:_ lay objectors most often lose
+  credibility by raising non-material concerns (loss of view, property values, competition,
+  private disputes). Naming them — and offering a material reframe where one exists — is as
+  valuable as naming the good grounds.
+- **Honest ranking (decision-critical / supporting / weak) and a "no strong ground" output.**
+  _Why:_ consistent with the suite's integrity principle — the point is to spend effort where
+  it counts, and sometimes the honest answer is not to object.
+
+### Notes
+- Routes to `ecological-representation`, `transport-representation`, `heritage-representation`
+  and `flood-representation`; for considerations without a dedicated skill yet (design,
+  amenity, Green Belt, landscape, trees, air quality, …) it gives the framework to argue on
+  the application's own facts. Add routes here as new representation skills are built.

--- a/application-triage/LICENSE
+++ b/application-triage/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ian Howard
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/application-triage/README.md
+++ b/application-triage/README.md
@@ -1,0 +1,38 @@
+# Application Triage
+
+The **router** for the planning representation skills. Given a UK planning application, it
+works out which material planning considerations are actually engaged, ranks them, and routes
+each to the skill that handles it — or says plainly that there is no strong ground to object.
+
+> **Not legal advice. No warranty.** A starting assessment provided "as is"; **a human must
+> review the grounds and evidence before acting.** Anything later submitted to a council is
+> published on its portal in the submitter's name.
+
+## What it does
+
+- Reads the application (via the reference + council, or the documents) and its site
+  constraints.
+- Identifies the engaged material considerations from the proposal, the constraints, and the
+  presence or telling *absence* of technical documents.
+- **Ranks** them (decision-critical / supporting / weak) and **sets aside non-material
+  concerns** (loss of view, property values, competition, private disputes) — with a reframe
+  where one exists.
+- **Routes** each live ground to its representation skill.
+
+## Contents
+
+| File | What it is |
+|---|---|
+| `SKILL.md` | The skill: workflow, the integrity principle, and the routing table. **Start here.** |
+| `references/material-considerations.md` | The map: each consideration's tells, the skill/framework that handles it, and the non-material concerns to exclude. |
+| `CHANGELOG.md` | Design decisions and their rationale, per revision. |
+
+## Pairs with
+
+- **planning-document-search** — fetches the application documents and the constraint signals.
+- **ecological-representation**, **transport-representation**, **heritage-representation**,
+  **flood-representation** — the drafting skills this one routes to.
+
+## License
+
+MIT — see [`LICENSE`](LICENSE). Provided as-is, with no warranty; not legal advice.

--- a/application-triage/SKILL.md
+++ b/application-triage/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: application-triage
+description: >-
+  Given a UK planning application, work out which material planning
+  considerations are actually engaged and which representation skill(s) to run
+  (ecology, transport, heritage, flood risk, …), in what priority order — or
+  advise that there is no strong ground to object. The router for the planning
+  representation skills. England-focused. Not legal advice; human review required.
+license: MIT
+---
+
+# Planning application triage
+
+Help a member of the public who has an application in front of them but doesn't know **which
+grounds are worth pursuing**. This skill reads the application, identifies the material
+considerations that are genuinely engaged, ranks them, and routes each to the representation
+skill that handles it — or says plainly that there is no strong objection.
+
+It is the **router** for the representation skills, not a drafting skill itself. It answers
+"what should I object about, and how strong is each ground?", then hands off.
+
+## When to use
+
+The user has a planning application (a reference + council, or the documents) and asks
+something like: "should I object to this?", "what are the grounds?", "what's wrong with this
+application?", "which of these is worth raising?" Use it first, before the topic-specific
+skills, whenever the grounds aren't already decided.
+
+## What you need first
+
+- The **application reference and council**, or the documents. The companion
+  **planning-document-search** skill retrieves them.
+- The **proposal description and application type** (full / outline / reserved matters / s73
+  / listed building consent / householder …) — this frames everything.
+- The **site's planning constraints** — is it in a conservation area, near a listed building,
+  in a flood zone, Green Belt, an AONB/National Landscape, greenfield? Public constraint data
+  (e.g. `planning.data.gov.uk` for conservation areas, listed buildings, Article 4 directions;
+  the Environment Agency "Flood map for planning" for flood zones) tells you this without the
+  application documents.
+- The **document list itself** — it is the single best signal. The presence of an *Ecological
+  Impact Assessment*, *Transport Assessment*, *Heritage Statement* or *Flood Risk Assessment*
+  tells you which considerations the applicant themselves thought were engaged.
+
+## The integrity principle
+
+**Only flag a ground that is genuinely engaged and arguable.** Triage is not a licence to
+manufacture objections — if the application is sound, or a consideration is not actually in
+play, say so. Two disciplines in particular:
+
+- **Distinguish material from non-material.** Objections must rest on *material planning
+  considerations*. Common **non-material** concerns to set aside (or reframe): loss of a
+  private view; impact on property values; competition with an existing business; boundary or
+  covenant disputes; the identity or motives of the applicant; construction disturbance in
+  itself (as opposed to a permanent effect); and moral objections. Tell the user honestly when
+  their concern isn't material — and whether it can be reframed as one that is (e.g. "it will
+  ruin my view" is not material, but "it is overbearing and harms the character of the street"
+  may be).
+- **Rank honestly.** Not every engaged ground is a *strong* ground. Say which are decision-
+  critical, which are supporting, and which are weak — so the user spends effort where it
+  counts.
+
+## Workflow
+
+### Step 1 — Intake
+Get the application (reference + council, or documents), the proposal and its **type/stage**,
+and the **site constraints** (conservation area, listed buildings, flood zone, Green Belt,
+AONB, greenfield/brownfield, protected trees). Retrieve the **document list**.
+
+### Step 2 — Scan for engaged considerations
+Work through [`references/material-considerations.md`](references/material-considerations.md).
+For each consideration, check the *tells* — the application type, the proposal, the site
+constraints, and the presence (or telling *absence*) of the relevant technical document. Note
+the evidence for each ground you flag.
+
+### Step 3 — Rank
+Grade each engaged ground: **decision-critical / supporting / weak**, on the strength of (a)
+how clearly national or local policy is engaged, (b) whether the applicant's evidence looks
+thin or is missing, and (c) how much weight the consideration typically carries. Set aside
+non-material concerns (with a reframe where possible).
+
+### Step 4 — Route
+For each ground worth pursuing, name the representation skill that handles it and hand off:
+
+| Consideration | Skill |
+|---|---|
+| Ecology / biodiversity / protected species / BNG | **ecological-representation** |
+| Transport / highways / access / parking / active travel | **transport-representation** |
+| Heritage / listed buildings / conservation areas / archaeology | **heritage-representation** |
+| Flood risk / drainage / SuDS | **flood-representation** |
+| Other material considerations (design, amenity, Green Belt, landscape, …) | *no dedicated skill yet — see the map for the framework and argue on the documents' own facts* |
+
+Recommend an order (lead with the decision-critical grounds). Note where two skills should
+both run (a scheme often engages several).
+
+### Step 5 — Hand off / summarise
+Tell the user: the grounds worth objecting on (ranked), which skill will draft each, the
+non-material concerns to drop, and — if that's the honest answer — that there is no strong
+ground and an objection would not be sustainable.
+
+## Reference files
+
+- [`references/material-considerations.md`](references/material-considerations.md) — the
+  catalogue of material considerations: what each is, the tells that it's engaged, the skill
+  or framework that handles it, and the common non-material concerns to exclude.
+
+## Scope and limitations
+
+- **Not legal advice; no warranty; output requires human review.** Triage is a starting
+  assessment, provided "as is"; a person must confirm the grounds and the evidence before
+  acting.
+- **England-focused.** Material considerations are broadly similar across the UK but the
+  policy framework differs in the devolved nations — flag when the application is outside
+  England.
+- **A UK planning representation is public and in the submitter's name** — carry that warning
+  through to whichever representation skill drafts the objection.
+- **"No strong ground" is a valid, valuable output.** Say it when it's true.

--- a/application-triage/references/material-considerations.md
+++ b/application-triage/references/material-considerations.md
@@ -1,0 +1,136 @@
+# Material considerations — a triage map
+
+For each consideration: **what it is**, the **tells** that it's engaged (from the application
+type, the proposal, the site constraints, and the presence or *absence* of a technical
+document), the **skill or framework** that handles it, and a note on how much weight it
+typically carries. Then a list of **non-material** concerns to set aside.
+
+Use this to decide what to object about. Cite the specific framework, and route to the named
+skill. Where there is no dedicated skill yet, the framework line tells you what to argue on
+the application's own facts.
+
+> **Read the document list first.** The applicant's own submission usually names the engaged
+> considerations: an *Ecological Impact Assessment*, *Transport Assessment*, *Heritage
+> Statement / Statement of Significance*, *Flood Risk Assessment*, *Arboricultural Report*,
+> *Daylight/Sunlight Assessment*, *Landscape and Visual Impact Assessment*, *Air Quality
+> Assessment*, *Noise Assessment*. A telling **absence** (e.g. no FRA for a site partly in a
+> flood zone, no Heritage Statement next to a listed building) is itself a ground.
+
+---
+
+## Considerations with a dedicated skill
+
+### Ecology / biodiversity → **ecological-representation**
+- *What:* protected species (bats, great crested newts, reptiles, dormice, badgers, birds),
+  priority habitats, Biodiversity Net Gain, lighting, protected sites.
+- *Tells:* an Ecological Impact Assessment / Preliminary Ecological Appraisal, BNG metric,
+  protected-species surveys; a greenfield or vegetated site, watercourses, hedgerows, mature
+  trees, ponds; a designated site (SSSI/SAC/SPA) nearby; or the telling absence of ecological
+  survey where habitat is obviously present.
+- *Weight:* high where a European Protected Species or a designated site is engaged (Habitats
+  Regulations); statutory 10% BNG applies to most major development.
+
+### Transport / highways → **transport-representation**
+- *What:* access and safety, walking/cycling/public-transport provision, trip generation and
+  capacity, parking, inclusive design, delivery of secured mitigation.
+- *Tells:* a Transport Assessment/Statement, Travel Plan, parking schedules, access/visibility
+  drawings; a site with poor public-transport access, on a fast road, or reliant on active-
+  travel connections; the highway authority's consultation response.
+- *Weight:* refusal on *capacity/safety* needs a "severe"/"unacceptable" impact (high bar);
+  the winnable grounds are sustainable-transport, active-travel and inclusive-design
+  compliance, and evidence adequacy.
+
+### Heritage / historic environment → **heritage-representation**
+- *What:* harm to a listed building (or its setting), a conservation area, scheduled monument,
+  registered park/garden, or a non-designated heritage asset; archaeology.
+- *Tells:* a Heritage Statement / Statement of Significance, an archaeological desk-based
+  assessment; the site is in or adjoins a **conservation area**, is a **listed building** or
+  within its **setting**, or near a scheduled monument (check `planning.data.gov.uk` /
+  Historic England); a listed-building-consent or conservation-area application; or the
+  absence of a proportionate significance assessment.
+- *Weight:* high — the statutory duties (LB & CA Act 1990 ss.66/72) require *considerable
+  importance and weight*, and designated-asset harm attracts *great weight*.
+
+### Flood risk / drainage → **flood-representation**
+- *What:* flood risk to and from the development (all sources), the Sequential/Exception
+  Tests, safe access, sustainable drainage (SuDS), and surface-/foul-water capacity.
+- *Tells:* a Flood Risk Assessment, Drainage Strategy/SuDS report; the site is in **Flood Zone
+  2 or 3**, is >1 ha, or is in a critical drainage area (check the EA "Flood map for
+  planning"); a Lead Local Flood Authority or Environment Agency consultation; or the absence
+  of an FRA where one is required.
+- *Weight:* high where the Sequential/Exception Tests are engaged or an FRA is missing/
+  inadequate; the EA and LLFA are statutory consultees.
+
+---
+
+## Considerations without a dedicated skill yet (argue on the framework)
+
+Flag these when engaged and argue them on the application's own facts, citing the framework.
+
+- **Design and character** — NPPF Chapter 12 (well-designed places; refusal for poor design),
+  the National Design Guide and National Model Design Code, and local design policy. *Tells:*
+  a Design and Access Statement; an out-of-character bulk/height/density; local design codes.
+- **Residential amenity** — the neighbour classics: **daylight/sunlight** (BRE guidance),
+  **overlooking/loss of privacy**, **overbearing/overshadowing**, **noise and disturbance**.
+  *Tells:* a Daylight/Sunlight Assessment or Noise Assessment; close boundaries; windows
+  facing habitable rooms; a use that generates noise. Weight is real but fact-sensitive.
+- **Green Belt** — a *heavyweight* ground where it applies: development in the Green Belt is
+  *inappropriate* unless it falls within the exceptions, and inappropriate development is
+  harmful and should not be approved except in *very special circumstances* (NPPF Ch13).
+  *Tells:* the site is washed over by Green Belt (local plan / `planning.data.gov.uk`).
+- **Landscape and visual impact / AONB (National Landscape)** — NPPF Ch15; GLVIA3
+  methodology; great weight to conserving/enhancing National Landscapes. *Tells:* an LVIA;
+  a prominent or elevated site; an AONB/National Landscape or valued landscape.
+- **Trees** — TPOs, BS 5837, hedgerows (overlaps ecology). *Tells:* an Arboricultural Report;
+  protected trees; tree loss.
+- **Air quality** — NPPF; IAQM/EPUK guidance; Air Quality Management Areas. *Tells:* an Air
+  Quality Assessment; an AQMA; a trip-generating use.
+- **Agricultural land** — best and most versatile (BMV) land (NPPF). *Tells:* greenfield
+  agricultural land, an Agricultural Land Classification.
+- **Nutrient / water neutrality** — catchment-specific but decisive where it bites (Habitats
+  Regulations); overlaps ecology. *Tells:* the catchment is subject to a Natural England
+  advice position (e.g. certain river catchments).
+- **Housing land supply / the "tilted balance"** — whether the council can demonstrate a
+  five-year housing land supply engages the NPPF para 11 presumption; a strategic argument
+  rather than a site issue.
+- **Contamination, ground conditions, land stability; foul drainage capacity; light
+  pollution; ecology-adjacent public rights of way.**
+
+---
+
+## Not material — set these aside (or reframe)
+
+Objections must be *material planning considerations*. These commonly-raised concerns are
+**not** material, and an objection resting on them will carry no weight:
+
+- **Loss of a private view** (no right to a view) — *reframe:* impact on the character of the
+  area, or an overbearing effect, may be material.
+- **Impact on property values.**
+- **Competition** with, or loss of trade to, an existing business.
+- **Private disputes** — boundaries, covenants, rights of way as private-law matters, the
+  developer's motives or identity.
+- **Construction-period disturbance in itself** (noise/dust during works) — usually a matter
+  for a Construction Management Plan condition, not a reason for refusal; *reframe* to any
+  *permanent* effect.
+- **Moral objections**, or the fact that the land could be "better used" for something else.
+- **Matters controlled by other regimes** (e.g. building regulations, licensing) except where
+  they are also a planning consideration.
+
+Tell the user honestly when their concern is not material — and whether it can be reframed as
+one that is. Credibility with the case officer depends on it.
+
+## Quick triage from the document list + constraints
+
+1. **List the documents** (planning-document-search). Each technical report ⇒ its
+   consideration is in play; a missing report where the constraint is present ⇒ a ground.
+2. **Check constraints** — conservation area / listed buildings / Article 4
+   (`planning.data.gov.uk`), flood zones (EA flood map), Green Belt / AONB (local plan). Each
+   hit ⇒ the corresponding consideration.
+3. **Read the proposal and stage** — outline vs reserved matters vs s73 vs full vs LBC changes
+   what is open.
+4. **Read the statutory consultees' responses** — the highway authority, the LLFA/EA, Historic
+   England, Natural England, the county ecologist. Their concerns are strong signals (and their
+   *withdrawal* on safety/capacity is not an assessment of sustainability — see the transport
+   skill's "spine").
+5. **Rank and route** — lead with decision-critical grounds; drop the non-material; hand each
+   live ground to its skill.

--- a/flood-representation/CHANGELOG.md
+++ b/flood-representation/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog — flood-representation
+
+Design decisions per revision, newest first. See `../CLAUDE.md` for the format and the
+house rules. The **_Why_** lines record the rationale so a future editor understands the
+intent.
+
+## 0.1.0 — 2026-08-14 — Initial release
+
+First version, built to the same pattern as the other representation skills: (1) evaluate the
+flood-risk and drainage evidence, (2) map deficiencies to national policy/guidance and the
+tests, and (3) draft a concise representation — or advise that none is warranted. Structure:
+`SKILL.md` + `references/` (`deficiency-catalogue.md`, `national-guidance.md`, `house-style.md`,
+`objection-template.md`). Key design decisions:
+
+### Added
+- **Two anchors as the spine:** *the statutory consultees (Environment Agency, Lead Local Flood
+  Authority) are your allies* — read their responses first and build on any objection; and *the
+  two hard requirements* — safe for the development's lifetime, and no increase in flood risk
+  elsewhere. _Why:_ flood objections succeed when they align with the consultees and press the
+  two requirements that policy makes non-negotiable, rather than asserting "it will flood."
+- **Lead with the Sequential Test.** _Why:_ it is the first hurdle and can defeat an application
+  on its own (reasonably available lower-risk sites), before any site-specific FRA detail.
+- **A web-verified guidance catalogue** — the NPPF flood policies and the Sequential/Exception
+  Tests, the PPG flood zones and vulnerability classes, the EA/LLFA roles and standing advice,
+  climate-change allowances, and the SuDS standards — with time-sensitive items flagged ⏳ (NPPF
+  numbering; the Schedule 3 mandatory-SuDS status; climate allowances).
+- **Deficiency catalogue** covering the Sequential/Exception Tests, FRA adequacy (all sources,
+  current data, climate change, safe access, residual risk), not increasing risk elsewhere
+  (floodplain storage, runoff), SuDS and the drainage hierarchy, foul capacity, and consultee
+  engagement.
+- **House style + annotated template** with the bullet / lettered-sub-point discipline built in
+  from the start, so drafts are scannable.
+
+### Changed / Security
+- **Scoped to flood risk, England-focused, explicitly not legal advice; no warranty; human
+  review required; public-document-in-your-name flag.** _Why:_ the same user-protection
+  disclaimers as the other skills.
+- **Built generic and public-safe** — no case/campaign/consultant/place fingerprints; local
+  policy references left as `[insert …]`. _Why:_ repo house rules.

--- a/flood-representation/LICENSE
+++ b/flood-representation/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ian Howard
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/flood-representation/README.md
+++ b/flood-representation/README.md
@@ -1,0 +1,53 @@
+# Flood Representation
+
+A skill for producing a rigorous, credible representation on the **flood-risk and drainage**
+merits of a UK planning application — or advising that no sustainable objection exists.
+England-focused.
+
+> **Not legal advice. No warranty.** Output is a draft aid provided "as is". **A human must
+> review and check it before submitting.** A UK planning representation is normally **published
+> on the council's portal in the submitter's name** — include only personal details you're
+> content to make public.
+
+It does three things:
+
+1. **Evaluate** the applicant's flood-risk and drainage evidence (Flood Risk Assessment,
+   Drainage Strategy / SuDS report, Sequential/Exception Test) against current policy and
+   guidance, and identify the material deficiencies.
+2. **Map** each deficiency to the specific policy, test and guidance it engages.
+3. **Draft** the representation in clear, precise, concise language.
+
+## Contents
+
+| File | What it is |
+|---|---|
+| `SKILL.md` | The skill: workflow, integrity principle, and the two flood anchors. **Start here.** |
+| `references/deficiency-catalogue.md` | Function 1 — the evaluation checklist. |
+| `references/national-guidance.md` | Function 2 — the policy/guidance catalogue with citations. |
+| `references/house-style.md` | Function 3 — how a strong representation reads. |
+| `references/objection-template.md` | Skeleton + annotated worked example. |
+| `CHANGELOG.md` | Design decisions and their rationale, per revision. |
+
+## Two things that define this skill
+
+- **The statutory consultees are your allies.** The Environment Agency and the Lead Local Flood
+  Authority carry weight — read their responses first and build on any objection or holding
+  position.
+- **Two hard requirements.** Whatever the benefits, the development must be *safe for its
+  lifetime* and must *not increase flood risk elsewhere*. Lead with the Sequential Test, which
+  can defeat an application on its own.
+
+## Pairs with
+
+The **planning-document-search** skill retrieves the documents; **application-triage** decides
+whether flood risk is a live ground.
+
+## Freshness
+
+The guidance catalogue was web-verified **August 2026**. Policy and standards change (NPPF
+paragraph numbers; the status of mandatory SuDS under Schedule 3; climate-change allowances) —
+items flagged ⏳ in `national-guidance.md` are time-sensitive; re-verify at the point of drafting.
+
+## License
+
+MIT — see [`LICENSE`](LICENSE). Provided as-is, with no warranty; not legal advice.

--- a/flood-representation/SKILL.md
+++ b/flood-representation/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: flood-representation
+description: >-
+  Evaluate the flood-risk and drainage evidence submitted with a UK planning
+  application (Flood Risk Assessment, Drainage Strategy / SuDS report, and the
+  Sequential/Exception Test justification), identify the national policy and
+  guidance it engages, and draft a concise, well-founded objection — or advise
+  that no sustainable objection exists. England-focused. Not legal advice; no
+  warranty; output requires human review.
+license: MIT
+---
+
+# Flood-risk representation on a planning application
+
+Help a member of the public produce a rigorous, credible representation on the **flood-risk
+and drainage** merits of a planning application. The skill does three things:
+
+1. **Evaluate** the applicant's flood-risk and drainage evidence against current national
+   policy and guidance, and identify the material deficiencies.
+2. **Map** each deficiency to the specific policy, test and guidance it engages.
+3. **Draft** the representation in clear, precise, concise language — or advise that the
+   evidence is sound and no sustainable objection exists.
+
+## When to use
+
+The user has a planning application and wants to object, or find out whether they can, on
+flood-risk or drainage grounds — the Sequential/Exception Tests, an inadequate or missing Flood
+Risk Assessment, increased flood risk elsewhere, surface-water/foul drainage, or sustainable
+drainage (SuDS). Trigger phrases: "object on flood grounds", "is this Flood Risk Assessment
+adequate", "this will flood my property / make flooding worse", "they haven't done a sequential
+test", "the drainage isn't sustainable."
+
+Not this skill: ecology, transport, heritage, general amenity — separate matters.
+
+## What you need first
+
+- The **application reference and council**, or the documents (the **planning-document-search**
+  skill retrieves them).
+- The **flood/drainage documents** — the Flood Risk Assessment, the Drainage Strategy / SuDS
+  report, and any Sequential/Exception Test statement. Also the **Environment Agency and Lead
+  Local Flood Authority consultation responses** (often decisive — read them first).
+- The **flood context** — which **Flood Zone** the site is in (Environment Agency "Flood map for
+  planning"), its size, and any other flood sources (surface water, groundwater, sewers) or
+  critical drainage area; whether the site is greenfield.
+- The **local plan's** flood-risk and drainage policies, and any Strategic Flood Risk Assessment.
+
+## The integrity principle and two anchors (read before drafting)
+
+**Only object where the evidence is genuinely inadequate or the risk genuinely unacceptable.**
+If the site is in Flood Zone 1 with no other source, an FRA may not even be required; if the FRA
+is adequate, the tests are satisfied, and the EA and LLFA are content, there is **no sustainable
+objection** — say so. Treat "don't object" as a valid output.
+
+Two anchors:
+- **The statutory consultees are your allies.** The **Environment Agency** (river/sea risk) and
+  the **Lead Local Flood Authority** (surface-water drainage on major development) are statutory
+  consultees. Read their responses first; align with any objection/holding position and press
+  for it to be resolved *before* determination.
+- **The two hard requirements.** Whatever the benefits: the development must be **safe for its
+  lifetime** and must **not increase flood risk elsewhere** (ideally reduce it). Test both.
+
+## Workflow
+
+### Step 1 — Intake and read
+Identify the **flood zone(s)** and sources of risk, the site size, whether it is greenfield, and
+the application type. Read the **EA and LLFA responses first**. Get the FRA, Drainage Strategy
+and any Sequential/Exception Test statement.
+
+### Step 2 — Evaluate against the deficiency catalogue (function 1)
+Work through [`references/deficiency-catalogue.md`](references/deficiency-catalogue.md). Confirm
+each candidate deficiency is **present** and **material**, and capture the specific evidence —
+the document, author, date, and the paragraph/figure/plan. Quote the FRA's own words, or the
+consultee response. Grade findings and lead with the decision-critical.
+
+Key tests: Is the **Sequential Test** passed (reasonably available lower-risk sites)? Is the
+**Exception Test** (both limbs) met where required? Is a **site-specific FRA** provided where
+required, assessing **all sources** with current data and **climate-change allowances**? Are
+**safe access/egress and floor levels** shown, and **residual risk** assessed? Does the scheme
+**increase flood risk elsewhere** (floodplain storage, runoff)? Does the **drainage** follow the
+hierarchy, restrict runoff, and secure maintenance? Are the **EA/LLFA** satisfied?
+
+### Step 3 — Map to policy and guidance (function 2)
+Attach the precise instrument from
+[`references/national-guidance.md`](references/national-guidance.md) — the NPPF flood paragraphs
+and the Sequential/Exception Tests, the PPG (flood zones, when an FRA is required, vulnerability
+classes), the EA/LLFA roles and standing advice, the climate-change allowances, and the SuDS
+standards — plus the **local plan** flood policies and the Strategic Flood Risk Assessment. Cite
+specifically.
+
+### Step 4 — Draft (function 3)
+Draft to [`references/house-style.md`](references/house-style.md) and
+[`references/objection-template.md`](references/objection-template.md): header → RE line (note
+the flood zone) → opening → bulleted framework list → numbered conclusion-headed points (lead
+with the Sequential Test; quoted evidence; the ask) → numbered **Summary of requests** →
+objection sentence → sign-off. Keep it concise; use bullets for lists and `(a)/(b)` for
+multi-limb points (e.g. the Exception Test).
+
+### Step 5 — Check before sending
+- Every point is evidenced from the documents/consultees or cited policy; nothing asserted.
+- Figures and flood-zone references are accurate.
+- It aligns with, and builds on, the EA/LLFA positions.
+- Consultant-/campaign-specific framing excluded unless the user asked and it is defensible.
+- Requests are concrete and correctly timed.
+- **Hand back to a human, with the two warnings:** the draft must be read and checked, and
+  submitting it puts a **public document in the user's name** on the council's portal.
+
+## Reference files
+
+- [`references/deficiency-catalogue.md`](references/deficiency-catalogue.md) — the evaluation
+  checklist.
+- [`references/national-guidance.md`](references/national-guidance.md) — the policy/guidance
+  catalogue with citations.
+- [`references/house-style.md`](references/house-style.md) — how a strong representation reads.
+- [`references/objection-template.md`](references/objection-template.md) — skeleton + annotated
+  worked example.
+
+## Scope and limitations
+
+- **Not legal advice, and no warranty.** Not a substitute for a solicitor or a flood-risk
+  engineer; guarantees no outcome; provided "as is".
+- **Human review is necessary before submitting.** A person must check every figure and citation
+  against the actual documents.
+- **A UK planning representation is a public document in the submitter's name** — normally
+  published on the council's portal; include only personal details the user is content to make
+  public.
+- **England-focused.** The NPPF/PPG and EA/LLFA framework are England; devolved policy differs —
+  flag when outside England.
+- **Evidence-bound.** Don't invent flood levels, flows or modelling; where information is
+  missing, that *absence* is itself the point ("no FRA / no sequential test"), argued as such.
+- **The honest answer is sometimes "don't object."**

--- a/flood-representation/references/deficiency-catalogue.md
+++ b/flood-representation/references/deficiency-catalogue.md
@@ -1,0 +1,142 @@
+# Flood-risk & drainage submission — deficiency catalogue
+
+The recurring, defensible grounds on which a planning application's **flood-risk and drainage
+evidence** (a Flood Risk Assessment, a Drainage Strategy / SuDS report, and the Sequential/
+Exception Test justification) can be challenged. Each entry is a *pattern to look for*, not a
+template sentence: find the specific instance, quote it, and attach the request. Cross-
+references point to [`national-guidance.md`](national-guidance.md).
+
+> **Integrity rule (read first).** Only raise a deficiency that is actually present and
+> material. If the site is in Flood Zone 1 with no other flood source, an FRA may not even be
+> required; if the FRA is adequate, the Sequential/Exception Tests are satisfied, and the EA
+> and Lead Local Flood Authority are content, there is **no sustainable objection** — say so.
+>
+> **Two anchors for flood objections:**
+> - **The statutory consultees are your allies.** The **Environment Agency** (river/sea flood
+>   risk) and the **Lead Local Flood Authority** (surface-water drainage, major development) are
+>   statutory consultees. Read their responses first; align with any objection or "holding"
+>   position, and press for it to be resolved *before* determination.
+> - **The two hard requirements.** Whatever the benefits, the development must be **safe for its
+>   lifetime** and must **not increase flood risk elsewhere** (ideally reduce it). Those are the
+>   points to test.
+
+---
+
+## A. The Sequential and Exception Tests
+
+**A1 — Sequential Test not applied, or not passed.** Development that should be steered to
+areas at **lower** flood risk, without evidence that there are no **reasonably available sites**
+at lower risk within the area of search.
+- *Why it matters:* the Sequential Test is the first hurdle — if there are lower-risk
+  alternatives, the test fails and permission should be refused, whatever the site's own FRA
+  says.
+- *Ask:* a Sequential Test with a defined area of search and evidence that no reasonably
+  available lower-risk sites exist — before determination.
+
+**A2 — Exception Test not applied, or only half-done.** Where the Exception Test is required
+(a more-vulnerable use in a higher flood zone), it has **two** limbs and **both** must be met:
+- **(a)** the development provides wider sustainability benefits to the community that
+  **outweigh** the flood risk; and
+- **(b)** it will be **safe for its lifetime**, **without increasing flood risk elsewhere**,
+  and where possible will **reduce** flood risk overall.
+- *Tell:* the benefits limb asserted but the safety/no-worsening limb not demonstrated (or
+  vice versa).
+- *Ask:* both limbs of the Exception Test demonstrated on the evidence.
+
+**A3 — Sequential approach within the site not applied.** The most vulnerable uses (housing,
+ground-floor sleeping accommodation) placed in the higher-risk parts of the site when lower-
+risk parts exist.
+- *Ask:* the layout re-worked to put the most vulnerable uses in the lowest-risk areas.
+
+**A4 — Wrong vulnerability / flood-zone compatibility.** A "more vulnerable" (e.g. residential)
+or "highly vulnerable" use proposed in a flood zone where it is incompatible or requires the
+Exception Test, without that being addressed.
+- *Ask:* the vulnerability classification and flood-zone compatibility correctly applied.
+
+---
+
+## B. Flood Risk Assessment adequacy
+
+**B1 — No site-specific FRA where one is required.** No FRA for a site in **Flood Zone 2 or
+3**, over **1 hectare** in Zone 1, or in an area with other flood sources / a critical drainage
+problem.
+- *Ask:* a site-specific FRA to the required standard before determination.
+
+**B2 — Not all sources of flooding assessed.** The FRA addresses only rivers/sea and ignores
+**surface water, groundwater, sewers, and reservoirs**, where these are a risk at the site.
+- *Ask:* an assessment of all relevant sources of flood risk.
+
+**B3 — Out of date or wrong baseline.** The FRA uses superseded flood-zone/modelling data, the
+wrong flood zone, or ignores more recent EA mapping or a local surface-water study.
+- *Ask:* the FRA re-based on the current Environment Agency data and any local study.
+
+**B4 — Climate change allowances not applied, or the wrong ones.** Peak river-flow / peak
+rainfall allowances for the development's **lifetime** not applied, or an out-of-date/too-low
+allowance used.
+- *Ask:* the current climate-change allowances applied over the development's lifetime.
+
+**B5 — Safe access/egress and finished levels not demonstrated.** No safe access and egress in
+a flood event; finished floor levels not set above the design flood level (with freeboard);
+residual risk (e.g. a breach, or an event exceeding the design standard) not assessed; no flood
+warning/evacuation consideration where relevant.
+- *Ask:* safe access/egress, appropriate floor levels and freeboard, and a residual-risk
+  assessment.
+
+---
+
+## C. Not increasing flood risk elsewhere
+
+**C1 — Loss of floodplain storage not compensated.** Building in the floodplain displaces flood
+water without **compensatory storage** (level-for-level, volume-for-volume), increasing risk to
+others.
+- *Ask:* compensatory flood storage demonstrated, or the footprint kept out of the floodplain.
+
+**C2 — Development on functional floodplain (Zone 3b).** Built development (other than the water-
+compatible/essential exceptions) proposed on land that floods in the design event and is needed
+to store or convey flood water.
+- *Ask:* the functional floodplain kept free of inappropriate development.
+
+**C3 — Increased surface-water runoff.** Runoff not restricted to the **greenfield rate** (or a
+betterment on a brownfield site); attenuation undersized for the design storm (including the
+climate-change allowance).
+- *Ask:* runoff restricted to greenfield/agreed rates with adequately-sized attenuation.
+
+---
+
+## D. Drainage and SuDS
+
+**D1 — No sustainable drainage for major development.** Sustainable drainage systems (SuDS) not
+provided where expected for major development; a piped/attenuation-tank-only solution presented
+without justifying why SuDS features (swales, basins, permeable surfaces) are not used.
+- *Ask:* a SuDS-led drainage strategy for the major development.
+
+**D2 — Drainage hierarchy not followed.** The strategy discharges to sewer as a first resort
+without demonstrating that **discharge to ground (infiltration)** and then to a **watercourse**
+are not feasible; no infiltration (percolation) testing where ground discharge is dismissed.
+- *Ask:* the drainage hierarchy evidenced — infiltration tested first, watercourse next, sewer
+  only as a last resort.
+
+**D3 — SuDS deferred without deliverability or securing.** SuDS/drainage "to be secured by
+condition" with no demonstration that there is **space** in the layout for it, and no
+**maintenance/adoption/funding** mechanism for the lifetime of the development.
+- *Ask:* the drainage designed into the layout now, with a secured long-term maintenance and
+  adoption mechanism.
+
+**D4 — Foul drainage / sewer capacity not confirmed.** No confirmation from the sewerage
+undertaker that the **foul** network (and any surface-water connection) has capacity, risking
+sewer flooding or pollution.
+- *Ask:* confirmation of foul and surface-water capacity from the undertaker.
+
+---
+
+## E. Statutory-consultee engagement
+
+**E1 — Environment Agency objection or holding position not resolved.** An EA objection (often
+pending an adequate FRA) treated as if it can be conditioned away, or not resolved before
+determination.
+- *Ask:* the EA's objection resolved by evidence, and re-consultation on any revised FRA, before
+  determination.
+
+**E2 — Lead Local Flood Authority concerns not resolved.** The LLFA's surface-water/SuDS
+comments unanswered or the scheme inconsistent with them.
+- *Ask:* the LLFA's requirements met and secured before determination.

--- a/flood-representation/references/house-style.md
+++ b/flood-representation/references/house-style.md
@@ -1,0 +1,70 @@
+# House style — how a strong flood-risk representation reads
+
+The goal is a representation a busy case officer can act on: **concise, specific, evidenced,
+and easy to lift into the officer report.** These are the writing rules the skill applies at
+the drafting stage (function 3); they match the other representation skills, with the flood-
+specific moves flagged.
+
+## Voice and stance
+
+- **Measured and technical, never alarmist.** The force comes from the tests and the evidence —
+  the Sequential Test, the Exception Test, the FRA's own gaps — not from "it will flood." Quote
+  the FRA and the statutory consultees against the proposal.
+- **Material considerations only.** The adequacy of the flood-risk and drainage evidence and
+  compliance with national policy; not a general worry about weather.
+- **Align with the statutory consultees.** The Environment Agency and the Lead Local Flood
+  Authority carry weight; read their responses first and build on any objection or holding
+  position rather than duplicating it.
+- **Concede what is sound; don't manufacture.** If the FRA is adequate and the consultees are
+  content, say so. If the whole thing is sound, advise *not* objecting.
+
+## The flood-specific spine
+
+- **Sequential Test first.** If the development could reasonably go somewhere at lower flood
+  risk, it fails the first test — argue this before the site-specific detail, because it can be
+  decisive on its own.
+- **Both limbs of the Exception Test.** Wider benefits **and** safe-for-lifetime-without-
+  worsening-elsewhere. Applicants often prove the first and assert the second.
+- **The two hard requirements.** Whatever the benefits: **safe for its lifetime**, and **no
+  increase in flood risk elsewhere** (ideally a reduction). Test both.
+- **All sources, and the drainage hierarchy.** Surface water, groundwater and sewers matter as
+  much as rivers; SuDS and infiltration come before discharge to sewer.
+
+## Structure
+
+1. **Header block**; **RE line** (note the flood zone and application type); **opening**
+   (consultation status; material considerations; place on file; name the flood zone / sources).
+2. **Framework list** — a short **bulleted** list of the policy/guidance engaged (see
+   `national-guidance.md`) and the EA/LLFA positions.
+3. **Numbered sections** — one point per numbered sub-section, each a **bold conclusion
+   heading** then 1–3 tight paragraphs.
+4. **Summary of requests** — numbered, mostly "before determination".
+5. **Objection sentence** + sign-off.
+
+## Each point: the anatomy
+
+1. **Name the defect** in the heading as a conclusion.
+2. **Quote the document** — the FRA/Drainage Strategy's own words with the reference; or quote
+   the EA/LLFA response.
+3. **Say why it matters** — the consequence and the specific policy/test breached, cited.
+4. **State the ask** — the specific thing to do, and *when* ("before determination").
+
+## Formatting discipline (keep it scannable)
+
+- **Shorter is stronger.** One point per paragraph; prefer short sentences to long ones chained
+  with semicolons.
+- **Break dense material out — don't run it into prose.**
+  - list several things (the un-assessed flood sources, the drainage-hierarchy steps skipped,
+    the missing FRA elements) as a **bulleted list**;
+  - use **bold lettered sub-points** `(a)/(b)` for multi-limb points (e.g. the two limbs of the
+    Exception Test);
+  - present the framework list as bullets.
+- Bold each heading as a conclusion; italicise quoted text; end each point with a **Request:**
+  line.
+- British spelling and legal register. Spell out an acronym once (FRA, SuDS, EA, LLFA).
+
+## What to leave out
+
+- Anything you cannot evidence; generalised "it always floods here" without a source.
+- Non-material concerns (property values, insurance costs in the abstract).
+- Consultant-/campaign-specific framing — argue each point on this application's own facts.

--- a/flood-representation/references/national-guidance.md
+++ b/flood-representation/references/national-guidance.md
@@ -1,0 +1,177 @@
+# Flood-risk & drainage policy and guidance (England)
+
+The framework to cite when mapping a deficiency (skill function 2). **Cite the specific
+instrument and clause, never "best practice" in the abstract.** Each deficiency in
+[`deficiency-catalogue.md`](deficiency-catalogue.md) points here.
+
+> **Compiled and web-verified 14 August 2026 (England).** ⏳ Several items are time-sensitive —
+> the NPPF is under revision (its flood paragraphs will renumber if republished), the national
+> SuDS standards were replaced in 2025, and climate-change allowance *figures* now live in
+> refreshed datasets rather than the guidance page. **Re-verify anything marked ⏳ before
+> relying on it.** This is not legal advice.
+>
+> **Scope:** England. The NPPF/PPG, the EA/LLFA framework and the SuDS standards are England-
+> specific; Wales/Scotland/NI differ (notably, mandatory SuDS via Schedule 3 *is* in force in
+> Wales — see Part 5).
+
+---
+
+## Part 1 — NPPF (Chapter 14, "Planning and flood risk")
+
+**December 2024 edition** (current; amended 7 Feb 2025, flood policy unchanged). ⏳ The flood
+paragraphs are **170–182**; they renumbered from the Dec 2023 edition (which used 165–175), and
+a further revision is expected — confirm the numbers when you draft.
+gov.uk/guidance/national-planning-policy-framework/14-meeting-the-challenge-of-climate-change-flooding-and-coastal-change
+
+- **Para 170 — avoid inappropriate development / safe for lifetime:** steer development away from
+  the highest-risk areas; where development must be there, it "should be made **safe for its
+  lifetime without increasing flood risk elsewhere**."
+- **Para 173 — a sequential, risk-based approach applies to *individual applications*** in areas
+  at risk now or in future **from any form of flooding** (surface water is explicitly in scope
+  in the Dec 2024 edition).
+- **Para 174 — the Sequential Test:** "steer new development to areas with the lowest risk of
+  flooding from any source. Development should not be allocated or **permitted if there are
+  reasonably available sites appropriate for the proposed development in areas with a lower risk
+  of flooding**." (The first hurdle — can be decisive on its own.)
+- **Para 175 — the carve-out:** the Sequential Test is not needed only where a site-specific FRA
+  shows no built development, access/escape, land-raising or vulnerable elements would sit in an
+  at-risk area, now or in future.
+- **Paras 177–179 — the Exception Test (both parts required):** where development can't be
+  located at lower risk, it may proceed only if **(a)** it "would provide **wider sustainability
+  benefits to the community that outweigh the flood risk**", **and (b)** it "will be **safe for
+  its lifetime… without increasing flood risk elsewhere, and, where possible, will reduce flood
+  risk overall**." Para 179: **both** elements must be satisfied.
+- **Para 181 — the site-specific requirements (and FRA trigger):** flood risk must **not be
+  increased elsewhere**, and development in a risk area is only allowed where the FRA shows
+  **(a)** the most vulnerable development is in the site's **lowest-risk areas** (within-site
+  sequential approach); **(b)** it is flood **resistant/resilient**; **(c)** it incorporates
+  **SuDS** unless clearly inappropriate; **(d)** **residual risk** can be safely managed; and
+  **(e)** **safe access/escape** routes are included as part of an agreed emergency plan.
+  **Footnote 63** sets the **FRA trigger:** required for *all* development in **Flood Zones 2
+  and 3**; and in Zone 1 for sites **≥1 ha**, land with EA-notified critical drainage problems,
+  land an SFRA identifies as at increased future risk, or land subject to other flood sources
+  where a more vulnerable use is introduced.
+- **Para 182 — SuDS:** "Applications which could affect drainage on or around the site should
+  incorporate **sustainable drainage systems** to control flow rates and reduce volumes of
+  runoff." For **major development** SuDS must **(a)** take account of LLFA advice, **(b)** meet
+  appropriate minimum operational standards, and **(c)** have maintenance arrangements for the
+  development's lifetime.
+- **NPPF Annex 3 — Flood Risk Vulnerability Classification:** the five categories — *essential
+  infrastructure, highly vulnerable, more vulnerable, less vulnerable, water-compatible*.
+
+*Do not mis-cite the NPPF:* it does **not** itemise the six flood sources, does not use the term
+"climate change allowances" (only "current and future impacts of climate change"), and does not
+set out the drainage hierarchy or the national SuDS standards — those are PPG / technical-
+standards material (Parts 2, 4).
+
+---
+
+## Part 2 — Planning Practice Guidance ("Flood risk and coastal change")
+gov.uk/guidance/flood-risk-and-coastal-change (paragraph Ref IDs `7-…`)
+
+- **Flood Zones (Table 1, `7-078`):** **Zone 1 (Low)** <0.1% annual probability; **Zone 2
+  (Medium)** 0.1–1% river / 0.1–0.5% sea; **Zone 3a (High)** ≥1% river / ≥0.5% sea; **Zone 3b
+  (Functional Floodplain)** land that must flood or store water (normally ≥3.3% annual, or
+  designed to flood), defined by the LPA's Strategic Flood Risk Assessment with the EA. The
+  Flood Map ignores defences and **does not account for climate change** — consult the SFRA too.
+- **When a site-specific FRA is required (`7-020`):** defers to the NPPF footnote (see para 181/
+  footnote 63). Assessments must be **proportionate to the degree of flood risk (`7-021`)**.
+  *(Note: the PPG page still calls it "footnote 55"; the live Dec 2024 NPPF renumbers it to 63 —
+  same content.)*
+- **Sequential Test (`7-023`–`7-029`, `7-035`):** aim is to steer to the lowest risk; **existing
+  flood defences are initially ignored** (uncertain long-term funding, `7-024`); applies to
+  **major and non-major** development; the **applicant demonstrates, the LPA decides**; a
+  defined **area of search (`7-027a`)**; a "**reasonably available**" site is one that is
+  suitable, meets the same need, and has a reasonable prospect of coming forward at the same
+  time (need not be owned by the applicant, `7-028`); the **absence of a 5-year housing land
+  supply is not relevant** to the Sequential Test.
+- **Exception Test (`7-031`, `7-035`):** the two parts (above); "**not a tool to justify
+  development when the Sequential Test has already shown there are reasonably available,
+  lower-risk sites**" — the Sequential Test comes first.
+- **Vulnerability × flood-zone compatibility matrix (Table 2, `7-079`):** *more vulnerable*
+  (most housing) needs the **Exception Test in Zone 3a** and is **not permitted in Zone 3b**;
+  *highly vulnerable* is **not permitted in Zone 3a/3b**; use the **highest** vulnerability where
+  a scheme mixes uses. Cite this where a vulnerable use is proposed in the wrong zone.
+
+---
+
+## Part 3 — Environment Agency
+- **Statutory consultee** (Town and Country Planning (DMPO) (England) Order 2015, SI 2015/595,
+  Sch 4): the LPA must consult the EA before permitting development within 20 m of a main river,
+  non-minor development in Flood Zones 2/3, vulnerable uses in flood zones, and Zone 1 sites in
+  EA-notified critical drainage areas. Read the EA's response first and build on any objection.
+- **Flood map for planning** (flood-map-for-planning.service.gov.uk) — the **authoritative**
+  flood zones for planning (ignores defences; no climate change). Do **not** cite the public
+  "Check your long term flood risk" service for planning zones.
+- **Flood risk assessment: standing advice** (LPA- and applicant-facing; updated 2026) — the
+  benchmark for when an FRA is required and its content; the yardstick for a deficient/missing
+  FRA. gov.uk/guidance/flood-risk-assessment-standing-advice
+- **Climate-change allowances** — peak river-flow / peak-rainfall / sea-level allowances by
+  catchment and epoch. ⏳ The guidance *page* is unchanged since 2022, but the **allowance
+  datasets were refreshed (Sep 2025)** — take specific figures from the live datasets, not the
+  page. gov.uk/guidance/flood-risk-assessments-climate-change-allowances
+
+---
+
+## Part 4 — Lead Local Flood Authority (LLFA) and SuDS
+- **LLFA — statutory consultee** on surface-water drainage for **major development** since **15
+  April 2015** (WMS HCWS161; SI 2015/595). "Major" = 10+ dwellings, or residential on ≥0.5 ha
+  where the number is unknown, or ≥1,000 m² floorspace, or a site ≥1 ha.
+- **National standards for sustainable drainage systems (SuDS)** — ⚠ **Defra, June 2025 (updated
+  July 2025), which REPLACED the March 2015 non-statutory technical standards** at the same URL.
+  Still non-statutory (delivered through planning policy); cover the runoff-destination
+  hierarchy, interception, peak-flow control, water quality, amenity and biodiversity, and
+  maintenance. gov.uk/government/publications/sustainable-drainage-systems-non-statutory-technical-standards
+- **CIRIA "The SuDS Manual" (C753, 2015)** — the principal UK technical benchmark (no successor
+  as of 2026). Key concepts to test a drainage strategy against:
+  - the **SuDS management train** — prevention → source control → site control → regional
+    control (manage runoff in stages, most local first);
+  - the **drainage hierarchy** — (1) to ground / infiltration / soakaway; (2) to a watercourse;
+    (3) to a surface-water sewer; (4) to a combined sewer (last resort);
+  - **greenfield runoff rates** — restrict post-development rate *and* volume toward the
+    pre-development (greenfield) rate so downstream risk is not increased.
+
+---
+
+## Part 5 — Statutory duties, foul drainage, watercourses, reservoirs
+- ⏳ **Schedule 3 to the Flood and Water Management Act 2010 (mandatory SuDS / SuDS Approving
+  Body) is NOT commenced in England** as of Aug 2026 — the Government's stated preference is the
+  planning-policy route. **Rely on the NPPF/PPG SuDS policy and the 2025 National Standards, not
+  on any statutory SAB duty in England.** (It *is* in force in Wales.)
+- **Flood and Water Management Act 2010:** s.6 defines the LLFA; s.9 (local flood-risk
+  management strategy); s.19 (duty to investigate flooding); s.21 (register of flood-risk
+  structures). The EA leads the national FCERM strategy (s.7).
+- **Ordinary watercourse consent — Land Drainage Act 1991 s.23** (not "FWMA s.23"): no
+  culvert/weir/obstruction to an ordinary watercourse without written LLFA/IDB consent — relevant
+  where culverting is proposed.
+- **Foul drainage:** PPG "Water supply, wastewater and water quality" — the **first presumption
+  is connection to the public foul sewer** (package plants/septic tanks only where a connection
+  is impractical); support early engagement with the sewerage undertaker and phasing/refusal
+  where capacity works don't fit the timescale. The right to connect (Water Industry Act 1991
+  s.106) is **qualified** (the undertaker may refuse where prejudicial) and does **not** guarantee
+  downstream capacity — use this to rebut "there's an automatic right to connect, so capacity is
+  irrelevant." **Building Regulations Approved Document H** ranks surface-water discharge
+  (soakaway → watercourse → sewer) in **H3** (H1 is foul).
+- **Reservoir flood risk** (Reservoirs Act 1975; EA reservoir flood maps) — treat as a
+  **residual risk** relevant to emergency planning and safe access/egress, not an absolute bar.
+
+---
+
+## Part 6 — Superseded / currency (citing the old one is an objection or an error)
+
+| Topic | Current | Superseded / status |
+|---|---|---|
+| National SuDS standards | **Defra National Standards for SuDS (2025)** | ⚠ 2015 non-statutory technical standards — replaced |
+| Mandatory SuDS (England) | **not in force — planning-policy route** | Schedule 3 FWMA 2010 uncommenced in England (in force in Wales) |
+| Climate-change allowance figures | **live EA datasets (refreshed 2025)** | the 2022 guidance-page figures |
+| NPPF flood paragraphs | **Dec 2024, paras 170–182** | Dec 2023 (165–175) |
+| SuDS technical manual | **CIRIA C753 (2015)** | C697 (2007) |
+
+## Part 7 — ⏳ Verify-before-relying (time-sensitive as of Aug 2026)
+- **NPPF edition & flood paragraph numbers** — a revision is expected; confirm the live numbers.
+- **Climate-change allowance figures** — take from the live EA datasets, not the 2022 page.
+- **Schedule 3 status** — confirm it is still uncommenced in England before relying on the
+  policy-route framing.
+- **2025 National SuDS Standards detail** — confirm the specific standard/clause before quoting.
+- **The PPG vs NPPF footnote-number mismatch** (55 vs 63) for the FRA trigger — cite the content,
+  note the source.

--- a/flood-representation/references/objection-template.md
+++ b/flood-representation/references/objection-template.md
@@ -1,0 +1,150 @@
+# Objection template + annotated worked example
+
+A **skeleton** to fill, and a **worked example** showing the house style in practice. Match the
+example's density, tone and layout — every point must come from the documents in front of you.
+
+---
+
+## Skeleton
+
+```
+[Your name]
+[Your address]
+[Email]
+
+[Date]
+
+[Planning department / Council name / address]
+[For the attention of [Case Officer], if known]
+
+RE: Application [ref] — [site]
+[One-line description — note the flood zone(s) and whether an FRA is provided]
+
+Dear [Sir or Madam / Mr/Ms Name],
+
+REPRESENTATION ON FLOOD RISK AND DRAINAGE GROUNDS — OBJECTION UNLESS MATTERS RESOLVED
+
+[Opening: consultation status; matters are material considerations while undecided; ask
+that this be placed on the file. Name the flood zone(s) and the sources of flood risk.]
+
+[State which documents you address — the Flood Risk Assessment (author, date), the Drainage
+Strategy / SuDS report — and align with the Environment Agency and Lead Local Flood Authority
+where they have objected or asked for more.]
+
+The relevant framework includes: [short bulleted list from national-guidance.md — the NPPF
+flood policies and tests, the PPG flood zones, the EA/LLFA roles, the SuDS standards].
+
+## 1. [Point stated as a conclusion]
+[Quote the document / consultee. Why it matters + the test/policy breached. The ask.]
+
+## 2. [Next point]
+…
+
+## Summary of requests
+[Numbered, concrete, mostly "before determination".]
+
+Unless and until these matters are resolved, I object to the grant of planning permission.
+
+Yours [sincerely/faithfully],
+[Name]
+```
+
+---
+
+## Worked example (condensed — annotations in ⟨…⟩)
+
+> ⟨Header, RE line and opening omitted for brevity — see the skeleton. The opening names the
+> flood zone(s) and sources, and aligns with the Environment Agency's holding objection.⟩
+
+**The relevant framework includes:** ⟨a bulleted list, not a semicolon-run⟩
+
+- the NPPF's flood-risk policies — the Sequential Test, the Exception Test, the requirement to
+  be safe for the development's lifetime and not increase flood risk elsewhere, and sustainable
+  drainage;
+- the Planning Practice Guidance on flood risk (flood zones; when a site-specific FRA is
+  required);
+- the Environment Agency's role and flood-risk standing advice, and the Lead Local Flood
+  Authority's role on surface-water drainage;
+- the non-statutory technical standards for SuDS and the CIRIA SuDS Manual;
+- **[the Local Plan's flood-risk and drainage policies — insert the specific references]**.
+
+### 1. The Sequential Test has not been passed
+⟨Lead with the first hurdle — it can be decisive on its own.⟩
+
+The application provides no Sequential Test. The site lies in **Flood Zone [2/3]**, so the
+development should be steered to areas at lower risk unless there are no reasonably available
+sites at lower risk within the area of search. That exercise has not been carried out, so the
+Council cannot conclude the test is passed. **Request:** a Sequential Test with a defined area
+of search and evidence that no reasonably available lower-risk sites exist, before determination.
+
+### 2. The Exception Test is only half-made
+⟨Two limbs — use lettered sub-points.⟩
+
+Where the Exception Test is required it has two limbs, and both must be met:
+
+**(a)** *Wider sustainability benefits.* The FRA asserts the scheme's benefits but does not
+weigh them against the flood risk.
+
+**(b)** *Safe for its lifetime, without increasing flood risk elsewhere.* This is not
+demonstrated — [there is no compensatory storage for the floodplain lost / finished floor
+levels and safe access are not shown / climate-change allowances are not applied].
+
+**Request:** both limbs of the Exception Test demonstrated on the evidence, before determination.
+
+### 3. The FRA does not assess all sources of flood risk
+⟨Bullet the omissions.⟩
+
+The FRA addresses only fluvial risk. It does not assess:
+
+- **surface-water** flood risk, despite the site's mapped surface-water hazard;
+- **groundwater** risk;
+- **sewer** flooding and the capacity of the receiving network.
+
+**Request:** an assessment of all relevant sources of flood risk.
+
+### 4. The drainage strategy does not follow the hierarchy or restrict runoff
+⟨Technical but concrete.⟩
+
+The Drainage Strategy discharges surface water to the public sewer as a first resort, without
+demonstrating that discharge to ground (infiltration) or to a watercourse is not feasible — no
+infiltration testing is provided. Runoff is not restricted to the greenfield rate, and the
+attenuation is not sized for the design storm including the climate-change allowance.
+**Request:** a SuDS-led strategy following the drainage hierarchy (infiltration first), with
+runoff restricted to greenfield rates and attenuation sized for the climate-change design storm,
+and a secured maintenance mechanism.
+
+### Summary of requests
+
+Before determination:
+1. A Sequential Test with a defined area of search and evidence on reasonably available lower-
+   risk sites;
+2. Both limbs of the Exception Test demonstrated (benefits, and safe-for-lifetime without
+   increasing risk elsewhere);
+3. A site-specific FRA assessing all sources of flood risk, using current EA data and the
+   current climate-change allowances, with safe access/egress and a residual-risk assessment;
+4. A SuDS-led drainage strategy following the hierarchy, restricting runoff to greenfield rates,
+   with a secured long-term maintenance and adoption mechanism, and confirmation of foul/surface-
+   water capacity from the undertaker;
+5. The Environment Agency's and Lead Local Flood Authority's requirements resolved by evidence,
+   with re-consultation on any revised FRA.
+
+Unless and until these matters are resolved, I object to the grant of planning permission.
+
+Yours faithfully,
+[Name]
+
+---
+
+### Notes on adapting the example
+
+- **Lead with the Sequential Test** where the site is in Zone 2/3 — it can defeat the
+  application on its own, before the site-specific detail.
+- **Read the EA and LLFA responses first** and build on any objection or holding position rather
+  than duplicating it; a consultee objection pending an adequate FRA is a strong anchor.
+- **Consultant- or campaign-specific framing is excluded by default** — argue each point on this
+  application's own facts.
+- **Before submitting:** a person must read and check the draft — every quote and figure against
+  the actual documents — and be aware the representation is normally **published on the council's
+  portal in the submitter's name** and kept on the record, so include only personal details the
+  user is content to make public. This is a draft aid provided with no warranty; it is not legal
+  advice.

--- a/heritage-representation/CHANGELOG.md
+++ b/heritage-representation/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog — heritage-representation
+
+Design decisions per revision, newest first. See `../CLAUDE.md` for the format and the
+house rules. The **_Why_** lines record the rationale so a future editor understands the
+intent.
+
+## 0.1.0 — 2026-08-14 — Initial release
+
+First version, built to the same pattern as the ecological- and transport-representation
+skills: (1) evaluate the heritage evidence, (2) map deficiencies to the statutory duties and
+national policy/guidance, and (3) draft a concise representation — or advise that none is
+warranted. Structure: `SKILL.md` + `references/` (`deficiency-catalogue.md`,
+`national-guidance.md`, `house-style.md`, `objection-template.md`). Key design decisions:
+
+### Added
+- **The two heritage framing points as the spine:** *the level of harm drives the test*
+  (substantial vs less-than-substantial), and *"less than substantial" is not "neutral"* (the
+  statutory duties require considerable importance and weight; the NPPF requires great weight).
+  _Why:_ these are the two things applicants and officer reports most often get wrong, and
+  where a well-pitched representation has the most leverage.
+- **A web-verified guidance catalogue** — the LB & CA Act 1990 duties (ss.66/72 verbatim), the
+  NPPF Chapter 16 harm tests **with the Dec 2024 +13 renumbering flagged**, the PPG, Historic
+  England GPA/HEAN guidance (with the setting method), and the case law (*Barnwell Manor*,
+  *Mordue*, *Palmer*, *Bramshill*, *South Lakeland*). _Why:_ heritage turns on the precise
+  statutory duty and the correct harm test; citing the wrong paragraph or missing the "great
+  weight" duty loses the point. Time-sensitive items (NPPF under revision; two case citations
+  to confirm) are flagged ⏳.
+- **Deficiency catalogue** covering significance (assessed, and proportionately, incl.
+  setting/group value), harm characterisation, the statutory-weight and public-benefit balance,
+  conservation-area preserve-or-enhance, archaeology, and consultee engagement.
+- **House style + annotated template** with the bullet / lettered-sub-point discipline built in
+  from the start (learned from the transport skill), so drafts are scannable.
+
+### Changed / Security
+- **Scoped to heritage, England-focused, explicitly not legal advice; no warranty; human
+  review required; public-document-in-your-name flag.** _Why:_ the same user-protection
+  disclaimers as the other skills.
+- **Built generic and public-safe** — no case/campaign/consultant/place fingerprints; local
+  policy references left as `[insert …]`. _Why:_ repo house rules.

--- a/heritage-representation/LICENSE
+++ b/heritage-representation/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ian Howard
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/heritage-representation/README.md
+++ b/heritage-representation/README.md
@@ -1,0 +1,53 @@
+# Heritage Representation
+
+A skill for producing a rigorous, credible representation on the **heritage / historic-
+environment** merits of a UK planning application — or advising that no sustainable objection
+exists. Covers listed buildings and their settings, conservation areas, scheduled monuments,
+registered parks/gardens, non-designated heritage assets, and archaeology. England-focused.
+
+> **Not legal advice. No warranty.** Output is a draft aid provided "as is". **A human must
+> review and check it before submitting.** A UK planning representation is normally **published
+> on the council's portal in the submitter's name** — include only personal details you're
+> content to make public.
+
+It does three things:
+
+1. **Evaluate** the applicant's heritage evidence (Heritage Statement / Statement of
+   Significance, setting and archaeological assessments) against the statutory duties and
+   current policy and guidance, and identify the material deficiencies.
+2. **Map** each deficiency to the specific legislation, national policy and guidance it engages.
+3. **Draft** the representation in clear, precise, concise language.
+
+## Contents
+
+| File | What it is |
+|---|---|
+| `SKILL.md` | The skill: workflow, integrity principle, and the two heritage framing points. **Start here.** |
+| `references/deficiency-catalogue.md` | Function 1 — the evaluation checklist. |
+| `references/national-guidance.md` | Function 2 — the law/policy/guidance catalogue with citations. |
+| `references/house-style.md` | Function 3 — how a strong representation reads. |
+| `references/objection-template.md` | Skeleton + annotated worked example. |
+| `CHANGELOG.md` | Design decisions and their rationale, per revision. |
+
+## Two things that define this skill
+
+- **The level of harm drives the test.** *Substantial harm* engages a very demanding test;
+  *less than substantial harm* is weighed against public benefits. Applicants routinely
+  under-state harm — getting the level right is decisive (and don't over-claim it either).
+- **"Less than substantial" is not "neutral".** The Act requires *considerable importance and
+  weight* to preserving the asset and its setting; the NPPF requires *great weight* to
+  conservation of a designated asset.
+
+## Pairs with
+
+The **planning-document-search** skill retrieves the documents; **application-triage** decides
+whether heritage is a live ground.
+
+## Freshness
+
+The guidance catalogue was web-verified **August 2026**. ⏳ The NPPF is under revision and its
+Chapter 16 paragraph numbers will change if republished — re-verify at the point of drafting.
+
+## License
+
+MIT — see [`LICENSE`](LICENSE). Provided as-is, with no warranty; not legal advice.

--- a/heritage-representation/SKILL.md
+++ b/heritage-representation/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: heritage-representation
+description: >-
+  Evaluate the heritage/historic-environment evidence submitted with a UK
+  planning application (Heritage Statement / Statement of Significance, setting
+  and archaeological assessments), identify the statutory duties and national
+  policy it engages, and draft a concise, well-founded objection — or advise
+  that no sustainable objection exists. Covers listed buildings, conservation
+  areas, scheduled monuments, non-designated assets and archaeology.
+  England-focused. Not legal advice; no warranty; output requires human review.
+license: MIT
+---
+
+# Heritage representation on a planning application
+
+Help a member of the public produce a rigorous, credible representation on the **heritage /
+historic-environment** merits of a planning application. The skill does three things:
+
+1. **Evaluate** the applicant's heritage evidence against the statutory duties and current
+   policy and guidance, and identify the material deficiencies.
+2. **Map** each deficiency to the specific legislation, national policy and guidance it
+   engages.
+3. **Draft** the representation in clear, precise, concise language — or advise that the
+   evidence is sound and no sustainable objection exists.
+
+## When to use
+
+The user has a planning application (or a listed-building-consent application) and wants to
+object, or find out whether they can, on heritage grounds — harm to a **listed building** or
+its **setting**, a **conservation area**, a **scheduled monument**, a **registered park/garden
+or battlefield**, a **non-designated heritage asset**, or **archaeology**. Trigger phrases:
+"object on heritage grounds", "is this Heritage Statement adequate", "this harms the
+conservation area / the setting of the listed building", "they haven't assessed the
+archaeology."
+
+Not this skill: ecology, transport, flood risk, general amenity — separate matters.
+
+## What you need first
+
+- The **application reference and council**, or the documents (the **planning-document-search**
+  skill retrieves them).
+- The **heritage documents** — the Heritage Statement / Statement of Significance, any setting
+  assessment, archaeological desk-based assessment or evaluation, and the heritage section of
+  the Design and Access Statement. Also the **conservation officer's and Historic England's
+  consultation responses** (often the strongest anchor).
+- The **designations and their significance** — what is listed (and its grade), the
+  conservation area and its **appraisal**, scheduled monuments, registered parks/gardens
+  (check `planning.data.gov.uk` and the Historic England list).
+- The **local plan's** historic-environment policies.
+
+## The integrity principle and two framing points (read before drafting)
+
+**Only object where the evidence is genuinely inadequate or the harm genuinely unacceptable.**
+Heritage harm is a matter of planning judgement; if significance is properly assessed and the
+proposal genuinely preserves or enhances, there is **no sustainable objection** — say so.
+Treat "don't object" as a valid output.
+
+Two points specific to heritage:
+- **The level of harm drives the test.** *Substantial harm / total loss* engages a very
+  demanding test; *less than substantial harm* is weighed against public benefits. Applicants
+  routinely under-state harm — getting the level right is decisive. (But don't over-claim
+  "substantial harm" either; credibility depends on the honest level.)
+- **"Less than substantial" is not "neutral".** The Act requires **considerable importance and
+  weight** to preserving the asset, its setting and conservation-area character; the NPPF
+  requires **great weight** to conservation of a designated asset.
+
+## Workflow
+
+### Step 1 — Intake and read
+Identify the asset(s) affected and their designation/grade; whether the effect is on the asset,
+its setting, or a conservation area's character; and the application type (permission vs
+listed-building consent). Read the conservation officer's / Historic England's response first.
+Get the Statement of Significance and any setting/archaeology assessments.
+
+### Step 2 — Evaluate against the deficiency catalogue (function 1)
+Work through [`references/deficiency-catalogue.md`](references/deficiency-catalogue.md). For
+each candidate deficiency, confirm it is **present** and **material**, and capture the specific
+evidence — the document, author, date, paragraph. Quote the Heritage Statement's own words.
+Grade findings and lead with the decision-critical. Apply the integrity principle.
+
+Key tests: Is **significance** assessed, and proportionately (fabric *and* setting, group
+value, historic interest)? Is the **level of harm** correctly characterised? Are the
+**statutory duties and great weight** given effect? Is the **public-benefit balance** genuinely
+carried out? For conservation areas, does the scheme **preserve or enhance**? For archaeology,
+is significance established **before** determination?
+
+### Step 3 — Map to law, policy and guidance (function 2)
+Attach the precise instrument from
+[`references/national-guidance.md`](references/national-guidance.md) — the LB & CA Act 1990
+duties (ss.66/72), the NPPF historic-environment paragraphs and the harm tests, the PPG,
+Historic England guidance, the relevant case law on the statutory duties — plus the **local
+plan** heritage policies and the **conservation area appraisal**. Cite specifically.
+
+### Step 4 — Draft (function 3)
+Draft to [`references/house-style.md`](references/house-style.md) and
+[`references/objection-template.md`](references/objection-template.md): header → RE line
+(name the asset) → opening → bulleted framework list → numbered conclusion-headed points
+(quoted evidence; establish significance / characterise harm / invoke the duty; the ask) →
+numbered **Summary of requests** → objection sentence → sign-off. Keep it concise; use bullets
+for lists and `(a)/(b)` for multi-limb points.
+
+### Step 5 — Check before sending
+- Every point is evidenced from the documents or cited guidance; nothing asserted.
+- The harm level is characterised honestly (not over- or under-claimed).
+- The statutory duties and great weight are correctly invoked.
+- Consultant-/campaign-specific framing excluded unless the user asked and it is defensible.
+- Requests are concrete and correctly timed.
+- **Hand back to a human, with the two warnings:** the draft must be read and checked, and
+  submitting it puts a **public document in the user's name** on the council's portal.
+
+## Reference files
+
+- [`references/deficiency-catalogue.md`](references/deficiency-catalogue.md) — the evaluation
+  checklist.
+- [`references/national-guidance.md`](references/national-guidance.md) — the law/policy/guidance
+  catalogue with citations.
+- [`references/house-style.md`](references/house-style.md) — how a strong representation reads.
+- [`references/objection-template.md`](references/objection-template.md) — skeleton + annotated
+  worked example.
+
+## Scope and limitations
+
+- **Not legal advice, and no warranty.** Not a substitute for a solicitor or a heritage
+  professional; guarantees no outcome; provided "as is".
+- **Human review is necessary before submitting.** A person must check every quote and
+  citation against the actual documents.
+- **A UK planning representation is a public document in the submitter's name** — normally
+  published on the council's portal; include only personal details the user is content to make
+  public.
+- **England-focused.** The 1990 Act applies in England and Wales, but national policy (NPPF/
+  PPG) is England; devolved policy differs — flag when outside England.
+- **Evidence-bound; heritage harm is a matter of judgement.** Identify significance and harm on
+  the evidence; don't assert a level of harm you cannot support.
+- **The honest answer is sometimes "don't object."**

--- a/heritage-representation/references/deficiency-catalogue.md
+++ b/heritage-representation/references/deficiency-catalogue.md
@@ -1,0 +1,151 @@
+# Heritage submission — deficiency catalogue
+
+The recurring, defensible grounds on which a planning application's **heritage evidence** (a
+Heritage Statement / Statement of Significance, a setting assessment, an archaeological desk-
+based assessment, a Design and Access Statement's heritage section, and any listed-building or
+conservation-area justification) can be challenged. Each entry is a *pattern to look for*, not
+a template sentence: find the specific instance in the documents, quote it, and attach the
+request. Cross-references point to [`national-guidance.md`](national-guidance.md).
+
+> **Integrity rule (read first).** Only raise a deficiency that is actually present and
+> material. Heritage harm is a matter of planning judgement; your job is to make sure
+> **significance is properly identified, the level of harm is correctly characterised, the
+> statutory duties are given effect, and the right test and balance are applied** — not to
+> assert harm where none exists. If the significance assessment is sound and the proposal
+> genuinely preserves or enhances, say so.
+>
+> **The two framing points that win heritage objections:**
+> - **The level of harm drives the test.** *Substantial harm / total loss* engages a very
+>   demanding test; *less than substantial harm* is weighed against public benefits. Getting
+>   the applicant's harm characterisation right (they routinely under-state it) is decisive.
+> - **"Less than substantial" is not "negligible".** Even less-than-substantial harm must be
+>   given **great weight**, and the statutory duties require **considerable importance and
+>   weight** to preserving a listed building, its setting, and conservation-area character.
+>   The common LPA/applicant error is to treat less-than-substantial harm as if it were
+>   neutral and simply outweighed — press for the correct, weighted balance.
+
+---
+
+## A. Significance — assessed at all, and proportionately
+
+**A1 — No significance assessment, or not proportionate to the asset's importance.**
+- *Tell:* no Statement of Significance, or a thin/generic one, for a proposal affecting a
+  listed building, conservation area, scheduled monument or their settings.
+- *Why it matters:* national policy requires the applicant to describe the significance of any
+  heritage asset affected (including from development within its setting), proportionate to
+  the asset's importance; the LPA cannot weigh harm it has not had described.
+- *Ask:* a proportionate Statement of Significance before determination.
+
+**A2 — Significance drawn too narrowly.** Significance limited to the building's fabric, when
+it also derives from **setting, group value, historic/associative interest, communal value,
+plan-form, or archaeological interest**. Under-drawing significance under-states the harm.
+- *Ask:* a significance assessment covering all the heritage interests, not just fabric.
+
+**A3 — Non-designated heritage assets not identified.** Locally-listed buildings, buildings of
+local interest, or assets meeting the local-list criteria treated as if they had no heritage
+value; the "balanced judgement" for non-designated assets never engaged.
+- *Ask:* identify the non-designated heritage assets affected and apply the balanced judgement.
+
+---
+
+## B. Setting
+
+**B1 — Setting not assessed, or not to the recognised method.** The contribution the setting
+makes to the asset's significance is dismissed in a line, without the staged assessment of
+setting that good practice requires (identify the assets; assess the contribution of setting;
+assess the effect of the proposal; consider mitigation).
+- *Why it matters:* development *within the setting* of a designated asset engages the
+  statutory duty and great weight even if the asset itself is untouched.
+- *Ask:* a setting assessment to the recognised method, covering the key views and the
+  experience of the asset.
+
+**B2 — Selective or unrepresentative visualisations.** Views chosen to minimise the apparent
+effect; key or worst-case viewpoints omitted; verified views not provided where the effect is
+significant.
+- *Ask:* representative/verified views from the viewpoints that matter, including the adverse
+  ones.
+
+---
+
+## C. Harm — correctly identified and characterised
+
+**C1 — Harm understated or mislabelled.** "No harm" asserted where there is harm; or
+*substantial* harm mischaracterised as *less than substantial* to escape the more demanding
+test. The threshold between the two is where the significance is *vitiated or very much
+reduced* — press it where the applicant has drawn it too low.
+- *Ask:* the level of harm correctly characterised, and the correct test applied.
+
+**C2 — The statutory duty not given effect.** The assessment treats harm to a listed building/
+its setting, or to a conservation area, as an ordinary material consideration, without giving
+it the **considerable importance and weight** the Act requires, and the **great weight** the
+NPPF requires to conservation of a designated asset.
+- *Ask:* the officer report to apply the statutory duties and give harm the requisite weight.
+
+**C3 — "Less than substantial" treated as neutral.** Less-than-substantial harm acknowledged
+but then not actually weighed — or weighed as if trivial — against public benefits.
+- *Ask:* the proper public-benefit balance, with great weight given to the harm.
+
+**C4 — Cumulative / incremental harm ignored.** Erosion of a conservation area's character by
+increments ("death by a thousand cuts") dismissed because each change is individually small.
+- *Ask:* assessment of the cumulative effect on the area's character and appearance.
+
+---
+
+## D. Public benefits and the balance
+
+**D1 — Public benefits overstated or not genuinely public.** Private benefits (developer
+profit, a larger dwelling) presented as public benefits; benefits asserted without evidence or
+weight; the balance treated as a formality.
+- *Why it matters:* only genuine, and generally public, benefits count in the balance against
+  heritage harm, and they must be weighed against harm to which great weight attaches.
+- *Ask:* the public benefits evidenced and weighed against the (great-weight) harm.
+
+**D2 — Optimum viable use / enabling development not tested.** A harm-for-benefit or heritage-
+at-risk case advanced without testing it against the optimum viable use or genuine
+alternatives, or without securing the heritage benefit that justifies the harm.
+- *Ask:* the case tested against alternatives/optimum viable use, and the securing mechanism.
+
+---
+
+## E. Conservation areas
+
+**E1 — Fails to preserve or enhance character or appearance.** The proposal's scale, height,
+bulk, materials, plot pattern, roofscape or rhythm does not preserve or enhance the character
+or appearance of the conservation area; the **conservation area appraisal** is not engaged.
+- *Ask:* a design response demonstrably preserving or enhancing the area's character, assessed
+  against the appraisal.
+
+**E2 — Loss of a positive contributor.** Demolition or alteration of an unlisted building that
+*positively contributes* to the conservation area, treated as neutral.
+- *Ask:* assessment of the contribution the building makes, and of the harm from its loss.
+
+---
+
+## F. Archaeology
+
+**F1 — No assessment where there is archaeological potential.** No desk-based assessment or
+field evaluation on a site with known or likely buried remains; the significance of the
+archaeology not established *before* determination.
+- *Why it matters:* the LPA needs sufficient information to judge significance and the
+  appropriate response; assessment cannot simply be deferred to a condition where it should
+  inform the decision.
+- *Ask:* a desk-based assessment and, where potential is identified, field evaluation before
+  determination.
+
+**F2 — "Preserve by record" where in-situ preservation is warranted.** A recording condition
+proposed for remains that may merit preservation in situ, without justifying the choice.
+- *Ask:* justification for the mitigation strategy against the significance of the remains.
+
+---
+
+## G. Evidence quality and consultee engagement
+
+**G1 — Consultee concerns not addressed.** The conservation officer's or Historic England's
+concerns are unanswered, or the assessment is inconsistent with them.
+- *Ask:* the concerns of the heritage consultees resolved before determination.
+
+**G2 — A generic, template Heritage Statement.** Boilerplate not specific to this asset — wrong
+descriptions, mismatched photographs, significance lifted from another site — indicating the
+assessment was not actually carried out for this application.
+- *Ask:* an asset-specific assessment; a generic statement is not an adequate basis for the
+  weighing the Act and the NPPF require.

--- a/heritage-representation/references/house-style.md
+++ b/heritage-representation/references/house-style.md
@@ -1,0 +1,87 @@
+# House style — how a strong heritage representation reads
+
+The goal is a representation a busy case officer can act on: **concise, specific, evidenced,
+and easy to lift into the officer report.** These are the writing rules the skill applies at
+the drafting stage (function 3); they match the other representation skills, with the
+heritage-specific moves flagged.
+
+## Voice and stance
+
+- **Measured and expert, never emotive.** The force comes from specificity — quoting the
+  applicant's own Heritage Statement against itself and identifying the significance and harm
+  precisely — not from adjectives.
+- **Material considerations only.** The adequacy of the significance assessment, the correct
+  characterisation of harm, the statutory duties, and the public-benefit balance. Not "old
+  buildings are nicer."
+- **Concede what is sound; don't manufacture.** Heritage harm is a matter of judgement — if
+  the assessment is sound and the proposal genuinely preserves or enhances, say so. If the
+  whole thing is sound, advise *not* objecting.
+- **No personal criticism.** Critique the document and the method, not individuals.
+
+## The heritage-specific spine
+
+Three moves win heritage representations, and each point should serve one of them:
+
+- **Establish significance.** Identify what makes the asset significant — fabric, setting,
+  group value, historic interest, communal value — because harm can only be measured against
+  significance the applicant has under-drawn.
+- **Characterise the harm correctly.** The level of harm drives the test: *substantial harm /
+  total loss* engages a very demanding test; *less than substantial harm* is weighed against
+  public benefits. Applicants routinely under-state harm — press the correct level.
+- **Insist on the statutory weight.** The Act requires **considerable importance and weight**
+  to preserving a listed building, its setting and conservation-area character; the NPPF
+  requires **great weight** to the conservation of a designated asset. "Less than substantial"
+  is **not** "neutral."
+
+## Structure
+
+1. **Header block** — your name/address/email, the Council's address, date, case officer if
+   known.
+2. **RE line** — application reference + site + a one-line description (note if it is listed-
+   building consent, a conservation-area application, or affects a designated asset/setting).
+3. **Opening** — consultation status; matters are material considerations while undecided; ask
+   that the representation be placed on the file. Name the asset(s) affected and their grade/
+   designation.
+4. **Framework list** — a short **bulleted** list of the legislation/policy/guidance engaged
+   (see `national-guidance.md`) — the statutory duties, the NPPF paragraphs, Historic England
+   guidance, the conservation area appraisal.
+5. **Numbered sections** — one point per numbered sub-section, each with a **bold conclusion
+   heading**, then 1–3 tight paragraphs.
+6. **Summary of requests** — a numbered list, mostly "before determination".
+7. **Objection sentence** + sign-off.
+
+## Each point: the anatomy
+
+1. **Name the defect** in the heading as a conclusion.
+2. **Quote the document** — the Heritage Statement's own words, with the reference. Where its
+   significance assessment omits an interest, or its harm characterisation is too low, say so
+   in its own terms.
+3. **Say why it matters** — the consequence for the decision and the specific duty/policy
+   breached, cited precisely.
+4. **State the ask** — the specific thing to do, and *when* ("before determination").
+
+## Formatting discipline (keep it scannable)
+
+- **Shorter is stronger.** One point per paragraph; cut throat-clearing; prefer short sentences
+  to long ones chained with semicolons.
+- **Break dense material out — don't run it into prose.**
+  - where a point lists several things (the interests that make up significance, the omitted
+    viewpoints, the reasons harm is under-stated), use a **bulleted list**;
+  - where a point has two or more distinct limbs, use **bold lettered sub-points** `(a)/(b)`;
+  - present the framework list as bullets.
+- Bold each sub-section heading as a conclusion; italicise quoted document text; end each point
+  with a **Request:** line.
+- British spelling and legal register. Spell out an acronym once (Heritage Statement, HE for
+  Historic England, CA for conservation area).
+- Reference documents precisely by author and date the first time.
+
+## What to leave out
+
+- Anything you cannot evidence, or generalised dislike of new development near old buildings.
+- Non-material concerns (loss of a private view, property values).
+- Consultant- or campaign-specific framing (cross-referencing other applications, or a named
+  inquiry) — argue each point on this application's own facts, unless the user asks and it is
+  defensible here.
+- "Substantial harm" asserted where the honest characterisation is less-than-substantial —
+  over-claiming the harm level is as damaging to credibility as the applicant under-claiming
+  it. Get the level right and argue it.

--- a/heritage-representation/references/national-guidance.md
+++ b/heritage-representation/references/national-guidance.md
@@ -1,0 +1,169 @@
+# Historic-environment law, policy and guidance (England)
+
+The framework to cite when mapping a deficiency (skill function 2). **Cite the specific
+instrument and clause, never "best practice" in the abstract.** Each deficiency in
+[`deficiency-catalogue.md`](deficiency-catalogue.md) points here.
+
+> **Compiled and web-verified 14 August 2026 (England).** ⏳ The NPPF is under revision (a
+> restructured draft consulted to March 2026, a new edition expected); its Chapter 16
+> paragraph numbers will change again if it is republished, so **confirm the current numbers
+> when you draft.** This is not legal advice.
+>
+> **Scope:** the 1990 Act applies in England and Wales; the NPPF/PPG and Historic England
+> guidance are **England**. For Wales/Scotland/NI substitute the devolved framework.
+
+---
+
+## Part 1 — Primary legislation (the statutory duties — invoke the right one)
+
+**Planning (Listed Buildings and Conservation Areas) Act 1990.** These are **duties**, not
+policy — and the courts read them as requiring more than neutral weighing.
+
+- **s.66(1) — listed buildings (the key duty for a *planning* application):** in considering
+  whether to grant permission for development which **affects a listed building or its
+  setting**, the authority **"shall have special regard to the desirability of preserving the
+  building or its setting or any features of special architectural or historic interest which
+  it possesses."** Per *Barnwell Manor* (Part 5), "special regard" requires **considerable
+  importance and weight** and a **strong (rebuttable) presumption against** harm.
+- **s.16(2) — listed building consent:** the same "special regard" duty applies to an **LBC**
+  application (works to a listed building).
+- **s.72(1) — conservation areas:** for any planning decision on land in a conservation area,
+  **"special attention shall be paid to the desirability of preserving or enhancing the
+  character or appearance of that area."** "Preserving" means **doing no harm** (*South
+  Lakeland*, Part 5) — a neutral scheme satisfies the duty; a harmful one does not.
+- **s.69 — designation:** LPAs designate (and must review) conservation areas as "areas of
+  special architectural or historic interest the character or appearance of which it is
+  desirable to preserve or enhance."
+- *Invoke the right duty for the consent type:* s.16 for LBC; s.66 for planning permission
+  affecting a listed building/setting; s.72 for conservation areas.
+- *Source:* legislation.gov.uk/ukpga/1990/9 (ss.16, 66, 69, 72).
+
+**Ancient Monuments and Archaeological Areas Act 1979.** Scheduled monuments (s.1 schedule)
+have their **own consent regime** — **scheduled monument consent (s.2)** is required for most
+works and planning permission does **not** authorise them. Scheduled monuments are "assets of
+the highest significance" in NPPF terms. legislation.gov.uk/ukpga/1979/46
+
+**Registered parks & gardens, registered battlefields, World Heritage Sites.** Their weight
+flows from **NPPF policy, not a bespoke consent regime** (registered parks/gardens are
+statutory under the 1953 Act s.8C but add no consent control; battlefields and WHS are
+policy). All four are **"designated heritage assets"** in the NPPF Glossary, so the NPPF harm
+tests apply.
+
+---
+
+## Part 2 — NPPF (Chapter 16, "Conserving and enhancing the historic environment")
+
+**December 2024 edition** (current; amended 7 Feb 2025, Chapter 16 unchanged). ⏳ Chapter 16
+was **renumbered +13 from the Dec 2023 edition** (Dec 2024 = Dec 2023 + 13); a further revision
+is expected, so re-confirm numbers. gov.uk/guidance/national-planning-policy-framework/16-conserving-and-enhancing-the-historic-environment
+
+- **Para 207 [was 194] — describe significance (proportionately):** the applicant must
+  **describe the significance of any heritage assets affected, including any contribution made
+  by their setting**, in detail proportionate to the asset's importance. The hook for "no
+  proportionate significance/setting assessment provided." (For the "proportionate / don't
+  demand more information than needed" point, cite para 207 + the PPG, not a separate NPPF
+  sentence.)
+- **Para 208 [was 195] — LPA to identify and assess significance**, including where development
+  affects the **setting**, to avoid or minimise conflict.
+- **Para 209 [was 196] — deliberate neglect/damage** must not be taken into account in favour
+  of the applicant.
+- **Para 212 [was 199] — GREAT WEIGHT:** "great weight should be given to the asset's
+  conservation … the more important the asset, the greater the weight." Applies **whether the
+  harm is substantial, less than substantial, or none.**
+- **Para 213 [was 200] — substantial harm / total loss threshold:** any harm needs **clear and
+  convincing justification**; substantial harm/total loss to **grade II** should be
+  **exceptional**, and to **assets of the highest significance** (scheduled monuments, grade I
+  and II* listed buildings, grade I/II* registered parks & gardens, registered battlefields,
+  protected wreck sites, World Heritage Sites) **wholly exceptional**.
+- **Para 214 [was 201] — the substantial-harm test:** refuse unless the harm is **necessary to
+  achieve substantial public benefits that outweigh it**, OR **all four** of: (a) the asset's
+  nature prevents all reasonable use of the site; (b) no viable use of the asset itself can be
+  found through appropriate marketing; (c) not-for-profit/charitable/public conservation is
+  demonstrably impossible; and (d) harm is outweighed by bringing the site back into use.
+- **Para 215 [was 202] — LESS THAN SUBSTANTIAL harm:** "weighed against the public benefits of
+  the proposal including, where appropriate, securing its optimum viable use." Remember para
+  212: great weight still applies. Less-than-substantial harm is **not** neutral (*Bramshill*).
+- **Para 216 [was 203] — non-designated heritage assets:** a **"balanced judgement … having
+  regard to the scale of any harm or loss and the significance of the heritage asset."**
+- **Paras 217–218 [~205–206] — archaeology:** where a site has archaeological interest or
+  potential, require an **appropriate desk-based assessment and, where necessary, field
+  evaluation**; where justified loss occurs, require **recording and advancing understanding**
+  proportionate to importance, deposited with the Historic Environment Record — and **the
+  record must not be a substitute for preservation** where preservation is warranted.
+- **Setting** is woven through paras 207–208 (not a single paragraph); the operative method is
+  Historic England GPA3 (Part 4). NPPF Glossary: *setting* = "the surroundings in which a
+  heritage asset is experienced."
+
+---
+
+## Part 3 — Planning Practice Guidance ("Historic environment")
+gov.uk/guidance/conserving-and-enhancing-the-historic-environment (Ref ID 18a; substantive
+detail at 18a-015 to 18a-020)
+- **Proportionate significance assessment** — decisions on a proportionate assessment of the
+  particular significance of any asset affected, including its setting.
+- **Setting** — how setting contributes to significance and how to assess effects (with GPA3).
+- **Optimum viable use** — securing the use that keeps the asset viable while causing least
+  harm to significance; a public benefit to weigh under para 215.
+- **Enabling development** — otherwise-unacceptable development justified because it secures an
+  asset's conservation; tests apply (with Historic England GPA4).
+- **Recording / the Historic Environment Record (HER)** — recording as mitigation, proportionate
+  to importance, publicly deposited.
+
+---
+
+## Part 4 — Historic England guidance (current editions)
+- **GPA1 — The Historic Environment in Local Plans** (2015).
+- **GPA2 — Managing Significance in Decision-Taking in the Historic Environment** (2015) — the
+  core decision-taking note: assess significance, understand impact, minimise harm, use HERs.
+- **GPA3 — The Setting of Heritage Assets** — **2nd ed., Dec 2017** (⚠ supersedes the 2015 1st
+  ed.). The **staged setting method:** Step 1 identify the assets affected; Step 2 assess
+  whether/how setting contributes to significance; Step 3 assess the effect of the proposal;
+  Step 4 maximise enhancement/minimise harm; Step 5 make and document the decision. Cite this
+  when a setting assessment is absent or not to method.
+- **GPA4 — Enabling Development and Heritage Assets** (2020).
+- **HEAN 12 — Statements of Heritage Significance: Analysing Significance in Heritage Assets**
+  (2019) — the benchmark for preparing/critiquing a Statement of Significance.
+- **HEAN 1 (2nd ed., 2019) — Conservation Area Appraisal, Designation and Management** (⚠ this
+  is HEAN 1, not "HEAN 3"). Cite alongside the local conservation-area appraisal.
+- ⏳ **HEAN 4 Tall Buildings (2015)** and **HEAN 10 Listed Buildings and Curtilage (2018)** —
+  relevant to townscape/long views and to curtilage; confirm current editions before citing.
+  **HEAN 2 Making Changes to Heritage Assets** has a Dec 2025 revision — check the edition.
+
+**Significance vocabulary — use the statutory one.** Lead with the NPPF's four **interests** —
+**archaeological, architectural, artistic, historic** (the language of statute, the NPPF and
+HEAN 12). Historic England's *Conservation Principles* (2008) four **values** — **evidential,
+historical, aesthetic, communal** — are a useful analytical overlay but are not the
+statutory/policy vocabulary; don't conflate the two.
+
+---
+
+## Part 5 — Case law on the statutory duties
+- **Barnwell Manor / East Northamptonshire DC v SSCLG [2014] EWCA Civ 137:** the **s.66(1)
+  duty** requires the desirability of preserving a listed building/its setting to be given
+  **"considerable importance and weight"** — a **strong presumption against** harm, not neutral
+  weighing.
+- **Jones v Mordue [2015] EWCA Civ 1243:** an LPA that **works through the NPPF's historic-
+  environment paragraphs** will "generally" have discharged the s.66(1) duty — so insist the
+  officer report actually applies them.
+- **Palmer v Herefordshire [2016] EWCA Civ 1061:** applies *Mordue*; an express reference to the
+  NPPF heritage policies indicates compliance absent contrary evidence.
+- **R (Forge Field) v Sevenoaks DC [2014] EWHC 1895 (Admin):** even where harm is "less than
+  substantial," the desirability of preservation gets **considerable importance and weight**,
+  and benefits must **clearly outweigh** the harm. ⏳ confirm citation before quoting.
+- **South Lakeland DC v SSE [1992] (HL):** **"preserving" = doing no harm** (s.72). ⏳ confirm
+  the [1992] 2 AC 141 parallel citation.
+- **R (Bramshill) v SSHCLG [2021] EWCA Civ 320:** "less than substantial harm" is **not** "less
+  than substantial weight"; the NPPF harm categories operate **alongside** the statutory duties,
+  not in place of them.
+
+---
+
+## Part 6 — ⏳ Verify-before-relying (time-sensitive as of Aug 2026)
+- **NPPF edition & Chapter 16 numbers** — Dec 2024 used here; a restructured revision is
+  expected. Confirm the live edition and paragraph numbers when you draft (a republish will
+  renumber again).
+- **Historic England editions** — GPA3 is the 2017 2nd ed.; confirm HEAN 2/4/10 current editions.
+- **Case citations** — *Forge Field* and the *South Lakeland* AC citation want a quick
+  BAILII/ICLR confirmation before quoting.
+- **The "don't demand more information than reasonably needed" proposition** — cite para 207 +
+  PPG, not a specific NPPF sentence (it isn't expressly in Chapter 16).

--- a/heritage-representation/references/objection-template.md
+++ b/heritage-representation/references/objection-template.md
@@ -1,0 +1,155 @@
+# Objection template + annotated worked example
+
+A **skeleton** to fill, and a **worked example** showing the house style in practice. Match
+the example's density, tone and layout — every point must come from the documents in front of
+you.
+
+---
+
+## Skeleton
+
+```
+[Your name]
+[Your address]
+[Email]
+
+[Date]
+
+[Planning department / Council name / address]
+[For the attention of [Case Officer], if known]
+
+RE: Application [ref] — [site]
+[One-line description — note if listed-building consent / conservation-area / affects a
+designated asset or its setting; name the asset(s) and grade]
+
+Dear [Sir or Madam / Mr/Ms Name],
+
+REPRESENTATION ON HERITAGE GROUNDS — OBJECTION UNLESS MATTERS RESOLVED
+
+[Opening: consultation status; matters are material considerations while undecided; ask
+that this be placed on the file. Name the heritage asset(s) affected and their designation.]
+
+[State which documents you address — the Heritage Statement / Statement of Significance
+(author, date), the setting assessment, any archaeological assessment — and align with the
+conservation officer / Historic England where they have raised concerns.]
+
+The relevant framework includes: [short bulleted list from national-guidance.md — the
+statutory duties, the NPPF paragraphs, Historic England guidance, the conservation area
+appraisal].
+
+## 1. [Point stated as a conclusion]
+[Quote the document. Establish significance / characterise harm / invoke the duty. The ask.]
+
+## 2. [Next point]
+…
+
+## Summary of requests
+[Numbered, concrete, mostly "before determination".]
+
+Unless and until these matters are resolved, I object to the grant of [planning permission /
+listed building consent].
+
+Yours [sincerely/faithfully],
+[Name]
+```
+
+---
+
+## Worked example (condensed — annotations in ⟨…⟩)
+
+> ⟨Header, RE line and opening omitted for brevity — see the skeleton. The opening names the
+> asset (e.g. "the Grade II listed [building], and the [name] Conservation Area within which
+> the site sits") and aligns with the conservation officer's holding concerns.⟩
+
+**The relevant framework includes:** ⟨keep to what is engaged — a bulleted list, not a
+semicolon-run⟩
+
+- sections 66 and 72 of the Planning (Listed Buildings and Conservation Areas) Act 1990 — the
+  duties to have special regard to preserving a listed building and its setting, and special
+  attention to preserving or enhancing the character or appearance of a conservation area;
+- the NPPF's historic-environment policies — describing significance, great weight to the
+  conservation of designated assets, and the harm/public-benefit tests;
+- Historic England's Good Practice Advice (managing significance; the setting of heritage
+  assets);
+- the **[name] Conservation Area Appraisal**;
+- **[the Local Plan's historic-environment policies — insert the specific references]**.
+
+### 1. The significance of the asset has been under-assessed
+⟨Establish significance; bullet the interests the Statement omits.⟩
+
+The Heritage Statement confines the asset's significance to its external fabric. It does not
+assess the significance that derives from:
+
+- its **setting** — the [garden / street / group of buildings] through which the asset is
+  experienced;
+- its **group value** with the adjoining [assets];
+- its **historic interest** — [the association / phase / plan-form];
+- its **contribution to the conservation area's** character.
+
+Harm can only be measured against significance that has been identified. Because the Statement
+draws significance too narrowly, it also under-states the harm.
+
+**Request:** a Statement of Significance covering all the heritage interests — fabric, setting,
+group value and historic interest — before determination.
+
+### 2. The harm is mischaracterised, and the statutory weight is not applied
+⟨Two limbs — use lettered sub-points.⟩
+
+**(a)** The Statement describes the effect as causing "no harm" / "less than substantial
+harm." On a correct assessment the [demolition of the positive contributor / insertion into
+the setting] would [vitiate / very much reduce] the significance, which is **[substantial
+harm / a higher point on the less-than-substantial scale]** and engages the more demanding
+test.
+
+**(b)** Even on the applicant's own "less than substantial" characterisation, the assessment
+treats the harm as if it were neutral and simply outweighed. The Act requires **considerable
+importance and weight** to preserving the asset and its setting, and the NPPF requires **great
+weight** to the conservation of a designated asset. That weighted balance has not been carried
+out.
+
+**Request:** the level of harm correctly characterised, and the correct test and weighted
+public-benefit balance applied — and recorded — in the officer report.
+
+### 3. The public benefits are overstated and not weighed against the harm
+⟨Only genuine, generally public benefits count, weighed against great-weight harm.⟩
+
+The benefits relied on are largely private — [a larger dwelling / the applicant's return].
+The genuinely public benefits are [modest / unquantified], and they are asserted rather than
+weighed against harm to which great weight attaches.
+
+**Request:** the public benefits evidenced and expressly weighed against the (great-weight)
+heritage harm, not treated as a formality.
+
+### Summary of requests
+
+Before determination:
+1. A proportionate Statement of Significance covering all the heritage interests, including
+   setting and group value;
+2. A setting assessment to the recognised method, with representative views;
+3. The level of harm correctly characterised and the correct test applied, with the statutory
+   duties and great weight given effect and recorded in the officer report;
+4. The public benefits evidenced and weighed against the heritage harm;
+5. [Where relevant] an archaeological desk-based assessment and field evaluation before
+   determination.
+
+Unless and until these matters are resolved, I object to the grant of planning permission.
+
+Yours faithfully,
+[Name]
+
+---
+
+### Notes on adapting the example
+
+- **Match the point to the asset.** A listed building engages ss.66 and great weight; a
+  conservation area engages s.72 and "preserve or enhance"; a scheduled monument engages the
+  1979 Act; a non-designated asset engages the "balanced judgement." Name the right test.
+- **Get the harm level right.** Over-claiming "substantial harm" where the honest answer is
+  less-than-substantial damages credibility as much as the applicant under-claiming it.
+- **Consultant- or campaign-specific framing is excluded by default** — argue each point on
+  this application's own facts, not by reference to another case.
+- **Before submitting:** a person must read and check the draft — every quote and citation
+  against the actual documents — and be aware the representation is normally **published on the
+  council's portal in the submitter's name** and kept on the record, so include only personal
+  details the user is content to make public. This is a draft aid provided with no warranty; it
+  is not legal advice.


### PR DESCRIPTION
Three new skills, in priority order (heritage → flood → triage), built to the established `{deficiency-catalogue + web-verified national-guidance + house-style + template}` pattern and generic/public-safe.

## `application-triage` (the router)
Reads an application, identifies which **material considerations** are engaged, **ranks** them (decision-critical / supporting / weak), **sets aside non-material concerns** (loss of view, property values, competition, private disputes — with a reframe where one exists), and **routes** each live ground to the representation skill that handles it. Also carries the framework for considerations without a dedicated skill yet (design, amenity, Green Belt, landscape, trees, air quality…).

## `heritage-representation`
Evaluate the heritage evidence (Heritage Statement / Statement of Significance, setting and archaeology assessments) and draft a representation. Web-verified catalogue: the **LB & CA Act 1990 duties (ss.66/72)**, the **NPPF Chapter 16 harm tests with the Dec 2024 +13 renumbering**, Historic England GPA/HEAN guidance, and the case law (*Barnwell Manor*, *Mordue*, *Bramshill*, *South Lakeland*). Spine: *the level of harm drives the test*; *"less than substantial" is not "neutral"*.

## `flood-representation`
Evaluate the flood-risk/drainage evidence (FRA, Drainage/SuDS strategy, Sequential/Exception Tests). Web-verified catalogue: **NPPF Chapter 14 (paras 170–182)**, the **PPG flood zones and vulnerability matrix**, the **EA and LLFA statutory-consultee roles**, and the SuDS standards — with the important corrections that the **2015 SuDS standards were replaced by the 2025 National Standards** and **Schedule 3 mandatory SuDS is not commenced in England**. Spine: *the statutory consultees are allies*; *safe-for-lifetime + no-worsening-elsewhere*; lead with the Sequential Test.

## Repo
- Top-level README updated to the **retrieve → triage → represent** flow, now listing all six skills.
- Each new skill has README, LICENSE and a CHANGELOG recording the design rationale.

## House-rules compliance
- **Generic and public-safe** — no case/campaign/consultant/place fingerprints (verified across the new files and the tree).
- **Not legal advice, no warranty, human review required**, and the public-document-in-your-name flag — carried through every SKILL, README and template.
- Guidance catalogues **web-verified (Aug 2026)** with time-sensitive items flagged ⏳ (NPPF under revision; SuDS standards; Schedule 3 status; climate-allowance datasets; two heritage case citations to confirm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)