### PR TITLE
Planning-judgment upgrades: s.38(6) framework, planning history, consultee map, A/B/C outcomes, conditions test

### DIFF
--- a/application-triage/CHANGELOG.md
+++ b/application-triage/CHANGELOG.md
@@ -6,6 +6,25 @@ intent.
 
 ## Unreleased
 
+### Added
+- **New Step 2 — "Establish the decision framework (s.38(6))":** adopted development plan →
+  relevant policies → emerging plan and its weight → neighbourhood plan → national policy,
+  before scanning for grounds; findings are anchored to named plan policies. _Why:_ reviewer
+  feedback — determination legally starts with the development plan, and grounds framed as
+  conflict with named plan policies are the strongest an objector can raise; the plan was
+  previously an afterthought.
+- **Planning history in intake:** previous applications, refusals, appeal decisions on the
+  same site, enforcement, extant permissions/conditions, s73s. _Why:_ a previous Inspector's
+  decision on the same site can outweigh any generic policy argument.
+- **Consultee map in `references/material-considerations.md`** (who speaks to what), with an
+  instruction to locate and read the matching response for every engaged consideration.
+  _Why:_ generalises the ecology skill's "the LPA ecologist is the strongest anchor" insight
+  across the system; a consultee's requested conditions are a ready-made ask.
+- **"So-what" test in ranking (A/B/C):** each ground is classified as demonstrated harm (A),
+  insufficient evidence (B), or conditionable (C), with an honest view on whether the grounds
+  together would plausibly justify refusal. _Why:_ a list of technically valid criticisms is
+  not itself a case for refusal; this stops impressive-but-ineffective objections.
+
 ### Changed
 - **"What you need first" now says uploaded/pasted/already-downloaded documents work
   directly, and `planning-document-search` is only needed when the user doesn't have

--- a/application-triage/SKILL.md
+++ b/application-triage/SKILL.md
@@ -42,6 +42,14 @@ skills, whenever the grounds aren't already decided.
 - The **document list itself** — it is the single best signal. The presence of an *Ecological
   Impact Assessment*, *Transport Assessment*, *Heritage Statement* or *Flood Risk Assessment*
   tells you which considerations the applicant themselves thought were engaged.
+- The **development plan** for the area — the adopted local plan (and any made neighbourhood
+  plan), from the council website. Determination starts here (see Step 2), so the relevant
+  policies are needed before grounds can be ranked.
+- The **site's planning history** — previous applications and refusals, **appeal decisions on
+  the same site**, enforcement history where relevant, extant permissions and their
+  conditions, and any s73 variations. Portals list related applications on the detail page; a
+  previous Inspector's decision on the same site can be worth more than any generic policy
+  argument, and a recent refusal tells you what the LPA already considers unacceptable.
 
 ## The integrity principle
 
@@ -65,22 +73,52 @@ play, say so. Two disciplines in particular:
 
 ### Step 1 — Intake
 Get the application (reference + council, or documents), the proposal and its **type/stage**,
-and the **site constraints** (conservation area, listed buildings, flood zone, Green Belt,
-AONB, greenfield/brownfield, protected trees). Retrieve the **document list**.
+the **site constraints** (conservation area, listed buildings, flood zone, Green Belt,
+AONB, greenfield/brownfield, protected trees), and the **site's planning history** (previous
+applications, refusals, appeal decisions, enforcement, extant permissions and conditions,
+s73s — see "What you need first"). Retrieve the **document list**.
 
-### Step 2 — Scan for engaged considerations
+### Step 2 — Establish the decision framework (s.38(6))
+Section 38(6) of the Planning and Compulsory Purchase Act 2004 requires applications to be
+determined **in accordance with the development plan unless material considerations indicate
+otherwise** — so the development plan is the starting point, not an afterthought. Before
+scanning for grounds, establish:
+
+1. the **adopted development plan** — the local plan (and any joint/minerals/waste plans) and
+   any made **neighbourhood plan**;
+2. the **relevant policies** for this proposal and site (settlement boundaries, housing,
+   design, amenity, and the topic policies for each consideration);
+3. any **emerging plan** and the weight it can carry (stage of preparation, unresolved
+   objections, consistency with national policy);
+4. **national policy** (NPPF/PPG) as a material consideration alongside the plan.
+
+Grounds framed as **conflict with named development-plan policies** are the strongest kind an
+objector can raise — anchor each finding in Step 3 to a plan policy wherever one exists.
+
+### Step 3 — Scan for engaged considerations
 Work through [`references/material-considerations.md`](references/material-considerations.md).
 For each consideration, check the *tells* — the application type, the proposal, the site
 constraints, and the presence (or telling *absence*) of the relevant technical document. Note
