### PR TITLE
Add national-planning-policy: shared NPPF/PPG layer with edition register and decision-making core

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ in its own folder with a `SKILL.md`, a `README.md`, and supporting reference fil
 | [`transport-representation/`](transport-representation/) | Evaluate the **transport / highways** evidence (Transport Assessment/Statement, Travel Plan, parking, street layout, secured mitigation), map deficiencies to policy/guidance, and draft a representation. |
 | [`heritage-representation/`](heritage-representation/) | Evaluate the **heritage / historic-environment** evidence (Heritage Statement, setting and archaeology assessments) for listed buildings, conservation areas, monuments and non-designated assets, and draft a representation. |
 | [`flood-representation/`](flood-representation/) | Evaluate the **flood-risk and drainage** evidence (Flood Risk Assessment, Drainage/SuDS strategy, Sequential/Exception Tests), map deficiencies to national policy, and draft a representation. |
+| [`national-planning-policy/`](national-planning-policy/) | **Shared layer.** The current NPPF/PPG edition register with a verify-before-citing protocol, plus the decision-making core the other skills share — s.38(6) and the development plan's primacy, the para 11 presumption ("tilted balance"), emerging-plan weight, and the conditions/obligations tests. |
 
 All England-focused. The skills chain:
 

--- a/application-triage/CHANGELOG.md
+++ b/application-triage/CHANGELOG.md
@@ -6,6 +6,12 @@ intent.
 
 ## Unreleased
 
+### Changed
+- **Step 2 (decision framework) now points to the companion `national-planning-policy`
+  skill** for the edition register, verify-before-citing protocol, and the shared s.38(6)/
+  presumption citations — including checking whether the tilted balance is engaged or
+  disapplied. _Why:_ one shared register instead of per-skill NPPF snapshots that drift.
+
 ### Added
 - **New Step 2 — "Establish the decision framework (s.38(6))":** adopted development plan →
   relevant policies → emerging plan and its weight → neighbourhood plan → national policy,

--- a/application-triage/SKILL.md
+++ b/application-triage/SKILL.md
@@ -95,6 +95,12 @@ scanning for grounds, establish:
 Grounds framed as **conflict with named development-plan policies** are the strongest kind an
 objector can raise — anchor each finding in Step 3 to a plan policy wherever one exists.
 
+The companion **national-planning-policy** skill holds the current NPPF/PPG edition
+register, the verify-before-citing protocol, and the shared decision-making citations
+(s.38(6) and plan primacy, the para 11 presumption/"tilted balance" and its footnotes,
+emerging-plan weight) — use it for this step, including checking whether the tilted balance
+is engaged or disapplied for this site.
+
 ### Step 3 — Scan for engaged considerations
 Work through [`references/material-considerations.md`](references/material-considerations.md).
 For each consideration, check the *tells* — the application type, the proposal, the site

--- a/ecological-representation/CHANGELOG.md
+++ b/ecological-representation/CHANGELOG.md
@@ -6,6 +6,13 @@ intent.
 
 ## Unreleased
 
+### Changed
+- **`national-guidance.md` now defers to the companion `national-planning-policy` skill**
+  for the NPPF/PPG edition register, the verify-before-citing protocol, and the shared
+  decision-making core; this file keeps only the topic layer. _Why:_ reviewer feedback —
+  per-skill NPPF snapshots drift out of sync as editions change; one register, checked
+  first, keeps the citations consistent (two-layers house rule).
+
 ### Added
 - **A/B/C outcome discipline:** every point must be classified as **(A)** demonstrated
   unacceptable impact (refusal reason), **(B)** insufficient evidence to reach the necessary

--- a/ecological-representation/references/national-guidance.md
+++ b/ecological-representation/references/national-guidance.md
@@ -4,6 +4,12 @@ The framework to cite when mapping a deficiency (skill function 2). **Cite the s
 instrument and clause, never "best practice" in the abstract.** Each deficiency in
 [`deficiency-catalogue.md`](deficiency-catalogue.md) points here.
 
+The **current NPPF/PPG edition register, the verify-before-citing protocol, and the shared
+decision-making core** (s.38(6) and plan primacy, the para 11 presumption and its footnotes,
+emerging-plan weight, the conditions and obligations tests) live in the companion
+**national-planning-policy** skill — check it first when citing the NPPF/PPG. This file owns
+only the topic-specific layer.
+
 > **Compiled and web-verified 14 August 2026 (England).** Several items are time-sensitive
 > — NPPF is under review, statutory BNG rules changed through 2026, and professional
 > guidance editions turn over. **Re-verify anything marked ⏳ before relying on it**, and

