### PR TITLE
planning-document-search: Recipe J (Idox Publisher docs host) + Colchester registry entry

### DIFF
--- a/planning-document-search/CHANGELOG.md
+++ b/planning-document-search/CHANGELOG.md
@@ -7,6 +7,17 @@ editor understands the intent.
 ## Unreleased
 
 ### Added
+- **Recipe J — Idox "Publisher" document host** (+ vendor entry `idox-publisher-docs` and a
+  tested-ok registry entry for Colchester). A *documents module* that pairs with a bespoke
+  register: `listDocuments?identifier=<module>&ref=<key>` establishes a session-bound
+  document context, `getDocumentList` returns JSON rows, and `/publisher/docs/…` downloads
+  are session-gated (a cold GET 404s under the `.pdf` name). At Colchester the human
+  reference is the key everywhere (wampd detail id and Publisher ref alike), so no search
+  step is needed. _Why:_ retrieval failed at Colchester because its bespoke
+  register+Publisher combination matched no recipe; validated end-to-end (magic-byte
+  verified) before recording, per the contributing rules. Documented as a docs-host
+  pattern, not a Colchester one-off, because Publisher may recur at other Idox-EDRMS
+  councils — same pattern class as PE's per-council doc modules.
 - **Checklist: flag consultee responses as their own document class, and pass on the site's
   planning history** (related applications listed on portal detail pages) when the retrieval
   feeds a triage or representation. _Why:_ the downstream skills now systematically read

--- a/planning-document-search/SKILL.md
+++ b/planning-document-search/SKILL.md
@@ -107,6 +107,7 @@ Manchester is mislabelled `Idox`), so confirm against the markup.
 | **Arcus** (Salesforce) | `*.my.site.com`/`*.force.com`/council CNAME; Lightning SPA; `Server: sfdcedge` | often mislabelled | — browser-only* | Guest Aura curl-able; blocked on unknown apex sigs | Small, growing |
 | **DEF Atrium** | `/Search/Results` POST + `__RequestVerificationToken`; `/Planning/Display?applicationNumber=`; `/Document/Download?module=PLA&…`; `/Content/def/` CSS | `Atrium` or `Custom` | **A** | None; Somerset adds a disclaimer-cookie gate | Small (incl. county registers) |
 | **Tascomi RSH** (Idox group) | `index.html?fa=<action>` dispatcher; "Regulatory Services Hub" title; `AWSCaptcha.js` | `Tascomi` | — browser-only | **Enforcing AWS WAF challenge** (202 + `x-amzn-waf-action`) | Small, growing (ex-PE) |
+| **Idox Publisher** (docs host) | `d0cs.*` host; `/Publisher/mvc/listDocuments?identifier=…&ref=…`; `/publisher/idoxui/` CSS | `Custom` | **J** | None seen (downloads session-gated) | Docs module only — pairs with bespoke registers (Colchester) |
 | **Custom / bespoke** | none of the above | `Custom` | treat A as a template | Varies | Long tail |
 
 \* Arcus public registers have no anonymous API surface — treat as browser-only and hand
@@ -121,7 +122,9 @@ TerraQuest PP2; Salesforce `*.force.com`/`my.site.com`/`Server: sfdcedge` = Arcu
 `civica.loader.js` = Civica; `/Search/Results` + `__RequestVerificationToken` +
 `/Document/Download?module=PLA` = DEF Atrium; `index.html?fa=` dispatcher + "Regulatory
 Services Hub" = Tascomi (browser-only); `/CMWebDrawer/` = HP TRIM docs host (append
-`&format=json`); `__VIEWSTATE` with none of the above = bespoke WebForms.
+`&format=json`); `/Publisher/mvc/listDocuments` + `/publisher/idoxui/` assets = Idox
+Publisher docs host (Recipe J — a documents module paired with a bespoke register);
+`__VIEWSTATE` with none of the above = bespoke WebForms.
 **When the portal is a JS/SPA shell, fetch its runtime-config file** (`/__ENV.js`,
 `config.js`, or the app bundle) — for the open-API vendors (StatMap, Agile, TerraQuest)
 that file hands you the real API host, and often a tenant id/header you'll need.
@@ -745,6 +748,55 @@ curl -s -A "$UA" "$URI" -o form.pdf   # Azure Blob SAS — no headers needed on 
   download one document at a time, never batch-collect URIs first.
 - `SearchStatus` must be the **integer** `0`/`1`/`2` (string `"All"` is rejected).
   Docs are **not all PDFs** (.docx common) — verify magic bytes per file.