-the evidence for each ground you flag.
+the evidence for each ground you flag. For each engaged consideration, **locate and read the
+matching consultee response** (the consultee map in the reference file says who speaks to
+what) — read them before ranking, and note where a consultee objects, seeks conditions, or is
+silent.
 
-### Step 3 — Rank
+### Step 4 — Rank
 Grade each engaged ground: **decision-critical / supporting / weak**, on the strength of (a)
-how clearly national or local policy is engaged, (b) whether the applicant's evidence looks
-thin or is missing, and (c) how much weight the consideration typically carries. Set aside
-non-material concerns (with a reframe where possible).
+how clearly the development plan or national policy is engaged, (b) whether the applicant's
+evidence looks thin or is missing, and (c) how much weight the consideration typically
+carries. Set aside non-material concerns (with a reframe where possible).
 
-### Step 4 — Route
+Then apply the **"so-what" test**: a list of technically valid criticisms is not itself a
+case for refusal. Note for each ground whether it points to **(A)** a demonstrated
+unacceptable impact (a refusal reason), **(B)** insufficient evidence for the Council to
+reach the necessary conclusion (a "do not determine yet" ask), or **(C)** something a
+condition or obligation could secure (a mitigation ask) — and say honestly whether the
+grounds, taken together, would plausibly justify refusal under the applicable tests, or
+whether the credible representation is one that seeks information and conditions.
+
+### Step 5 — Route
 For each ground worth pursuing, name the representation skill that handles it and hand off:
 
 | Consideration | Skill |
@@ -94,10 +132,11 @@ For each ground worth pursuing, name the representation skill that handles it an
 Recommend an order (lead with the decision-critical grounds). Note where two skills should
 both run (a scheme often engages several).
 
-### Step 5 — Hand off / summarise
-Tell the user: the grounds worth objecting on (ranked), which skill will draft each, the
-non-material concerns to drop, and — if that's the honest answer — that there is no strong
-ground and an objection would not be sustainable.
+### Step 6 — Hand off / summarise
+Tell the user: the grounds worth objecting on (ranked, each anchored to the development-plan
+policies it engages and classified A/B/C), which skill will draft each, the non-material
+concerns to drop, and — if that's the honest answer — that there is no strong ground and an
+objection would not be sustainable.
 
 ## Reference files
 

--- a/application-triage/references/material-considerations.md
+++ b/application-triage/references/material-considerations.md
@@ -119,6 +119,29 @@ Objections must be *material planning considerations*. These commonly-raised con
 Tell the user honestly when their concern is not material — and whether it can be reframed as
 one that is. Credibility with the case officer depends on it.
 
+## Who speaks to what — the consultee map
+
+For every engaged consideration, deliberately **locate and read the matching consultee
+response** on the portal — don't treat them as incidental. A consultee's objection or holding
+position is often the strongest anchor a representation has; their requested conditions are a
+ready-made ask; and their *silence* on an engaged issue is itself worth noting. Compare each
+response against your own findings before ranking.
+
+| Consideration | Consultee response(s) to find |
+|---|---|
+| Ecology / biodiversity | LPA or county **ecologist**; **Natural England** (designated sites, EPS, nutrient/water neutrality) |
+| Transport / highways | **Highway authority** (county/unitary); **Active Travel England** (major schemes); National Highways (trunk roads) |
+| Flood risk / drainage | **Environment Agency** (river/sea flooding); **Lead Local Flood Authority** (surface water, major development); the water/sewerage company |
+| Heritage / archaeology | **Conservation officer**; **Historic England** (listed Grade I/II*, scheduled monuments, registered parks); county **archaeologist** |
+| Trees / landscape | **Tree officer** / arboricultural officer; landscape officer |
+| Amenity, noise, air quality, contamination | **Environmental health** |
+| Design | Design officer / **design review panel** where one operates |
+| Rights of way | The highway authority's PROW team |
+
+Caution: a consultee's "no objection" settles only their own remit — e.g. the highway
+authority's silence on capacity/safety is not an assessment of sustainable-transport policy
+compliance (see the transport skill), and the LPA must still strike its own balance.
+
 ## Quick triage from the document list + constraints
 
 1. **List the documents** (planning-document-search). Each technical report ⇒ its