--- a/flood-representation/CHANGELOG.md
+++ b/flood-representation/CHANGELOG.md
@@ -6,6 +6,13 @@ intent.
 
 ## Unreleased
 
+### Changed
+- **`national-guidance.md` now defers to the companion `national-planning-policy` skill**
+  for the NPPF/PPG edition register, the verify-before-citing protocol, and the shared
+  decision-making core; this file keeps only the topic layer. _Why:_ reviewer feedback —
+  per-skill NPPF snapshots drift out of sync as editions change; one register, checked
+  first, keeps the citations consistent (two-layers house rule).
+
 ### Added
 - **A/B/C outcome discipline:** every point must be classified as **(A)** demonstrated
   unacceptable impact (refusal reason), **(B)** insufficient evidence to reach the necessary

--- a/flood-representation/references/national-guidance.md
+++ b/flood-representation/references/national-guidance.md
@@ -4,6 +4,12 @@ The framework to cite when mapping a deficiency (skill function 2). **Cite the s
 instrument and clause, never "best practice" in the abstract.** Each deficiency in
 [`deficiency-catalogue.md`](deficiency-catalogue.md) points here.
 
+The **current NPPF/PPG edition register, the verify-before-citing protocol, and the shared
+decision-making core** (s.38(6) and plan primacy, the para 11 presumption and its footnotes,
+emerging-plan weight, the conditions and obligations tests) live in the companion
+**national-planning-policy** skill — check it first when citing the NPPF/PPG. This file owns
+only the topic-specific layer.
+
 > **Compiled and web-verified 14 August 2026 (England).** ⏳ Several items are time-sensitive —
 > the NPPF is under revision (its flood paragraphs will renumber if republished), the national
 > SuDS standards were replaced in 2025, and climate-change allowance *figures* now live in

--- a/heritage-representation/CHANGELOG.md
+++ b/heritage-representation/CHANGELOG.md
@@ -6,6 +6,13 @@ intent.
 
 ## Unreleased
 
+### Changed
+- **`national-guidance.md` now defers to the companion `national-planning-policy` skill**
+  for the NPPF/PPG edition register, the verify-before-citing protocol, and the shared
+  decision-making core; this file keeps only the topic layer. _Why:_ reviewer feedback —
+  per-skill NPPF snapshots drift out of sync as editions change; one register, checked
+  first, keeps the citations consistent (two-layers house rule).
+
 ### Added
 - **A/B/C outcome discipline:** every point must be classified as **(A)** demonstrated
   unacceptable impact (refusal reason), **(B)** insufficient evidence to reach the necessary

--- a/heritage-representation/references/national-guidance.md
+++ b/heritage-representation/references/national-guidance.md
@@ -4,6 +4,12 @@ The framework to cite when mapping a deficiency (skill function 2). **Cite the s
 instrument and clause, never "best practice" in the abstract.** Each deficiency in
 [`deficiency-catalogue.md`](deficiency-catalogue.md) points here.
 
+The **current NPPF/PPG edition register, the verify-before-citing protocol, and the shared
+decision-making core** (s.38(6) and plan primacy, the para 11 presumption and its footnotes,
+emerging-plan weight, the conditions and obligations tests) live in the companion
+**national-planning-policy** skill — check it first when citing the NPPF/PPG. This file owns
+only the topic-specific layer.
+
 > **Compiled and web-verified 14 August 2026 (England).** ⏳ The NPPF is under revision (a
 > restructured draft consulted to March 2026, a new edition expected); its Chapter 16
 > paragraph numbers will change again if it is republished, so **confirm the current numbers

--- a/national-planning-policy/CHANGELOG.md
+++ b/national-planning-policy/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog — national-planning-policy
+
+Design decisions per revision, newest first. See `../CLAUDE.md` for the format and the
+house rules. The **_Why_** lines record the rationale so a future editor understands the
+intent.
+
+## 0.1.0 — 2026-08-16 — Initial release
+
+### Added
+- **The skill itself: a central national-policy layer** with (1) an edition register and a
+  verify-before-citing protocol, and (2) the shared decision-making core (s.38(6)/paras
+  2, 12, 48; the para 10–11 presumption with footnotes 7 and 8; para 49 emerging-plan
+  weight; para 57 conditions tests; para 58 / CIL reg 122(2) obligations tests). _Why:_
+  reviewer feedback — NPPF knowledge distributed across the topic catalogues lets skills
+  drift out of sync as editions change; the December 2025 draft revision (final expected
+  Summer 2026) restructures the Framework into coded policies, so a single re-verification
+  point matters more than ever. Structured as a companion *skill*, not a shared reference
+  file, so each skill folder stays individually copyable (repo convention).
+- **All citations verified against the live gov.uk text on 16 Aug 2026**, not from memory
+  (house rule 3). The verification pass immediately caught a live defect: the transport
+  catalogue cited the conditions tests as "para 56" (a December 2023 number) — fixed in the
+  same change, which is the skill's rationale demonstrated.
+- **Two-layers rule stated in the skill:** this layer owns the shared core + register; the
+  topic catalogues own their chapters and professional instruments. _Why:_ prevents the
+  duplication this skill exists to remove.