+
+## Recipe J — Idox "Publisher" document host (pairs with bespoke registers)
+
+Detect: a separate documents host (e.g. `d0cs.<council>.gov.uk`) serving
+`/Publisher/mvc/listDocuments?identifier=<module>&ref=<key>`, with `/publisher/idoxui/`
+CSS and a "Document List" title. This is a **documents module, not a full portal** — the
+register itself can be something else entirely (Colchester pairs it with a bespoke
+Dynamics-based viewer at `www.colchester.gov.uk/wampd/?id=<ref>`). Same pattern class as
+Planning Explorer's per-council doc modules and Ocella's outsourced doc hosts: find the
+docs host from the detail page's documents link, or PlanIt's `docs_url` (pre-built).
+
+Colchester specifics (validated end-to-end Aug 2026): the **human reference is the key
+everywhere** — a bare 6-digit application number (e.g. `261486`) is simultaneously the
+application number, the `wampd` detail id, and the Publisher `ref`. `identifier=DC` is the
+planning module. The detail page renders its field values by script, so scrape nothing
+from it — go straight to the docs host.
+
+```bash
+UA="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36"
+BASE="https://d0cs.colchester.gov.uk"
+REF="261486"
+
+# 1. listDocuments establishes BOTH the session and the document context
+curl -s -c cj.txt -A "$UA" "$BASE/Publisher/mvc/listDocuments?identifier=DC&ref=$REF" -o list.html
+
+# 2. Same jar -> JSON rows: [Type, Date, Description, viewPath, measurePath]
+curl -s -b cj.txt -c cj.txt -A "$UA" "$BASE/publisher/mvc/getDocumentList" -o docs.json
+
+# 3. Download each viewPath with the SAME jar. Label from Type+Description+Date.
+grep -oE '"/docs/[A-F0-9]+/[^"]+"' docs.json | tr -d '"' | while read -r p; do
+  name=$(basename "$p")
+  curl -s -b cj.txt -A "$UA" "$BASE/publisher$p" -o "$name"
+  sleep 2
+done
+```
+
+Publisher gotchas:
+- **Downloads are session-gated** — a cold GET of a `/publisher/docs/…` URL returns a 404
+  JS/error page under the `.pdf` name. Keep one jar from step 1 through every download,
+  and verify magic bytes per file.
+- The page's own AJAX URL embeds `;jsessionid=…` — unnecessary when you carry the cookie
+  jar; call the plain endpoint.
+- **Completeness count**: `data` array length in the `getDocumentList` JSON is the
+  portal's own document count; a non-null `serviceError` field is an error, not an empty
+  set — distinguish the two.
+- Path case is inconsistent as served (`/Publisher/mvc/listDocuments` entry point,
+  `/publisher/…` everywhere else) — copy paths verbatim, don't normalise.
+- The fifth column is an OMT "measure document" viewer link — ignore it.
+- The page arms a session-idle timer — on long pulls, re-hit `listDocuments` to refresh.
 
 ## Arcus (Salesforce) — browser-only; hand the user a deep link
 

--- a/planning-document-search/planning-portal-registry.json
+++ b/planning-document-search/planning-portal-registry.json
@@ -25,6 +25,7 @@
       "arcus-salesforce",
       "def-atrium",
       "tascomi",
+      "idox-publisher-docs",
       "custom-aspnet",
       "custom-other",
       "unknown"
@@ -167,6 +168,20 @@
       "default_bot_protection": "No supported public API for the register data — search/detail/document listings run through the Arcus managed package's custom Salesforce controllers, not exposed to an anonymous HTTP client the way the open-API vendors are. Plain curl gets a Lightning app shell, not data. Treat as browser-only; do not attempt to reverse-engineer or replay the managed-package internals.",
       "specializations": "Footprint (all run the same managed package): Manchester, Haringey, Bromley, Wiltshire, Isle of Anglesey, Powys, Ashford, Salford. PlanIt is UNRELIABLE for Arcus: scraper_type can be mislabeled (Manchester says 'Idox') and applics carry no ref/docs_url/n_documents — but the `url` field IS the user deep link /pr/s/detail/{18-char-recordId}. Arcus refs are internal PLA-YYYY-NNNNNN, distinct from classic council refs. User-facing fallbacks: the record deep link, or the register landing …/pr/s/register-view?c__r=Arcus_BE_Public_Register (no known URL param to pre-fill a search).",
       "status": "browser-only"
