### PR TITLE
Add planning-balance: the final "so-what" test for a representation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,18 @@ in its own folder with a `SKILL.md`, a `README.md`, and supporting reference fil
 | [`heritage-representation/`](heritage-representation/) | Evaluate the **heritage / historic-environment** evidence (Heritage Statement, setting and archaeology assessments) for listed buildings, conservation areas, monuments and non-designated assets, and draft a representation. |
 | [`flood-representation/`](flood-representation/) | Evaluate the **flood-risk and drainage** evidence (Flood Risk Assessment, Drainage/SuDS strategy, Sequential/Exception Tests), map deficiencies to national policy, and draft a representation. |
 | [`national-planning-policy/`](national-planning-policy/) | **Shared layer.** The current NPPF/PPG edition register with a verify-before-citing protocol, plus the decision-making core the other skills share — s.38(6) and the development plan's primacy, the para 11 presumption ("tilted balance"), emerging-plan weight, and the conditions/obligations tests. |
+| [`planning-balance/`](planning-balance/) | **Final step.** The "so-what" test: anticipate the decision-maker's planning balance — governing framework, ground-specific gateways, harms vs benefits — and recommend what the representation should actually ask for (refusal, deferral for information, or conditions), or advise that the balance favours approval. |
 
 All England-focused. The skills chain:
 
 1. **`planning-document-search`** fetches the application documents;
 2. **`application-triage`** decides which grounds are worth pursuing and routes to —
 3. a **representation** skill (`ecological-`, `transport-`, `heritage-`, `flood-representation`)
-   which evaluates the evidence and drafts the objection.
+   which evaluates the evidence and drafts the objection;
+4. **`planning-balance`** runs the final "so-what" test — whether the assembled case actually
+   supports refusal, a request for further information, or conditions.
+
+(`national-planning-policy` sits under all of them as the shared NPPF/PPG layer.)
 
 Considerations without a dedicated skill yet (design, residential amenity, Green Belt,
 landscape, trees, air quality…) are covered by the triage skill's framework map, to argue on

--- a/application-triage/CHANGELOG.md
+++ b/application-triage/CHANGELOG.md
@@ -7,6 +7,9 @@ intent.
 ## Unreleased
 
 ### Changed
+- **Step 4's "so-what" test and the routing table now hand off to the new
+  `planning-balance` companion skill** as the final step of the chain. _Why:_ the test
+  needs the evidenced grounds to run properly; naming the skill makes the chain explicit.
 - **Step 2 (decision framework) now points to the companion `national-planning-policy`
   skill** for the edition register, verify-before-citing protocol, and the shared s.38(6)/
   presumption citations — including checking whether the tilted balance is engaged or

--- a/application-triage/SKILL.md
+++ b/application-triage/SKILL.md
@@ -122,7 +122,9 @@ unacceptable impact (a refusal reason), **(B)** insufficient evidence for the Co
 reach the necessary conclusion (a "do not determine yet" ask), or **(C)** something a
 condition or obligation could secure (a mitigation ask) — and say honestly whether the
 grounds, taken together, would plausibly justify refusal under the applicable tests, or
-whether the credible representation is one that seeks information and conditions.
+whether the credible representation is one that seeks information and conditions. The
+companion **planning-balance** skill runs this test in full once the representation skills
+have evidenced the grounds — recommend it as the final step of the chain.
 
 ### Step 5 — Route
 For each ground worth pursuing, name the representation skill that handles it and hand off:
@@ -134,6 +136,7 @@ For each ground worth pursuing, name the representation skill that handles it an
 | Heritage / listed buildings / conservation areas / archaeology | **heritage-representation** |
 | Flood risk / drainage / SuDS | **flood-representation** |
 | Other material considerations (design, amenity, Green Belt, landscape, …) | *no dedicated skill yet — see the map for the framework and argue on the documents' own facts* |
+| Final check — does the assembled case justify the ask? | **planning-balance** (run last, after the representation skills) |
 
 Recommend an order (lead with the decision-critical grounds). Note where two skills should
 both run (a scheme often engages several).

--- a/national-planning-policy/CHANGELOG.md
+++ b/national-planning-policy/CHANGELOG.md
@@ -4,6 +4,13 @@ Design decisions per revision, newest first. See `../CLAUDE.md` for the format a
 house rules. The **_Why_** lines record the rationale so a future editor understands the
 intent.
 
