### PR TITLE
Add optional /planning-object command; document skills-as-commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ Each skill already has the `SKILL.md` frontmatter (`name`, `description`) that d
 needs — so it's just a copy. After that, a prompt like *"object to this application on
 ecology grounds"* invokes the skill automatically.
 
+An installed skill is **also a slash command**: as well as auto-triggering, you can invoke it
+by name — `/planning-document-search`, `/application-triage`, `/heritage-representation`, and so
+on. For a single command that runs the whole flow (retrieve → triage → draft), the optional
+[`commands/`](commands/) folder adds **`/planning-object [ref] [council]`** — see
+[`commands/README.md`](commands/README.md).
+
 ### Before you rely on the output
 
 Read the disclaimer at the top: **not legal advice, no warranty, and the output needs

--- a/commands/README.md
+++ b/commands/README.md
@@ -1,0 +1,39 @@
+# Slash commands
+
+In current Claude Code, **an installed skill is already a slash command.** Once you copy a
+skill from this repo into `~/.claude/skills/<name>/` (personal) or a project's
+`.claude/skills/<name>/`, you can either let Claude pick it automatically from your request, or
+invoke it by name:
+
+- `/planning-document-search`
+- `/application-triage`
+- `/ecological-representation` · `/transport-representation` · `/heritage-representation` ·
+  `/flood-representation`
+
+So you do **not** need a wrapper command for a single skill — the skill *is* the command.
+(Custom commands and skills are the same system now: a `.claude/commands/x.md` and a
+`.claude/skills/x/SKILL.md` both create `/x`; if a name clashes, the skill wins.)
+
+## The one wrapper worth having
+
+`planning-object.md` is an optional **orchestration** command — one shortcut that runs the whole
+flow across several skills (retrieve → triage → draft), which no single skill does on its own:
+
+| Command | What it does |
+|---|---|
+| `/planning-object [ref] [council]` | Fetch the documents, triage the grounds, and draft objections for every live ground |
+
+### Install
+
+Copy it to where Claude Code discovers commands (personal, or a project you share):
+
+```bash
+mkdir -p ~/.claude/commands
+cp commands/planning-object.md ~/.claude/commands/
+```
+
+It invokes the skills, so install the skills too (see the top-level README). Then, for example:
+
+```
+/planning-object 24/00431/FULL, Hull City Council
+```

--- a/commands/planning-object.md
+++ b/commands/planning-object.md
@@ -1,0 +1,24 @@
+---
+description: Retrieve, triage and draft objections for a UK planning application
+argument-hint: [application reference] [council]
+---
+Use the UK planning skills — `planning-document-search`, `application-triage`, and the
+`ecological-`, `transport-`, `heritage-` and `flood-representation` skills — to help me
+respond to a UK planning application.
+
+Application: $ARGUMENTS
+
+Work through it end to end:
+
+1. **Retrieve** the application's documents from the council's public planning portal
+   (`planning-document-search`).
+2. **Triage** the grounds (`application-triage`): identify which material considerations are
+   genuinely engaged, rank them (decision-critical / supporting / weak), and set aside
+   non-material concerns (loss of view, property values, competition). **Be honest if there is
+   no strong ground.**
+3. For each live, worthwhile ground, run the matching **representation** skill to evaluate the
+   evidence and draft a concise, well-founded objection.
+
+Follow the skills' rules: material considerations only; evidence-bound (quote the documents);
+"don't object" is a valid answer; this is **not legal advice**; and the draft needs my review
+before submission — it becomes a **public document in my name** on the council's portal.


### PR DESCRIPTION
The Claude Code guide confirmed that installed skills are already slash commands (v2.1.x) and that commands and skills are the same system — so single-skill wrappers are redundant.

- Adds one genuinely additive wrapper: **`/planning-object [ref] [council]`** — an end-to-end orchestration (retrieve → triage → draft) that no single skill does on its own (`commands/planning-object.md`).
- `commands/README.md` explains that each installed skill is directly invocable as `/skill-name`, so no per-skill wrappers are needed.
- Top-level README `How to use` now states the skills-as-commands behaviour and points to the optional command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)