--- a/national-planning-policy/LICENSE
+++ b/national-planning-policy/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ian Howard
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/national-planning-policy/README.md
+++ b/national-planning-policy/README.md
@@ -1,0 +1,19 @@
+# national-planning-policy
+
+The shared national-policy layer for the planning skills in this repo. It does two jobs:
+
+1. **Edition discipline.** One register of the current NPPF edition (and the PPG's
+   page-by-page revision model), plus a protocol: never cite an NPPF paragraph from
+   memory — verify it against the live text before a draft leaves any skill. Editions
+   renumber, and a revision that restructures the whole Framework is expected imminently.
+2. **The decision-making core.** The citations every topic skill needs but none owns:
+   s.38(6) and the development plan's primacy, the paragraph-11 presumption ("tilted
+   balance") with its footnote 7/8 machinery, emerging-plan weight, and the tests for
+   planning conditions (para 57) and obligations (para 58 / CIL reg 122(2)).
+
+The topic skills (`ecological-`, `transport-`, `heritage-`, `flood-representation`) keep
+their own topic chapters and professional-guidance catalogues; `application-triage` uses
+this layer in Step 2 when it establishes the development-plan framework.
+
+> **Not legal advice. No warranty. England only.** Output requires human review; see the
+> repo README for the full disclaimer.