+## Unreleased
+
+### Changed
+- **A/B/C paragraph now also points to the `planning-balance` companion skill.** _Why:_
+  the balance skill is where the assembled case is weighed; the cross-reference completes
+  the chain.
+
 ## 0.1.0 — 2026-08-16 — Initial release
 
 ### Added

--- a/national-planning-policy/SKILL.md
+++ b/national-planning-policy/SKILL.md
@@ -109,7 +109,8 @@ three tests of CIL Regulation 122(2): **necessary** to make the development acce
 planning terms, **directly related** to the development, and **fairly and reasonably
 related in scale and kind** to it.
 
-**How this feeds the A/B/C discipline** (see the representation skills): outcome (A)
+**How this feeds the A/B/C discipline** (see the representation skills, and the companion
+**planning-balance** skill which weighs the assembled case): outcome (A)
 usually means conflict with the development plan and/or a failed NPPF test with the balance
 against approval; outcome (B) means the decision-maker cannot yet lawfully strike that
 balance; outcome (C) lives inside the para 57/58 tests — the ask must itself pass them.

--- a/planning-balance/CHANGELOG.md
+++ b/planning-balance/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog — planning-balance
+
+Design decisions per revision, newest first. See `../CLAUDE.md` for the format and the
+house rules. The **_Why_** lines record the rationale so a future editor understands the
+intent.
+
+## 0.1.0 — 2026-08-16 — Initial release
+
+### Added
+- **The skill itself: a final planning-balance ("so-what") stage** run after triage and
+  the representation skills — governing-framework identification (plan-led vs tilted
+  balance, footnote 7 disapplication), ground-specific gateways (Habitats Regulations
+  hard stop, Green Belt VSC, heritage harm tests, flood Sequential Test, transport
+  "severe" bar), an honest harms-vs-benefits weighing, and a four-outcome recommendation
+  (refuse / do not determine yet / conditions / balance favours approval). _Why:_ reviewer
+  feedback — a planning decision is not the sum of technical defects, and without a final
+  balance question the system can produce an impressive list of valid criticisms that
+  would not change the decision. Framed as *anticipating* the decision-maker's balance
+  because an objector is not the decision-maker.
+- **Benefits scrutinised with the same evidence discipline as harms** (unquantified
+  economic claims, unsecured affordable housing → reduced weight). _Why:_ the balance has
+  two pans; engaging with benefits honestly is both more credible and a source of
+  representation material in its own right.
+- **Kept to a single SKILL.md, deferring citations to `national-planning-policy` and the
+  topic catalogues.** _Why:_ two-layers house rule — this skill owns the *procedure* of
+  the balance; the instruments and current paragraph numbers live in the companion skills.

--- a/planning-balance/LICENSE
+++ b/planning-balance/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ian Howard
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/planning-balance/README.md
+++ b/planning-balance/README.md
@@ -1,0 +1,22 @@
+# planning-balance
+
+The final "so-what" test in the planning-skills chain. A planning decision is not the sum
+of technical defects — after `application-triage` has ranked the grounds and the
+representation skills have evidenced them, this skill anticipates the decision-maker's
+**planning balance**:
+
+- which framework governs (plan-led under s.38(6), or the NPPF para 11(d) tilted balance —
+  and whether footnote 7 disapplies it);
+- the ground-specific gateways (Habitats Regulations hard stops, Green Belt very special
+  circumstances, the heritage harm tests, the flood Sequential Test, the transport
+  "severe" bar);
+- an honest weighing of the surviving harms against the scheme's claimed benefits;
+- and the recommended ask: **refusal**, **do not determine yet**, **conditions** — or
+  advice that the balance favours approval and an objection is not sustainable.
+
+It exists to stop an impressive list of technically valid criticisms being mistaken for a
+case for refusal.
+
+> **Not legal advice. No warranty. England only.** The balance is the decision-maker's
+> judgement; this anticipates it. Output requires human review; see the repo README for
+> the full disclaimer.