+    },
+    "idox-publisher-docs": {
+      "name": "Idox Publisher (document host)",
+      "recipe": "Recipe J in SKILL.md",
+      "coverage": "Documents module only, not a full portal - pairs with a bespoke register (seen at Colchester). May recur at other Idox-EDRMS councils.",
+      "detection": [
+        "separate documents host, e.g. d0cs.<council>.gov.uk",
+        "/Publisher/mvc/listDocuments?identifier=<module>&ref=<key> entry point",
+        "/publisher/idoxui/ CSS assets; <title>Document List</title>",
+        "DataTables page whose rows load from /publisher/mvc/getDocumentList (JSON)"
+      ],
+      "default_bot_protection": "None seen; downloads are session-gated (cookie jar), not WAF-protected.",
+      "specializations": "listDocuments sets BOTH the JSESSIONID and the server-side document context; getDocumentList and every /publisher/docs/... download need the same cookie jar (a cold GET returns a 404 error page under the .pdf name). getDocumentList JSON: data rows [Type, Date, Description, viewPath, measurePath]; data length is the portal's own document count (completeness check); non-null serviceError = error, not an empty set. Path case inconsistent as served (/Publisher entry, /publisher elsewhere) - copy links verbatim.",
+      "status": "tested-ok"
     },
     "def-atrium": {
       "name": "DEF Software 'Atrium' planning register (ASP.NET MVC)",
@@ -604,6 +619,18 @@
       "reference_format_example": "SCC/4160/2026",
       "specializations": "POST-MERGER FRAGMENTATION (unitary since 2023): PlanIt still lists the legacy districts separately, and CURRENT 2026 applications are still filed on the legacy portals — Mendip publicaccess.mendip.gov.uk/online-applications/ (Idox) and South Somerset publicaccess.southsomerset.gov.uk (Idox; its docs live on ssdc.somerset.gov.uk/planningdocuments?ref_no=<enc-ref>, untested). Query PlanIt auth=Somerset to see which portal a given application lives on (applics url/docs_url point at the right host). The consolidated planning.somerset.gov.uk register is DEF ATRIUM (PlanIt scraper_type 'Atrium') and covers county matters (minerals/waste, SCC/NNNN/YYYY refs + legacy district-numbered conditions apps). Atrium chain: DISCLAIMER GATE first — POST /Disclaimer/Accept?returnUrl=<path> with an explicit 'Content-Length: 0' header (411 without it) -> AcceptedDisclaimer cookie (~1h), required for downloads (cold download 302s to disclaimer). Search: POST /Search/Results with __RequestVerificationToken pair + SearchPlanning=True + AdvancedSearch=True (+ District/DateReceivedFrom/To dd/mm/yyyy for sweeps). Detail: GET /Planning/Display?applicationNumber=<enc-ref>. Docs: /Document/Download?module=PLA&recordNumber=&planId=&imageId=&isPlan=&fileName= (identical scheme to Welwyn Hatfield — this identification is what re-classified Recipe A as the DEF Atrium product).",
       "notes": "One authority, three live portals (Atrium county register + 2 legacy Idox); PlanIt applics records are the router."
+    },
+    {
+      "authority": "Colchester City Council",
+      "aliases": ["Colchester"],
+      "region": "Essex, England",
+      "portal_url": "https://www.colchester.gov.uk/planning-search/",
+      "vendor": "custom-other",
+      "status": "tested-ok",
+      "last_tested": "2026-08-16",
+      "reference_format_example": "261486",
+      "specializations": "Bespoke register (Dynamics-based 'wampd' viewer at www.colchester.gov.uk/wampd/?id=<REF>; field values render by script - scrape nothing from it) + IDOX PUBLISHER docs host at d0cs.colchester.gov.uk (Recipe J, identifier=DC). The human reference is the key everywhere: the bare 6-digit application number is the wampd id AND the Publisher ref. PlanIt applics url/docs_url carry both links pre-built (its 'reference' field is null - the ref lives in uid). Downloads session-gated: keep one cookie jar from listDocuments through every download.",
+      "notes": ""
     }
   ]
 }


### PR DESCRIPTION
Closes #11.

## Diagnosis confirmed, retrieval now works

Colchester failed because it matches no documented vendor: a bespoke Dynamics-based register (`www.colchester.gov.uk/wampd/?id=…`) paired with an **Idox "Publisher" EDRMS documents host** (`d0cs.colchester.gov.uk`). Investigated live (16 Aug 2026) and validated end-to-end — real PDF downloads verified by magic bytes.

## What the investigation found

- **The reference→id problem dissolves**: Colchester's public reference is a bare 6-digit number (e.g. `261486`) which is simultaneously the application number, the `wampd` detail id, and the Publisher `ref`. Everything is constructible from the user's reference; PlanIt's `url`/`docs_url` carry both links pre-built (its `reference` field is null — the ref lives in `uid`).
- **The Publisher chain**: `listDocuments?identifier=DC&ref=<REF>` establishes both the JSESSIONID and a server-side document context → `getDocumentList` returns JSON rows `[Type, Date, Description, viewPath, measurePath]` → download `​/publisher` + viewPath **with the same cookie jar**. A cold GET 404s with an error page under the `.pdf` name — downloads are session-gated, no WAF.
- **Completeness check**: the JSON `data` length is the portal's own document count; non-null `serviceError` = error, not an empty set.
- The register page renders its values by script — the recipe scrapes nothing from it.

## Changes

- **Recipe J** in SKILL.md — written as a docs-host *pattern* (same class as PE's per-council doc modules), not a Colchester one-off, since Publisher may recur at other Idox-EDRMS councils. Detection signatures added to the vendor table and cheat-sheet.
- **Registry**: new `idox-publisher-docs` vendor entry + `tested-ok` Colchester authority entry with the quirks. Surgical JSON edit — 27 inserted lines, zero reformatting.
- Changelog entry with rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxttH6vHF5TswvbTd9zjid