@@ -128,9 +151,9 @@ one that is. Credibility with the case officer depends on it.
    hit ⇒ the corresponding consideration.
 3. **Read the proposal and stage** — outline vs reserved matters vs s73 vs full vs LBC changes
    what is open.
-4. **Read the statutory consultees' responses** — the highway authority, the LLFA/EA, Historic
-   England, Natural England, the county ecologist. Their concerns are strong signals (and their
-   *withdrawal* on safety/capacity is not an assessment of sustainability — see the transport
-   skill's "spine").
+4. **Read the consultee responses for every engaged consideration** (the consultee map above
+   says who speaks to what). Their concerns are strong signals (and their *withdrawal* on
+   safety/capacity is not an assessment of sustainability — see the transport skill's
+   "spine").
 5. **Rank and route** — lead with decision-critical grounds; drop the non-material; hand each
    live ground to its skill.

--- a/ecological-representation/CHANGELOG.md
+++ b/ecological-representation/CHANGELOG.md
@@ -6,6 +6,16 @@ intent.
 
 ## Unreleased
 
+### Added
+- **A/B/C outcome discipline:** every point must be classified as **(A)** demonstrated
+  unacceptable impact (refusal reason), **(B)** insufficient evidence to reach the necessary
+  conclusion (do-not-determine-yet ask), or **(C)** controllable by condition/obligation
+  (mitigation ask) — plus a pre-send checklist item that no point asks for refusal where a
+  condition would lawfully and satisfactorily do. _Why:_ reviewer feedback — an inadequate
+  assessment does not necessarily mean the development is unacceptable, only that the LPA
+  cannot presently be satisfied that it is; conflating the two (or over-asking for refusal
+  on conditionable points) is the classic credibility mistake in lay objections.
+
 ### Changed
 - **Renamed the skill folder and `name` from `ecological-objection` to
   `ecological-representation`.** _Why:_ parity with `transport-representation`, and a

--- a/ecological-representation/SKILL.md
+++ b/ecological-representation/SKILL.md
@@ -60,6 +60,18 @@ the credibility you need on the applications that matter. Sometimes the right ou
 note explaining why not to object, or a short representation asking only that the LPA
 ecologist's recommended conditions be imposed in full.
 
+**Classify every point's ask — (A) refuse, (B) don't determine yet, or (C) condition it.**
+An evidential deficiency is not itself a reason for refusal. For each confirmed point, be
+explicit about which outcome it supports: **(A)** the evidence *demonstrates* an unacceptable
+impact → a refusal reason; **(B)** the evidence is *insufficient* for the Council to reach the
+necessary conclusion (e.g. it cannot lawfully conclude on an EPS or a European site) → the
+application should **not be determined** until the information is provided; **(C)** the issue
+can be adequately controlled → ask for the *specific* condition or obligation (LEMP, lighting
+scheme, BNG verification). Most deficiency findings are (B), not (A) — claiming (A) on (B)
+evidence is the classic credibility mistake. And test every point against (C): if a condition
+would lawfully and satisfactorily resolve it, ask for that rather than refusal — over-asking
+weakens the whole representation.
+
 ## Workflow
 
 ### Step 1 — Intake and read
@@ -112,6 +124,9 @@ decision-critical points and align with the LPA ecologist.
 - Consultant-/campaign-specific framing excluded unless the user asked for it and it is
   defensible on this application's own facts (see the template note).
 - The requests are concrete and correctly timed to the application's stage.
+- Every point is classified **(A) demonstrated harm / (B) insufficient evidence / (C)
+  conditionable** — and no point asks for refusal where a condition would lawfully and
+  satisfactorily do.
 - Deadline: note if consultation has closed; representations are usually still accepted
   and are material while the application is undecided — say so in the opening.
 - **Hand back to a human, with the two warnings:** the draft must be read and checked by a

--- a/flood-representation/CHANGELOG.md
+++ b/flood-representation/CHANGELOG.md
@@ -6,6 +6,16 @@ intent.
 
 ## Unreleased
 
+### Added
+- **A/B/C outcome discipline:** every point must be classified as **(A)** demonstrated
+  unacceptable impact (refusal reason), **(B)** insufficient evidence to reach the necessary
+  conclusion (do-not-determine-yet ask), or **(C)** controllable by condition/obligation
+  (mitigation ask) — plus a pre-send checklist item that no point asks for refusal where a
+  condition would lawfully and satisfactorily do. _Why:_ reviewer feedback — an inadequate
+  assessment does not necessarily mean the development is unacceptable, only that the LPA
+  cannot presently be satisfied that it is; conflating the two (or over-asking for refusal
+  on conditionable points) is the classic credibility mistake in lay objections.
+
 ### Changed
 - **"What you need first" now says uploaded/pasted/already-downloaded documents work
   directly, and `planning-document-search` is only needed when the user doesn't have

--- a/flood-representation/SKILL.md
+++ b/flood-representation/SKILL.md
@@ -60,6 +60,20 @@ Two anchors:
 - **The two hard requirements.** Whatever the benefits: the development must be **safe for its
   lifetime** and must **not increase flood risk elsewhere** (ideally reduce it). Test both.
 
+**Classify every point's ask — (A) refuse, (B) don't determine yet, or (C) condition it.**
+An evidential deficiency is not itself a reason for refusal. For each confirmed point, be
+explicit about which outcome it supports: **(A)** the evidence *demonstrates* an unacceptable
+impact (a failed Sequential/Exception Test; demonstrated risk elsewhere) → a refusal reason;
+**(B)** the evidence is *insufficient* for the Council to reach the necessary conclusion (no
+FRA where one is required; no climate-change allowances; an unresolved EA/LLFA holding
+objection) → the application should **not be determined** until the information is provided;
+**(C)** the issue can be adequately controlled → ask for the *specific* condition or
+obligation (a detailed drainage scheme, runoff limits, a SuDS maintenance plan). Most
+deficiency findings are (B), not (A) — claiming (A) on (B) evidence is the classic
+credibility mistake. And test every point against (C): if a condition would lawfully and
+satisfactorily resolve it, ask for that rather than refusal — over-asking weakens the whole
+representation.
+
 ## Workflow
 
 ### Step 1 — Intake and read
@@ -102,6 +116,9 @@ multi-limb points (e.g. the Exception Test).
 - It aligns with, and builds on, the EA/LLFA positions.
 - Consultant-/campaign-specific framing excluded unless the user asked and it is defensible.
 - Requests are concrete and correctly timed.
+- Every point is classified **(A) demonstrated harm / (B) insufficient evidence / (C)
+  conditionable** — and no point asks for refusal where a condition would lawfully and
+  satisfactorily do.
 - **Hand back to a human, with the two warnings:** the draft must be read and checked, and
   submitting it puts a **public document in the user's name** on the council's portal.
 

--- a/heritage-representation/CHANGELOG.md
+++ b/heritage-representation/CHANGELOG.md
@@ -6,6 +6,16 @@ intent.
 
 ## Unreleased
 
+### Added
+- **A/B/C outcome discipline:** every point must be classified as **(A)** demonstrated
+  unacceptable impact (refusal reason), **(B)** insufficient evidence to reach the necessary
+  conclusion (do-not-determine-yet ask), or **(C)** controllable by condition/obligation
+  (mitigation ask) — plus a pre-send checklist item that no point asks for refusal where a
+  condition would lawfully and satisfactorily do. _Why:_ reviewer feedback — an inadequate
+  assessment does not necessarily mean the development is unacceptable, only that the LPA
+  cannot presently be satisfied that it is; conflating the two (or over-asking for refusal
+  on conditionable points) is the classic credibility mistake in lay objections.
+
 ### Changed
 - **"What you need first" now says uploaded/pasted/already-downloaded documents work
   directly, and `planning-document-search` is only needed when the user doesn't have

--- a/heritage-representation/SKILL.md
+++ b/heritage-representation/SKILL.md
@@ -65,6 +65,19 @@ Two points specific to heritage:
   weight** to preserving the asset, its setting and conservation-area character; the NPPF
   requires **great weight** to conservation of a designated asset.
 
+**Classify every point's ask — (A) refuse, (B) don't determine yet, or (C) condition it.**
+An evidential deficiency is not itself a reason for refusal. For each confirmed point, be
+explicit about which outcome it supports: **(A)** the evidence *demonstrates* unacceptable
+harm under the applicable test → a refusal reason; **(B)** the evidence is *insufficient* for
+the Council to reach the necessary conclusion (significance not assessed; archaeology not
+established before determination) → the application should **not be determined** until the
+information is provided; **(C)** the issue can be adequately controlled → ask for the
+*specific* condition or obligation (materials, detailed design, a written scheme of
+archaeological investigation). Most deficiency findings are (B), not (A) — claiming (A) on
+(B) evidence is the classic credibility mistake. And test every point against (C): if a
+condition would lawfully and satisfactorily resolve it, ask for that rather than refusal —
+over-asking weakens the whole representation.
+
 ## Workflow
 
 ### Step 1 — Intake and read
@@ -106,6 +119,9 @@ for lists and `(a)/(b)` for multi-limb points.
 - The statutory duties and great weight are correctly invoked.
 - Consultant-/campaign-specific framing excluded unless the user asked and it is defensible.
 - Requests are concrete and correctly timed.
+- Every point is classified **(A) demonstrated harm / (B) insufficient evidence / (C)
+  conditionable** — and no point asks for refusal where a condition would lawfully and
+  satisfactorily do.
 - **Hand back to a human, with the two warnings:** the draft must be read and checked, and
   submitting it puts a **public document in the user's name** on the council's portal.
 

--- a/planning-document-search/CHANGELOG.md
+++ b/planning-document-search/CHANGELOG.md
@@ -4,6 +4,15 @@ Design decisions per revision, newest first. See `../CLAUDE.md` for the format a
 house rules. The **_Why_** lines are the point: they record the rationale so a future
 editor understands the intent.
 
+## Unreleased
+
+### Added
+- **Checklist: flag consultee responses as their own document class, and pass on the site's
+  planning history** (related applications listed on portal detail pages) when the retrieval
+  feeds a triage or representation. _Why:_ the downstream skills now systematically read
+  consultee responses first and check planning history (reviewer feedback); the retrieval
+  skill is where both are cheapest to surface.
+
 ## 0.1.1 — 2026-08-16
 
 ### Added

--- a/planning-document-search/SKILL.md
+++ b/planning-document-search/SKILL.md
@@ -882,7 +882,13 @@ Keep the per-vendor recipe knowledge in *this* file and the per-council facts in
       reliable; the label is a hint.
 - [ ] **Distinguish a council backend outage from a block** — `500` everywhere while a
       health endpoint 200s and the doc host is TCP-dead = outage; retest later.
-- [ ] **Label the files** using the description/date shown next to each link.
+- [ ] **Label the files** using the description/date shown next to each link, and flag
+      **consultee responses** (highway authority, LLFA, Environment Agency, ecologist,
+      conservation officer, Historic England, environmental health…) as their own class —
+      the triage and representation skills read those first.
+- [ ] **Note the site's planning history** — portal detail pages usually list *related
+      applications* (earlier refusals, appeals, extant permissions, s73s). When the retrieval
+      feeds a triage or representation, pass those references on with the delivery.
 - [ ] **Report anything not retrieved** rather than silently returning a partial set.
 - [ ] **Struggling ≠ keep trying.** If the recipe (plus a couple of documented
       corrections) still isn't retrieving, stop and hand the user a browser link to

--- a/transport-representation/CHANGELOG.md
+++ b/transport-representation/CHANGELOG.md
@@ -6,6 +6,16 @@ intent.
 
 ## Unreleased
 
+### Added
+- **A/B/C outcome discipline:** every point must be classified as **(A)** demonstrated
+  unacceptable impact (refusal reason), **(B)** insufficient evidence to reach the necessary
+  conclusion (do-not-determine-yet ask), or **(C)** controllable by condition/obligation
+  (mitigation ask) — plus a pre-send checklist item that no point asks for refusal where a
+  condition would lawfully and satisfactorily do. _Why:_ reviewer feedback — an inadequate
+  assessment does not necessarily mean the development is unacceptable, only that the LPA
+  cannot presently be satisfied that it is; conflating the two (or over-asking for refusal
+  on conditionable points) is the classic credibility mistake in lay objections.
+
 ### Changed
 - **Enforced the bullet / lettered-sub-point drafting discipline** in `house-style.md` and
   the `objection-template.md` worked example (bulleted framework list; bulleted list of

--- a/transport-representation/SKILL.md
+++ b/transport-representation/SKILL.md
@@ -69,6 +69,19 @@ Two rules specific to transport:
   Objections are usually far stronger on **sustainable-transport and active-travel
   compliance, inclusive design, and the adequacy of the evidence.** Aim there.
 
+**Classify every point's ask — (A) refuse, (B) don't determine yet, or (C) condition it.**
+An evidential deficiency is not itself a reason for refusal. For each confirmed point, be
+explicit about which outcome it supports: **(A)** the evidence *demonstrates* an unacceptable
+impact (the "severe"/safety bar, or clear policy conflict) → a refusal reason; **(B)** the
+evidence is *insufficient* for the Council to reach the necessary conclusion (no route audit,
+no forecast flows, stale trip data) → the application should **not be determined** until the
+information is provided; **(C)** the issue can be adequately controlled → ask for the
+*specific* condition or obligation (Travel Plan securing, cycle-parking details, delivery of
+the outline mitigation). Most deficiency findings are (B), not (A) — claiming (A) on (B)
+evidence is the classic credibility mistake. And test every point against (C): if a condition
+or s106 obligation would lawfully and satisfactorily resolve it, ask for that rather than
+refusal — over-asking weakens the whole representation.
+
 ## Workflow
 
 ### Step 1 — Intake and read
@@ -123,6 +136,9 @@ the decision-critical points; aim at the winnable tests.
 - Consultant-/campaign-specific framing excluded unless the user asked and it is defensible
   on this application's own facts.
 - Requests are concrete and correctly timed to the stage.
+- Every point is classified **(A) demonstrated harm / (B) insufficient evidence / (C)
+  conditionable** — and no point asks for refusal where a condition or obligation would
+  lawfully and satisfactorily do.
 - Deadline: note if consultation has closed; representations remain material while the
   application is undecided.
 - **Hand back to a human, with the two warnings:** the draft must be read and checked by a


### PR DESCRIPTION
Closes #8 — the cross-cutting reviewer-feedback items (points 2, 5, 6, 7, 8). New skills (#9, #10) and Colchester (#11) follow in separate PRs.

## application-triage
- **New Step 2 — Establish the decision framework (s.38(6))**: adopted development plan → relevant policies → emerging plan + weight → neighbourhood plan → national policy, before any ground-scanning; every ground is then anchored to named plan policies.
- **Planning history** added to "What you need first" and intake: previous applications, refusals, appeal decisions on the same site, enforcement, extant permissions/conditions, s73s.
- **Consultee map** added to `references/material-considerations.md` (who speaks to what, with the "no objection settles only their remit" caution) + workflow instruction to locate and read the matching response for every engaged consideration.
- **"So-what" test in ranking**: grounds classified (A) demonstrated harm / (B) insufficient evidence / (C) conditionable, with an honest view on whether the grounds together would plausibly justify refusal.

## All four representation skills
- **A/B/C outcome discipline** (tailored examples per topic): an evidential deficiency is not itself a reason for refusal — each point states whether it supports refusal, a do-not-determine-yet ask, or a specific condition/obligation.
- **Conditions test** in every pre-send checklist: no point asks for refusal where a condition would lawfully and satisfactorily do.

## planning-document-search
- Checklist: flag consultee responses as their own document class; pass on the site's planning-history references with the delivery.

Changelogs updated in all six skills with rationale, per house rules.

**Not covered:** reviewer point 9 (application type's influence) arrived truncated — to be folded in or filed separately once the full text is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxttH6vHF5TswvbTd9zjid