--- a/planning-balance/SKILL.md
+++ b/planning-balance/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: planning-balance
+description: >-
+  The final "so-what" test for a planning representation: given the assembled,
+  evidenced grounds against a UK planning application, anticipate the
+  decision-maker's planning balance — identify the governing statutory/policy
+  tests (s.38(6), the tilted balance, heritage great weight, Green Belt very
+  special circumstances, the transport and flood tests), weigh harms against
+  the scheme's benefits honestly, and recommend what the representation should
+  actually ask for: refusal, deferral for information, or conditions — or
+  advise that the balance favours approval. Run after application-triage and
+  the representation skills. England-focused. Not legal advice; no warranty;
+  output requires human review.
+license: MIT
+---
+
+# Planning balance — the "so-what" test
+
+A planning decision is not the sum of technical defects. This skill runs **last**, after
+the grounds have been assembled and evidenced, and answers the question every strong
+representation must survive:
+
+> Even if these harms and deficiencies exist, are they sufficient — under the tests that
+> actually govern this application — to justify refusal?
+
+The objector is not the decision-maker. What this skill does is **anticipate the balance
+the case officer must strike**, so the representation asks for the outcome the balance can
+actually support — which is what makes it liftable into the officer report rather than
+filed as noise.
+
+## When to use
+
+- As the **final step** of the chain: `application-triage` has ranked the grounds, the
+  representation skills have evidenced them, and each point carries its A/B/C
+  classification. Run this before anything is drafted into a final ask.
+- Directly, when the user asks: "would this actually be refused?", "is our case strong
+  enough?", "should we push for refusal or for conditions?"
+
+## What you need first
+
+- The **evidenced grounds**, each classified **(A)** demonstrated unacceptable impact /
+  **(B)** insufficient evidence / **(C)** conditionable (the representation skills produce
+  this), and the **development-plan policies** each ground conflicts with (triage Step 2).
+- The **scheme's claimed benefits** — from the Planning Statement and application forms:
+  housing numbers (market and affordable), economic claims, regeneration, BNG, public
+  realm. The balance has two pans; a representation that never engages with the benefits
+  is not doing the exercise.
+- The **site constraints** that switch tests on or off (Green Belt, designated heritage,
+  flood zone, habitats sites — triage records these).
+- The **consultee positions** — an unresolved statutory-consultee objection changes what
+  the balance can conclude.
+- The companion **national-planning-policy** skill for the current citations: s.38(6) and
+  plan primacy, whether the **tilted balance** is engaged (most-important policies
+  out-of-date / housing land supply) or **disapplied by footnote 7**, and the
+  conditions/obligations tests.
+
+## The integrity principle (read first)
+
+**The balance is where over-claiming goes to die.** Inflating a (B) evidence gap into an
+(A) refusal case, dismissing real benefits, or demanding refusal where conditions would
+plainly do, hands the case officer a reason to discount the whole representation. The
+honest outputs of this skill include: "the balance favours approval — don't object",
+"object, but ask for conditions, not refusal", and "the only sound ask is that the
+application not be determined until X is before the Council." Each of those is a success,
+not a failure. Credibility spent here is spent for every future representation too.
+
+## Workflow
+
+### Step 1 — Identify the governing framework
+Start from s.38(6): does the assembled case amount to **conflict with the development plan
+read as a whole**, or only with fragments of it? Then establish which balance applies:
+
+- **Plan-led (the default):** determine in accordance with the plan unless material
+  considerations indicate otherwise. Plan conflict + no outweighing considerations →
+  refusal is the plan-led outcome.
+- **Tilted balance (NPPF para 11(d)):** engaged only where there are no relevant policies
+  or the most important ones are out-of-date (check housing land supply / Housing Delivery
+  Test via the national-planning-policy skill). If engaged, harm must **significantly and
+  demonstrably** outweigh benefits — a materially harder target for an objector — *unless*
+  **footnote 7** disapplies it (habitats sites, SSSIs, Green Belt, National Landscapes,
+  designated heritage, flood risk…). Getting this switch right is often the single most
+  strategic fact in the case.
+
+### Step 2 — Apply the ground-specific gateways
+Some grounds carry their own test that must be run *before* the general weighing — take
+the current citations from the topic skills and the national-planning-policy skill:
+
+- **Habitats Regulations** — not a balance at all: if adverse effect on a European site's
+  integrity cannot be ruled out, permission cannot lawfully be granted (a hard stop; also
+  the EPS derogation tests). These outrank everything else raised.
+- **Green Belt** — inappropriate development requires **very special circumstances**; the
+  applicant carries that burden, not the objector.
+- **Heritage** — characterise the harm level honestly, then apply the statutory
+  **considerable importance and weight** and the NPPF great-weight/public-benefit tests.
+- **Flood** — the **Sequential Test** is a gateway: if it fails, the balance is not
+  reached; the development must also be safe for its lifetime without increasing risk
+  elsewhere.
+- **Transport** — refusal on capacity/safety alone needs a **severe** residual cumulative
+  impact or an unacceptable safety impact; otherwise the ground argues policy
+  non-compliance, which weighs but rarely decides alone.
+
+### Step 3 — Weigh honestly
+Set the surviving harms (with their statutory/policy weightings) against the benefits —
+and scrutinise the benefits with the same evidence discipline the representation skills
+apply to harms: unquantified economic claims, double-counted open space, or "affordable
+housing" without a secured obligation attract reduced weight, and saying so (with the
+applicant's own document quoted) is itself good representation material. Note which
+harms are (B)-class: an unresolved evidence gap does not weigh as demonstrated harm — it
+means the balance **cannot yet lawfully be struck**, which is its own conclusion.
+
+### Step 4 — Conclude and recommend the ask
+One of four honest outcomes, driving what the representation requests:
+
+1. **Refusal** — (A) grounds sufficient under the governing tests: say which test fails
+   and why the benefits don't save it.
+2. **Do not determine yet** — (B) grounds dominate: the ask is the missing information
+   before determination, put as "the Council cannot presently conclude X".
+3. **Approve-with-conditions posture** — the harms resolve to (C): the ask is the precise
+   conditions/obligations (which must themselves pass the para 57/58 tests).
+4. **The balance favours approval** — say so, and advise not objecting (or a short
+   representation supporting conditions only).
+
+Output a **short balance statement** (a paragraph, two at most) the user can lift into the
+representation's opening or closing: the framework that governs, the decisive harms with
+their weights, the benefits acknowledged, and the conclusion with the ask. Then hand back
+to a human with the standard warnings: **review before use, and anything submitted is
+normally published on the council's portal in the submitter's name.**
+
+## Scope and limitations
+
+- **Not legal advice, and no warranty.** The balance is ultimately the decision-maker's
+  planning judgement; this skill anticipates it to sharpen a lay representation, is not a
+  substitute for a solicitor or planning consultant, guarantees no outcome, and is
+  provided "as is".
+- **Human review is necessary before use.** A person must check the tests invoked and the
+  weights claimed against the actual documents and current policy.
+- **England-focused.** The tests cited are the England framework; flag and adjust outside
+  England.
+- **Evidence-bound.** Weigh only harms that survived the representation skills' evidence
+  discipline and benefits actually claimed in the application; invent neither.
+- **The honest answer is sometimes "the balance favours approval."** Treat that as a
+  valid, valuable output.