--- a/national-planning-policy/SKILL.md
+++ b/national-planning-policy/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: national-planning-policy
+description: >-
+  The shared national-policy layer for the England planning skills: verify the
+  current NPPF/PPG edition before citing anything, and supply the
+  decision-making core — s.38(6) and the development plan's primacy, the
+  paragraph-11 presumption ("tilted balance") and its footnotes, emerging-plan
+  weight, and the tests for planning conditions and obligations. Used by the
+  triage and representation skills; also answers direct "what does the NPPF
+  say / is this paragraph current" questions. England-focused. Not legal
+  advice; no warranty; output requires human review.
+license: MIT
+---
+
+# National planning policy — the shared layer
+
+One place for the two things every companion skill needs from national policy: **which
+edition is current** (and the discipline of checking before citing), and the
+**decision-making core** that no topic catalogue owns — the statutory starting point, the
+presumption, and the tests for conditions and obligations.
+
+## When to use
+
+- **From the companion skills** — `application-triage` (Step 2, establishing the decision
+  framework) and the representation skills (when mapping deficiencies to national policy):
+  check the edition register here before citing the NPPF/PPG, and take the shared
+  decision-making citations from here rather than restating them per topic.
+- **Directly** — the user asks "what does the NPPF say about …", "is this paragraph number
+  still right", "does the tilted balance apply here".
+
+## Two layers, no duplication
+
+This skill owns the **shared core and the edition register**. The topic skills' own
+`references/national-guidance.md` files own their **topic chapters and instruments**
+(ecology's Chapter 15 map, CIEEM and BCT editions; transport's Chapter 9, LTN 1/20 and
+Manual for Streets; heritage's Chapter 16 and the 1990 Act duties; flood's paragraphs
+170–182 and the climate-change allowances). Don't copy either layer into the other.
+
+## The verification protocol — read before citing anything
+
+**Never cite an NPPF paragraph number from memory.** Editions renumber: December 2023 →
+December 2024 shifted several chapters by one, and the pending revision (below) restructures
+the entire document. A representation citing a stale paragraph loses credibility on the
+point it most needs it — and a superseded-edition citation is exactly the kind of defect the
+representation skills criticise applicants for.
+
+Before a draft leaves any companion skill:
+
+1. **Check the edition register below**, then confirm it is still current at
+   [gov.uk/guidance/national-planning-policy-framework](https://www.gov.uk/guidance/national-planning-policy-framework)
+   (the page's "Updates" tab shows the edition history).
+2. **Verify each cited paragraph against the live text** — the gov.uk HTML is the
+   quickest source; quote the paragraph, don't paraphrase from memory.
+3. **If the edition has changed** since the register below was verified: re-verify every
+   NPPF citation in the draft, tell the user the framework has changed, and update this
+   register and any affected topic catalogue (with changelog entries).
+4. **PPG**: cite by the paragraph ID (e.g. "Paragraph: 001 Reference ID: 21a-001-…") *and*
+   the page's "last updated" date — PPG pages revise independently and silently.
+
+## ⏳ Edition register (verified 16 August 2026 — re-verify at run time)
+
+- **NPPF in force: December 2024 edition** (published 12 Dec 2024, amended 7 Feb 2025).
+  Live text: gov.uk/guidance/national-planning-policy-framework. PDF:
+  assets.publishing.service.gov.uk/media/67aafe8f3b41f783cca46251/NPPF_December_2024.pdf
+- **⚠ Pending revision — expect a complete renumbering.** A draft revised NPPF was
+  published for consultation on 16 December 2025 (consultation closed 10 March 2026); the
+  final version is expected **Summer 2026** — i.e. imminently at the verification date
+  above. The draft restructures the Framework into ~133 coded policies in themed chapters,
+  so **paragraph-number citations will not survive it**. When it lands: switch to the new
+  policy codes, re-verify everything, and update every catalogue in this repo.
+- **PPG**: web-based guidance suite, revised page-by-page — no single edition; rely on
+  per-page "last updated" dates.
+
+## The decision-making core (verified against the live December 2024 text)
+
+**The statutory starting point.** Section 38(6) of the Planning and Compulsory Purchase
+Act 2004: applications must be determined **in accordance with the development plan unless
+material considerations indicate otherwise** (see also s.70(2) TCPA 1990). The NPPF
+restates this at **para 2** and **para 48**, and para 2 confirms the Framework itself "is a
+material consideration in planning decisions" — influential, but not above the plan.
+**Para 12**: the presumption in favour of sustainable development "does not change the
+statutory status of the development plan as the starting point for decision-making."
+
+**The presumption / "tilted balance" — paras 10–11.** For decision-taking, para 11(c):
+approve development that accords with an up-to-date plan without delay. Para 11(d) — the
+tilted balance — applies only where there are **no relevant development plan policies, or
+the policies which are most important for determining the application are out-of-date**
+(footnote 8: including where no five-year housing land supply can be demonstrated, or the
+Housing Delivery Test result was below 75%). Even then, permission should be *refused* if
+**footnote 7** assets provide a clear reason to (habitats sites, SSSIs, Green Belt, Local
+Green Space, National Landscapes, National Parks/Broads, Heritage Coast, irreplaceable
+habitats, designated heritage assets, areas at risk of flooding or coastal change) — the
+"footnote 7 disapplication" — or if adverse impacts would **significantly and demonstrably
+outweigh** the benefits. Whether the tilted balance is engaged, and whether footnote 7
+switches it off, is often decisive: check it before framing any objection strategically.
+
+**Emerging plans — para 49.** Weight according to (a) the stage of preparation, (b) the
+extent of unresolved objections, and (c) the degree of consistency with the Framework.
+
+**Planning conditions — para 57.** Conditions should be kept to a minimum and only imposed
+where they are "necessary, relevant to planning and to the development to be permitted,
+enforceable, precise and reasonable in all other respects" — the **six tests** (PPG "Use of
+planning conditions"). Two uses for an objector: a condition that fails a test can be
+challenged; and a condition cannot be *necessary* if it papers over a fundamental evidence
+gap — "conditions are not a substitute for adequate assessment" anchors here.
+
+**Planning obligations — para 58.** Obligations must only be sought where they meet the
+three tests of CIL Regulation 122(2): **necessary** to make the development acceptable in
+planning terms, **directly related** to the development, and **fairly and reasonably
+related in scale and kind** to it.
+
+**How this feeds the A/B/C discipline** (see the representation skills): outcome (A)
+usually means conflict with the development plan and/or a failed NPPF test with the balance
+against approval; outcome (B) means the decision-maker cannot yet lawfully strike that
+balance; outcome (C) lives inside the para 57/58 tests — the ask must itself pass them.
+
+## Scope and limitations
+
+- **Not legal advice, and no warranty.** A reference layer for lay representations; not a
+  substitute for a solicitor; provided "as is". **Human review required** before relying on
+  any citation.
+- **England-focused.** The NPPF/PPG are England; the devolved nations have their own
+  frameworks — flag and adjust when outside England.
+- **Time-sensitive by nature.** Everything here decays at the next NPPF revision — the
+  verification protocol is the skill; the register is only a snapshot.

--- a/transport-representation/CHANGELOG.md
+++ b/transport-representation/CHANGELOG.md
@@ -6,6 +6,19 @@ intent.
 
 ## Unreleased
 
+### Fixed
+- **Conditions six-tests citation corrected from NPPF para 56 to para 57.** _Why:_ para 56
+  was the December 2023 number; the December 2024 edition renumbered the chapter (as this
+  file's own edition note records). Caught by the verification pass that built the
+  `national-planning-policy` skill — the drift it exists to prevent.
+
+### Changed
+- **`national-guidance.md` now defers to the companion `national-planning-policy` skill**
+  for the NPPF/PPG edition register, the verify-before-citing protocol, and the shared
+  decision-making core; this file keeps only the topic layer. _Why:_ reviewer feedback —
+  per-skill NPPF snapshots drift out of sync as editions change; one register, checked
+  first, keeps the citations consistent (two-layers house rule).
+
 ### Added
 - **A/B/C outcome discipline:** every point must be classified as **(A)** demonstrated
   unacceptable impact (refusal reason), **(B)** insufficient evidence to reach the necessary

--- a/transport-representation/references/national-guidance.md
+++ b/transport-representation/references/national-guidance.md
@@ -4,6 +4,12 @@ The framework to cite when mapping a deficiency (skill function 2). **Cite the s
 instrument and clause, never "best practice" in the abstract.** Each deficiency in
 [`deficiency-catalogue.md`](deficiency-catalogue.md) points here.
 
+The **current NPPF/PPG edition register, the verify-before-citing protocol, and the shared
+decision-making core** (s.38(6) and plan primacy, the para 11 presumption and its footnotes,
+emerging-plan weight, the conditions and obligations tests) live in the companion
+**national-planning-policy** skill — check it first when citing the NPPF/PPG. This file owns
+only the topic-specific layer.
+
 > **Compiled and web-verified 14 August 2026 (England).** Several items are time-sensitive
 > — the NPPF is under review and its paragraph numbers shift between editions, Manual for
 > Streets is being updated, and some exact figures need checking in the source PDF.
@@ -79,7 +85,7 @@ Code** (Jan 2021) are the design references para 115(c) points to.
 - **Travel Plans — 42-003 / -011 / -012:** long-term management strategies with targets,
   measures, monitoring and review, secured by condition/obligation.
 - **"Conditions are not a substitute for adequate assessment"** — this is **not** in the
-  transport PPG; anchor it to the **six tests for planning conditions** (NPPF para 56 / PPG
+  transport PPG; anchor it to the **six tests for planning conditions** (NPPF para 57 / PPG
   "Use of planning conditions", category 21): a condition must be *necessary* and cannot cure
   a fundamental evidence deficiency.
 


### PR DESCRIPTION
Closes #9.

## New skill: `national-planning-policy/`

The shared national-policy layer (SKILL.md + README + CHANGELOG + LICENSE), doing two jobs:

1. **Edition discipline** — a register of the current NPPF edition (December 2024, amended Feb 2025) and a hard protocol: **never cite an NPPF paragraph from memory**; verify against the live gov.uk text before any draft leaves a skill. The register carries a prominent ⏳ warning: the December 2025 draft revision (consultation closed March 2026, final expected **Summer 2026 — imminent**) restructures the Framework into ~133 coded policies, so every paragraph citation in the repo will need re-verification when it lands.
2. **The decision-making core** no topic catalogue owns — all verified against the live text on 16 Aug 2026: s.38(6) and plan primacy (paras 2, 12, 48), the para 10–11 presumption / tilted balance with the footnote 7 disapplication and footnote 8 out-of-date triggers, emerging-plan weight (para 49), the conditions six tests (para 57), and the obligations tests (para 58 / CIL reg 122(2)) — plus how these feed the A/B/C outcome discipline.

## Wiring (two layers, no duplication)

- The four topic catalogues (`references/national-guidance.md`) now open with a pointer deferring to this skill for the edition register and shared core; they keep their topic chapters and professional instruments.
- `application-triage` Step 2 points here for the s.38(6)/presumption citations, including checking whether the tilted balance is engaged or disapplied for the site.
- Root README gains the skill's table row.

## Bonus fix, caught by the verification pass

The transport catalogue cited the conditions six tests as **"NPPF para 56"** — the December 2023 number; the December 2024 edition renumbered it to **57** (as that file's own edition note records). Fixed, with a changelog entry. This is precisely the drift the central layer exists to prevent.

Changelogs updated in all six affected skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxttH6vHF5TswvbTd9zjid