### PR DESCRIPTION
Closes #10.

## New skill: `planning-balance/`

Runs **last** in the chain, answering the question the reviewer identified as missing: *even if these harms/deficiencies exist, are they sufficient under the governing tests to justify refusal?* Framed for an objector — it **anticipates** the decision-maker's balance rather than pretending to strike it.

- **Step 1 — governing framework:** plan-led s.38(6) by default; checks whether the NPPF para 11(d) tilted balance is engaged (housing land supply / HDT) or **disapplied by footnote 7** — often the most strategic fact in the case. Citations defer to `national-planning-policy`.
- **Step 2 — ground-specific gateways** run before any weighing: Habitats Regulations as a hard stop (not a balance item), Green Belt very special circumstances (applicant's burden), the heritage harm-level tests, the flood Sequential Test as a gateway, the transport "severe" bar.
- **Step 3 — honest weighing:** benefits get the same evidence scrutiny as harms (unquantified economic claims and unsecured affordable housing attract reduced weight — and saying so is representation material). (B)-class evidence gaps don't weigh as demonstrated harm; they mean the balance cannot yet lawfully be struck.
- **Step 4 — four honest outcomes** driving the ask: refuse / do not determine yet / conditions (which must themselves pass the para 57/58 tests) / **the balance favours approval — don't object**. Outputs a short liftable balance statement, then hands back to a human with the standard public-document warnings.

## Wiring

- `application-triage`: Step 4's so-what test and the routing table hand off to the skill as the chain's final step.
- Root README: table row + the chain now reads retrieve → triage → represent → **balance**, with `national-planning-policy` noted as the layer under all of them.
- `national-planning-policy`: A/B/C paragraph cross-references the balance skill.
- Kept to a single SKILL.md (no references folder): the skill owns the *procedure*; instruments and paragraph numbers stay in the companion skills per the two-layers rule.

Changelogs added/updated in the three touched skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxttH6vHF5TswvbTd9zjid