### PR TITLE
Add policy-compliance-assessment and policy-representation skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ in its own folder with a `SKILL.md`, a `README.md`, and supporting reference fil
 | [`transport-representation/`](transport-representation/) | Evaluate the **transport / highways** evidence (Transport Assessment/Statement, Travel Plan, parking, street layout, secured mitigation), map deficiencies to policy/guidance, and draft a representation. |
 | [`heritage-representation/`](heritage-representation/) | Evaluate the **heritage / historic-environment** evidence (Heritage Statement, setting and archaeology assessments) for listed buildings, conservation areas, monuments and non-designated assets, and draft a representation. |
 | [`flood-representation/`](flood-representation/) | Evaluate the **flood-risk and drainage** evidence (Flood Risk Assessment, Drainage/SuDS strategy, Sequential/Exception Tests), map deficiencies to national policy, and draft a representation. |
+| [`policy-compliance-assessment/`](policy-compliance-assessment/) | **Policy foundation.** Identify and verify the **adopted** development plan for the local planning authority (the council's own policies, which have primacy) — adoption dates, superseded/saved policies, the policies map — then assess the application policy by policy and score accordance from **-2** (significant conflict) to **+2** (strongly aligned), with `?` where the evidence submitted cannot answer the policy. NPPF/PPG and emerging plans assessed in a separate, lower-weight tier. |
+| [`policy-representation/`](policy-representation/) | Draft the representation from that analysis — **in support or in objection**, as you choose — each point anchored to a quoted adopted policy and the application's own documents, the other side answered, and a clear ask. Won't manufacture policy compliance or conflict to fit a stance. |
 | [`national-planning-policy/`](national-planning-policy/) | **Shared layer.** The current NPPF/PPG edition register with a verify-before-citing protocol, plus the decision-making core the other skills share — s.38(6) and the development plan's primacy, the para 11 presumption ("tilted balance"), emerging-plan weight, and the conditions/obligations tests. |
 | [`planning-balance/`](planning-balance/) | **Final step.** The "so-what" test: anticipate the decision-maker's planning balance — governing framework, ground-specific gateways, harms vs benefits — and recommend what the representation should actually ask for (refusal, deferral for information, or conditions), or advise that the balance favours approval. |
 
@@ -36,12 +38,19 @@ All England-focused. The skills chain:
 
 1. **`planning-document-search`** fetches the application documents;
 2. **`application-triage`** decides which grounds are worth pursuing and routes to —
-3. a **representation** skill (`ecological-`, `transport-`, `heritage-`, `flood-representation`)
-   which evaluates the evidence and drafts the objection;
-4. **`planning-balance`** runs the final "so-what" test — whether the assembled case actually
+3. **`policy-compliance-assessment`**, which establishes the adopted development plan and scores
+   the application against its policies (the foundation every ground is anchored to), and
+4. a topic **representation** skill (`ecological-`, `transport-`, `heritage-`,
+   `flood-representation`) which evaluates the technical evidence and drafts the objection;
+5. **`policy-representation`** drafts the policy case itself — in **support** or **objection**;
+6. **`planning-balance`** runs the final "so-what" test — whether the assembled case actually
    supports refusal, a request for further information, or conditions.
 
 (`national-planning-policy` sits under all of them as the shared NPPF/PPG layer.)
+
+Steps 3–5 are where the two policy skills split the work deliberately: the assessment is
+comprehensive so you can review the findings, and the representation is short and selective so a
+case officer will act on it.
 
 Considerations without a dedicated skill yet (design, residential amenity, Green Belt,
 landscape, trees, air quality…) are covered by the triage skill's framework map, to argue on
@@ -75,15 +84,27 @@ Using the planning-document-search skill, find and download the documents for pl
 Using the application-triage skill, tell me which grounds are worth objecting on for this application — ranked, with non-material concerns (loss of view, property values) set aside. Be honest if there's no strong ground.
 ```
 
-**4 — Draft a representation for one ground**
+**4 — Assess it against the adopted local plan**
+
+```text
+Using the policy-compliance-assessment skill, identify the adopted development plan for this council and assess the application against its policies — a table of the relevant policies with a score from -2 to +2, and your conclusion on whether it accords with the plan read as a whole.
+```
+
+**5 — Draft a representation for one technical ground**
 
 ```text
 Using the ecological- / transport- / heritage- / flood-representation skill (pick the ground), evaluate the evidence and draft a concise objection — or tell me if there isn't a sustainable one.
 ```
 
-Working in stages lets you check the triage before spending effort on a draft — which is how the
-skills are meant to be used. Prefer a single command that runs all three? See the optional
-`/planning-object` command under *Install* below.
+**6 — Draft the policy representation, in support or objection**
+
+```text
+Using the policy-representation skill, draft my representation [in support of / objecting to] this application, based on the policy assessment. Tell me if the policies don't actually support that stance.
+```
+
+Working in stages lets you check the triage and the policy assessment before spending effort on a
+draft — which is how the skills are meant to be used. Prefer a single command that runs the
+objection flow? See the optional `/planning-object` command under *Install* below.
 
 ### 2. Install so they trigger automatically (Claude Code)
 
@@ -126,6 +147,10 @@ The skills share a posture set out in their own `SKILL.md`:
 Portal assignments and the representation skills' guidance catalogues (ecology, transport, heritage, flood) were web-verified in **August 2026**.
 Portals migrate and guidance editions turn over, so each skill re-resolves/re-verifies at
 run time; items flagged in the reference files are time-sensitive.
+
+The two policy skills hold **no policy catalogue at all, by design** — local plans are adopted,
+superseded and reviewed continuously, so the plan is located and every policy quoted from the
+council's own adopted document at run time.
 
 ## License
 

--- a/application-triage/CHANGELOG.md
+++ b/application-triage/CHANGELOG.md
@@ -7,6 +7,14 @@ intent.
 ## Unreleased
 
 ### Changed
+- **Step 2 now hands the policy work off to the new `policy-compliance-assessment` skill**,
+  keeping only what triage needs to route, and the routing table gains rows for that skill and
+  for `policy-representation`. _Why:_ two-layers house rule — Step 2's four-item list was a
+  framework summary standing in for a method the repo did not yet have. Now that a skill owns
+  identifying the adopted plan and scoring accordance policy by policy, triage should point at
+  it rather than imply the assessment can be done in passing. The hand-off also carries the
+  reminder that adopted policies are the local authority's own and have primacy over national
+  policy, which is the hierarchy a lay user most often inverts.
 - **Step 4's "so-what" test and the routing table now hand off to the new
   `planning-balance` companion skill** as the final step of the chain. _Why:_ the test
   needs the evidenced grounds to run properly; naming the skill makes the chain explicit.

--- a/application-triage/SKILL.md
+++ b/application-triage/SKILL.md
@@ -44,7 +44,9 @@ skills, whenever the grounds aren't already decided.
   tells you which considerations the applicant themselves thought were engaged.
 - The **development plan** for the area — the adopted local plan (and any made neighbourhood
   plan), from the council website. Determination starts here (see Step 2), so the relevant
-  policies are needed before grounds can be ranked.
+  policies are needed before grounds can be ranked; the companion
+  **policy-compliance-assessment** skill identifies and verifies the adopted plan and assesses
+  the proposal against it.
 - The **site's planning history** — previous applications and refusals, **appeal decisions on
   the same site**, enforcement history where relevant, extant permissions and their
   conditions, and any s73 variations. Portals list related applications on the detail page; a
@@ -95,6 +97,13 @@ scanning for grounds, establish:
 Grounds framed as **conflict with named development-plan policies** are the strongest kind an
 objector can raise — anchor each finding in Step 3 to a plan policy wherever one exists.
 
+Triage needs only enough of this to route. The companion **policy-compliance-assessment** skill
+does the work in full — identifying and verifying the **adopted** plan (adoption dates,
+superseded and saved policies, the policies map), assessing the proposal policy by policy, and
+scoring accordance from -2 to +2. Hand off to it for the policy foundation; don't attempt the
+full assessment here. Remember that the adopted policies are the **local authority's own** and
+carry primacy: national policy sits alongside the plan as a material consideration, not above it.
+
 The companion **national-planning-policy** skill holds the current NPPF/PPG edition
 register, the verify-before-citing protocol, and the shared decision-making citations
 (s.38(6) and plan primacy, the para 11 presumption/"tilted balance" and its footnotes,
@@ -136,6 +145,8 @@ For each ground worth pursuing, name the representation skill that handles it an
 | Heritage / listed buildings / conservation areas / archaeology | **heritage-representation** |
 | Flood risk / drainage / SuDS | **flood-representation** |
 | Other material considerations (design, amenity, Green Belt, landscape, …) | *no dedicated skill yet — see the map for the framework and argue on the documents' own facts* |
+| Compliance with the adopted development plan, policy by policy | **policy-compliance-assessment** (the policy foundation — run early; it underpins every ground) |
+| Drafting the policy case, in support **or** objection | **policy-representation** (after the policy assessment) |
 | Final check — does the assembled case justify the ask? | **planning-balance** (run last, after the representation skills) |
 
 Recommend an order (lead with the decision-critical grounds). Note where two skills should

--- a/commands/README.md
+++ b/commands/README.md
@@ -7,8 +7,10 @@ invoke it by name:
 
 - `/planning-document-search`
 - `/application-triage`
+- `/policy-compliance-assessment` · `/policy-representation`
 - `/ecological-representation` · `/transport-representation` · `/heritage-representation` ·
   `/flood-representation`
+- `/national-planning-policy` · `/planning-balance`
 
 So you do **not** need a wrapper command for a single skill — the skill *is* the command.
 (Custom commands and skills are the same system now: a `.claude/commands/x.md` and a
@@ -17,11 +19,16 @@ So you do **not** need a wrapper command for a single skill — the skill *is* t
 ## The one wrapper worth having
 
 `planning-object.md` is an optional **orchestration** command — one shortcut that runs the whole
-flow across several skills (retrieve → triage → draft), which no single skill does on its own:
+flow across several skills (retrieve → triage → assess policy → draft), which no single skill
+does on its own:
 
 | Command | What it does |
 |---|---|
-| `/planning-object [ref] [council]` | Fetch the documents, triage the grounds, and draft objections for every live ground |
+| `/planning-object [ref] [council]` | Fetch the documents, triage the grounds, assess the application against the adopted development plan, and draft objections for every live ground |
+
+The command is **objection-only**, as its name says. To write in **support**, or to run the policy
+analysis on its own, invoke the skills directly — `/policy-compliance-assessment` then
+`/policy-representation` — and say which stance you want.
 
 ### Install
 

--- a/commands/planning-object.md
+++ b/commands/planning-object.md
@@ -2,9 +2,10 @@
 description: Retrieve, triage and draft objections for a UK planning application
 argument-hint: [application reference] [council]
 ---
-Use the UK planning skills — `planning-document-search`, `application-triage`, and the
-`ecological-`, `transport-`, `heritage-` and `flood-representation` skills — to help me
-respond to a UK planning application.
+Use the UK planning skills — `planning-document-search`, `application-triage`,
+`policy-compliance-assessment`, the `ecological-`, `transport-`, `heritage-` and
+`flood-representation` skills, and `policy-representation` — to help me respond to a UK planning
+application.
 
 Application: $ARGUMENTS
 
@@ -16,8 +17,14 @@ Work through it end to end:
    genuinely engaged, rank them (decision-critical / supporting / weak), and set aside
    non-material concerns (loss of view, property values, competition). **Be honest if there is
    no strong ground.**
-3. For each live, worthwhile ground, run the matching **representation** skill to evaluate the
-   evidence and draft a concise, well-founded objection.
+3. **Assess the policies** (`policy-compliance-assessment`): identify and verify the **adopted**
+   development plan for the council — its own policies, which have primacy — and assess the
+   application against each relevant policy, scoring accordance from -2 to +2. Treat NPPF and any
+   emerging plan as lower-weight material considerations. Don't total or average the scores.
+4. For each live, worthwhile ground, run the matching topic **representation** skill to evaluate
+   the evidence and draft a concise, well-founded objection.
+5. **Draft the policy case** (`policy-representation`) as an objection, anchored to the quoted
+   adopted policies — and tell me if the policy analysis doesn't in fact support objecting.
 
 Follow the skills' rules: material considerations only; evidence-bound (quote the documents);
 "don't object" is a valid answer; this is **not legal advice**; and the draft needs my review

--- a/national-planning-policy/CHANGELOG.md
+++ b/national-planning-policy/CHANGELOG.md
@@ -7,6 +7,15 @@ intent.
 ## Unreleased
 
 ### Changed
+- **The "two layers" section now names `policy-compliance-assessment` as the owner of the
+  *local* tier**, and states the hierarchy explicitly: adopted local policies are the council's
+  own and have primacy, the Framework is a material consideration alongside the plan rather than
+  above it. _Why:_ with a skill now dedicated to local-plan assessment, this skill needed to say
+  where its own boundary lies — and to guard against the failure mode the split invites, where a
+  reader takes the most detailed catalogue in the repo (this one) for the most important tier.
+- **"When to use" now lists the two new policy skills as callers.** _Why:_ they are the heaviest
+  consumers of the edition register — one for the national and emerging tiers of its policy
+  table, the other for verifying every citation before a draft is sent.
 - **A/B/C paragraph now also points to the `planning-balance` companion skill.** _Why:_
   the balance skill is where the assembled case is weighed; the cross-reference completes
   the chain.

--- a/national-planning-policy/CHANGELOG.md
+++ b/national-planning-policy/CHANGELOG.md
@@ -7,6 +7,16 @@ intent.
 ## Unreleased
 
 ### Changed
+- **Edition register updated: the NPPF was republished on 17 August 2026**, replacing the
+  December 2024 edition with the anticipated coded-policies restructuring. The register now
+  records the new edition as in force, marks the decision-making core (still keyed to the
+  December 2024 text) as pending re-mapping, and adds the rule that past decisions are read
+  against the edition in force at their determination date. _Why:_ verified first-hand on
+  the gov.uk publication page (18 Aug 2026), after three independent assessment runs each
+  discovered the new edition at run time. Re-mapping the core and every topic catalogue to
+  the new policy codes is a repo-wide job tracked in its own issue; until it is done the
+  register must say loudly that every stored paragraph number is stale — a wrong-but-precise
+  register is exactly the defect the verify-before-citing protocol exists to prevent.
 - **The "two layers" section now names `policy-compliance-assessment` as the owner of the
   *local* tier**, and states the hierarchy explicitly: adopted local policies are the council's
   own and have primacy, the Framework is a material consideration alongside the plan rather than

--- a/national-planning-policy/SKILL.md
+++ b/national-planning-policy/SKILL.md
@@ -64,21 +64,25 @@ Before a draft leaves any companion skill:
 4. **PPG**: cite by the paragraph ID (e.g. "Paragraph: 001 Reference ID: 21a-001-…") *and*
    the page's "last updated" date — PPG pages revise independently and silently.
 
-## ⏳ Edition register (verified 16 August 2026 — re-verify at run time)
+## ⏳ Edition register (verified 18 August 2026 — re-verify at run time)
 
-- **NPPF in force: December 2024 edition** (published 12 Dec 2024, amended 7 Feb 2025).
-  Live text: gov.uk/guidance/national-planning-policy-framework. PDF:
-  assets.publishing.service.gov.uk/media/67aafe8f3b41f783cca46251/NPPF_December_2024.pdf
-- **⚠ Pending revision — expect a complete renumbering.** A draft revised NPPF was
-  published for consultation on 16 December 2025 (consultation closed 10 March 2026); the
-  final version is expected **Summer 2026** — i.e. imminently at the verification date
-  above. The draft restructures the Framework into ~133 coded policies in themed chapters,
-  so **paragraph-number citations will not survive it**. When it lands: switch to the new
-  policy codes, re-verify everything, and update every catalogue in this repo.
+- **NPPF in force: 17 August 2026 edition** (published 17 Aug 2026, replacing the December
+  2024 edition — confirmed on the gov.uk publication page's edition history). This is the
+  anticipated restructuring: the Framework is now organised as **coded policies in themed
+  chapters** rather than sequentially numbered paragraphs, so **every pre-August-2026
+  paragraph-number citation is stale**. Live text:
+  gov.uk/guidance/national-planning-policy-framework.
+- **⚠ Repo-wide re-verification in progress.** The decision-making core below and the topic
+  catalogues in the representation skills were verified against the **December 2024** text
+  and have not yet been re-mapped to the new policy codes — until that is done, treat every
+  NPPF reference in this repo as a pointer to the *concept*, and verify the current code and
+  wording against the live text before citing (protocol above). Applications **determined
+  before 17 August 2026** were decided under the earlier edition; when reviewing a past
+  decision, cite the edition in force at determination.
 - **PPG**: web-based guidance suite, revised page-by-page — no single edition; rely on
   per-page "last updated" dates.
 
-## The decision-making core (verified against the live December 2024 text)
+## The decision-making core (⏳ verified against the December 2024 text — re-map to the August 2026 policy codes before citing)
 
 **The statutory starting point.** Section 38(6) of the Planning and Compulsory Purchase
 Act 2004: applications must be determined **in accordance with the development plan unless

--- a/national-planning-policy/SKILL.md
+++ b/national-planning-policy/SKILL.md
@@ -22,16 +22,23 @@ presumption, and the tests for conditions and obligations.
 ## When to use
 
 - **From the companion skills** — `application-triage` (Step 2, establishing the decision
-  framework) and the representation skills (when mapping deficiencies to national policy):
-  check the edition register here before citing the NPPF/PPG, and take the shared
-  decision-making citations from here rather than restating them per topic.
+  framework), `policy-compliance-assessment` (the national and emerging tiers of its policy
+  table, and the plan-status and presumption tests), `policy-representation` (verifying every
+  citation before a draft is sent) and the topic representation skills (when mapping
+  deficiencies to national policy): check the edition register here before citing the NPPF/PPG,
+  and take the shared decision-making citations from here rather than restating them per topic.
 - **Directly** — the user asks "what does the NPPF say about …", "is this paragraph number
   still right", "does the tilted balance apply here".
 
 ## Two layers, no duplication
 
-This skill owns the **shared core and the edition register**. The topic skills' own
-`references/national-guidance.md` files own their **topic chapters and instruments**
+This skill owns the **shared core and the edition register** — the *national* tier. The
+**local** tier belongs to **policy-compliance-assessment**: identifying and verifying the
+adopted development plan for the authority, and assessing and scoring a proposal against its
+policies. Keep the hierarchy the right way up when citing from here — adopted local policies
+are the council's own and have primacy; the Framework is a material consideration alongside
+the plan, not above it. The topic skills' own `references/national-guidance.md` files own
+their **topic chapters and instruments**
 (ecology's Chapter 15 map, CIEEM and BCT editions; transport's Chapter 9, LTN 1/20 and
 Manual for Streets; heritage's Chapter 16 and the 1990 Act duties; flood's paragraphs
 170–182 and the climate-change allowances). Don't copy either layer into the other.

--- a/planning-balance/CHANGELOG.md
+++ b/planning-balance/CHANGELOG.md
@@ -4,6 +4,19 @@ Design decisions per revision, newest first. See `../CLAUDE.md` for the format a
 house rules. The **_Why_** lines record the rationale so a future editor understands the
 intent.
 
+## Unreleased
+
+### Changed
+- **"What you need first" now accepts the `policy-compliance-assessment` output** — the plan
+  register, the scored policy table, the weight tiers and the accordance statement — with two
+  cautions carried into the balance: the -2 to +2 scores are never totalled or averaged, and
+  every `?` (policy requirement that cannot be assessed) is a **(B)**. _Why:_ the new skill
+  produces the plan-conflict input this skill previously had to reconstruct from triage. The two
+  cautions travel with the data deliberately: a numeric table is exactly the kind of input that
+  invites a shortcut, and "accordance with the development plan read as a whole" is the judgement
+  this skill exists to make — an average would pre-empt it, and treating a `?` as harm would
+  weigh an evidence gap as if it were demonstrated impact.
+
 ## 0.1.0 — 2026-08-16 — Initial release
 
 ### Added

--- a/planning-balance/SKILL.md
+++ b/planning-balance/SKILL.md
@@ -40,7 +40,15 @@ filed as noise.
 
 - The **evidenced grounds**, each classified **(A)** demonstrated unacceptable impact /
   **(B)** insufficient evidence / **(C)** conditionable (the representation skills produce
-  this), and the **development-plan policies** each ground conflicts with (triage Step 2).
+  this), and the **development-plan policies** each ground conflicts with.
+- The **policy compliance assessment** from the companion **policy-compliance-assessment**
+  skill, where it has run — the plan register, the policy-by-policy accordance scores (-2 to
+  +2, with `?` where a policy requirement cannot be assessed), the weight tiers, and its
+  accordance statement. Two cautions carry through to the balance: the scores are **never
+  totalled or averaged** — accordance with the plan **read as a whole** is the judgement made
+  here, and one significant conflict with the plan's strategy can outweigh many compliances on
+  matters of detail; and every `?` is a **(B)**, so it bears on whether the balance can lawfully
+  be struck at all rather than weighing as harm.
 - The **scheme's claimed benefits** — from the Planning Statement and application forms:
   housing numbers (market and affordable), economic claims, regeneration, BNG, public
   realm. The balance has two pans; a representation that never engages with the benefits

--- a/policy-compliance-assessment/CHANGELOG.md
+++ b/policy-compliance-assessment/CHANGELOG.md
@@ -1,0 +1,78 @@
+# Changelog — policy-compliance-assessment
+
+Design decisions per revision, newest first. See `../CLAUDE.md` for the format and the house
+rules. The **_Why_** lines record the rationale so a future editor understands the intent.
+
+## 0.1.0 — 2026-08-17 — Initial release
+
+### Added
+- **The skill itself: a policy-compliance stage between triage and drafting** — identify and
+  verify the adopted development plan, select the relevant policies, assess each against the
+  application, score accordance, and conclude on the plan read as a whole. _Why:_ the repo
+  could evaluate a *topic's technical evidence* (the four representation skills) and could
+  anticipate the *final balance* (`planning-balance`), but nothing owned the step in between —
+  the systematic policy-by-policy assessment that s.38(6) makes the starting point of every
+  determination. Triage gestured at it in a four-item step; that is enough to route, not enough
+  to do the work.
+- **Identifying the adopted development plan as an explicit, gated first step**, with its own
+  reference file, a plan register output, and a table of what is *not* the development plan
+  (SPDs, design guides, draft plans, council strategies, unmade neighbourhood plans). _Why:_
+  "adopted" is a formal term and the most common lay error in this area is assessing against
+  the wrong document — a consultation draft, a superseded policy, or an SPD treated as policy.
+  An assessment built on the wrong plan is not weak, it is void, and a case officer spots it
+  immediately. Gating the workflow on this makes the failure mode hard to reach.
+- **The superseded/saved-policies and draft-numbering traps called out explicitly.** _Why:_ a
+  new plan usually replaces only *some* of its predecessor's policies, and policy numbers
+  routinely change between the publication draft and adoption. Both produce citations that look
+  authoritative and are wrong, which is worse than citing nothing.
+- **A -2 to +2 accordance score with anchored bands and calibration tests** ("if this were the
+  only policy in the plan, would the proposal fail on it?" for -1 versus -2). _Why:_ the score
+  makes a long analysis scannable and lets the drafting skill lead on what carries weight. The
+  anchors and calibration tests exist because an unanchored scale drifts into expressing
+  strength of feeling rather than accordance.
+- **A separate `?` "cannot be assessed" flag, explicitly not a negative score**, mapped to the
+  repo's **(B)** classification. _Why:_ the repo's central discipline is that an evidence gap
+  is not demonstrated harm. Folding "the applicant didn't submit the survey" into a -1 or -2
+  would smuggle a (B) into an (A) — the classic credibility mistake the representation skills
+  are built to avoid — and it also supports the wrong ask ("refuse" instead of "do not
+  determine yet").
+- **A weight-tier column kept separate from the score**, with a "reduced weight" tier for
+  out-of-date adopted policies and separate tiers for national policy, emerging plans and
+  guidance. _Why:_ how a proposal stands against a policy and how much that matters are
+  different questions. Merging them into a single number hides exactly the reasoning a decision
+  turns on — and an out-of-date policy still generates real conflict, just at less weight, so
+  silently discounting it would be as wrong as ignoring its status.
+- **A "most important policies for determining the application" flag.** _Why:_ that phrase is
+  what the national presumption turns on, so the analysis should surface the set explicitly
+  rather than leaving a reader to infer it.
+- **An explicit no-aggregation rule, with a worked demonstration.** _Why:_ a -2 to +2 scale
+  invites a total or a mean, and the arithmetic actively misleads: eight `+1`s on detailed
+  standards and one `-2` on the settlement-boundary policy averages positive while the proposal
+  is very likely contrary to the plan as a whole. Recording the temptation and the counter-example
+  in the rubric is the only way to stop a future editor "improving" the skill by adding a total.
+- **National policy and emerging plans assessed in a second, explicitly lower-weight table.**
+  _Why:_ the user requirement is that these are considered but subordinate to the adopted plan;
+  putting them in a physically separate table makes the hierarchy visible on the page instead of
+  relying on a column a reader may skim past.
+- **`references/policy-families.md`, keyed by proposal type, using descriptive family names and
+  never example policy numbers.** _Why:_ plans differ in numbering and structure, so the
+  transferable knowledge is *which families of policy to expect and when they bite*. Printing
+  plausible-looking policy references would invite exactly the from-memory citation the skill
+  exists to prevent.
+- **Explicit "the plan is silent" and "don't stretch a policy" guidance.** _Why:_ a missing
+  policy family is a real finding (and may show the plan is out-of-date on the topic), whereas
+  pressing an unrelated policy into service is easy to rebut and costs credibility on the
+  policies that do fit.
+
+### Changed
+- **No citations of its own: the statutory and NPPF layer defers wholly to
+  `national-planning-policy`.** _Why:_ two-layers house rule — this skill owns the *procedure*,
+  that skill owns the *instruments* and the current paragraph numbers. It also keeps the skill
+  intact through the pending NPPF revision, which will renumber everything.
+- **s.38 cited without sub-paragraph precision, with a ⏳ run-time verification flag**, and the
+  pending national-development-management-policies and supplementary-plans reforms flagged as
+  *not assumed to be in force*. _Why:_ house rule 3 — primary sources were unreachable from the
+  build environment (legislation.gov.uk and gov.uk were egress-blocked), so the composition of
+  the development plan is stated functionally and flagged for verification rather than pinned to
+  subsection letters from memory. A note also warns that older reproductions of s.38 circulating
+  online still carry the spent regional-strategy reference.

--- a/policy-compliance-assessment/CHANGELOG.md
+++ b/policy-compliance-assessment/CHANGELOG.md
@@ -3,6 +3,45 @@
 Design decisions per revision, newest first. See `../CLAUDE.md` for the format and the house
 rules. The **_Why_** lines record the rationale so a future editor understands the intent.
 
+## 0.1.2 — 2026-08-18 — Evidence disciplines from officer-practice benchmarking
+
+### Added
+- **Seven "evidence disciplines" in Step 4**, matching observed officer practice: a
+  window-by-window openings audit; a planning-history sweep with delta-assessment against
+  any extant fallback permission; amenity geometry measured relative to the neighbour, not
+  just the plot; multi-source verification of basic site facts including the council's own
+  GIS layers; a representations sweep; treating consultee positions as evidence to
+  re-derive rather than conclusions to adopt; and a condition-versus-refusal discipline for
+  separable detail and missing documents on minor schemes. _Why:_ five blind runs of this
+  skill against decided applications (major and householder) matched the real outcome every
+  time, and the residual divergences from the officers' delegated/committee reports were
+  concentrated in exactly these habits — a missed new opening that the officer conditioned;
+  an unswept history that held the controlling fallback or refusal precedent; a
+  procedural gap escalated to a refusal reason the officer handled as a condition.
+  Codifying them keeps the next assessment's misses from repeating the benchmarked ones,
+  while the existing integrity rules (missing evidence is (B), unsecured mitigation is (C))
+  already carry the classification these disciplines feed.
+
+## 0.1.1 — 2026-08-18 — Designated-area scoring uplift
+
+### Changed
+- **Conservation areas (and other designated heritage assets) now carry an explicit scoring
+  uplift.** Step 4 gains a "designated areas raise the bar" discipline, the rubric's -2
+  signals and the -1/-2 calibration test gain a designated-area limb, and "under-scoring a
+  designated-area conflict" joins the common-errors list. The rule: measure the **cumulative
+  volume of physical change** quantitatively from the drawings, and score a character/scale
+  criterion failure in a designated area at full strength rather than discounting it to a
+  tension because only one limb fails or each alteration looks modest. Citations (s.66/s.72,
+  NPPF heritage tests) stay with `heritage-representation` per the no-duplication rule.
+  _Why:_ benchmarking a blind run of this skill against a real decided application showed the
+  assessment converging with the officer on the operative policies and outcome but scoring the
+  design/overdevelopment conflict on a conservation-area building -1 where the officer ran it
+  as a standalone full-strength refusal reason grounded in plot metrics taken off the
+  drawings. The user's diagnosis — conservation-area status was underweighted — matches how
+  decision-makers actually behave: the statutory duty makes cumulative change in a designated
+  area refusal material on its own, and the skill's calibration should reflect observed
+  officer practice, not treat the designation as one criterion among many.
+
 ## 0.1.0 — 2026-08-17 — Initial release
 
 ### Added

--- a/policy-compliance-assessment/LICENSE
+++ b/policy-compliance-assessment/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ian Howard
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/policy-compliance-assessment/README.md
+++ b/policy-compliance-assessment/README.md
@@ -1,0 +1,43 @@
+# policy-compliance-assessment
+
+Assess a UK planning application against the policies that actually govern it — starting, as
+the statutory framework does, with the **formally adopted development plan**.
+
+The skill works in three moves:
+
+1. **Identify and verify the adopted development plan** for the relevant local planning
+   authority — the adopted local plan (often several documents), any **made** neighbourhood
+   plan, the minerals and waste plans, and in London the spatial development strategy — with
+   the adoption dates, the schedule of superseded and saved policies, and the site's position
+   on the policies map. "Adopted" is a formal term: a draft, submitted or examined plan is not
+   adopted, and neither is a supplementary planning document.
+2. **Assess** the proposal against each relevant policy, quoting the requirement and pointing
+   at the evidence in the application documents.
+3. **Score and conclude** — a policy-by-policy table scored from **-2** (significant conflict)
+   to **+2** (strongly aligned), with `?` where the application lacks the evidence the policy
+   requires, plus a reasoned conclusion on accordance with the development plan **read as a
+   whole**.
+
+Adopted policies are the **local authority's own** — written, examined, adopted and published by
+the council, on its own website, under its own numbering — and they carry **primacy** in the
+decision. National policy (NPPF/PPG) and any **emerging** plan are assessed in a separate,
+explicitly lower-weight tier: material considerations that inform the decision without
+displacing the plan.
+
+Two rules do most of the work:
+
+- **The scores are never totalled or averaged.** Accordance with the plan read as a whole is a
+  planning judgement; one significant conflict with the spatial strategy can outweigh eight
+  compliances on matters of detail, and an average would invert the answer.
+- **Missing evidence is not conflict.** Where the application does not contain what a policy
+  requires, the honest output is "cannot be assessed" — which supports a different ask.
+
+Feeds **`policy-representation`** (which drafts the representation, in support or objection)
+and **`planning-balance`** (which weighs the case). Takes its NPPF/PPG citations from
+**`national-planning-policy`** and leaves topic-specific technical evaluation to the
+`heritage-`, `transport-`, `flood-` and `ecological-representation` skills.
+
+> **Not legal advice. No warranty. England only.** Policy interpretation is ultimately for the
+> decision-maker. Plans are adopted and superseded continuously, so the plan must be
+> re-resolved and every policy re-quoted at run time. Output requires human review; see the
+> repo README for the full disclaimer.

--- a/policy-compliance-assessment/SKILL.md
+++ b/policy-compliance-assessment/SKILL.md
@@ -1,0 +1,249 @@
+---
+name: policy-compliance-assessment
+description: >-
+  Assess a UK planning application against the policies that govern it, starting
+  with the formally **adopted** development plan published by the local planning
+  authority — which has primacy. Identify and verify that plan first (adoption
+  dates, superseded policies, the policies map), then score the proposal policy
+  by policy from -2 (significant conflict) to +2 (strongly aligned), assess
+  NPPF/PPG and any emerging plan separately at lower weight, and conclude on
+  accordance with the plan read as a whole. Use for "does this comply with the
+  local plan", "which policies does this application breach", "assess this
+  against adopted policy", "policy analysis". England-focused. Not legal advice;
+  no warranty; output requires human review.
+license: MIT
+---
+
+# Policy compliance assessment
+
+Work out **which planning policies govern an application, and whether it accords with each
+one**. The skill does three things:
+
+1. **Identify the adopted development plan** for the relevant local planning authority, and
+   verify it — the essential first step, because determination starts there and nothing
+   downstream is safe if this is wrong.
+2. **Assess** the proposal against each relevant policy, on the evidence in the application
+   documents and the policy's own words.
+3. **Score and report** — a policy-by-policy table with an accordance score from **-2 to
+   +2**, then a reasoned conclusion on accordance with the development plan **read as a
+   whole**.
+
+National policy (NPPF/PPG) and any **emerging** plan are assessed too, but as material
+considerations carrying **less weight than the adopted plan** — never as a substitute for it.
+
+## When to use
+
+The user asks: "does this comply with the local plan?", "which policies does this application
+breach?", "assess this against the adopted policies", "what does the local plan say about
+this site?", "is this development plan compliant?" — or a representation needs a policy
+foundation before it is drafted.
+
+Use it **after** `application-triage` has identified which considerations are engaged (or
+alongside it — triage's decision-framework step hands off to this skill), and **before**
+`policy-representation` drafts anything.
+
+Not this skill: the deep technical evaluation of a topic's evidence base (the
+`ecological-`, `transport-`, `heritage-` and `flood-representation` skills own that), the
+current NPPF edition and paragraph numbers (`national-planning-policy` owns those), or the
+final harms-vs-benefits weighing (`planning-balance`).
+
+## Two layers, no duplication
+
+This skill owns the **procedure**: how to find and verify an adopted development plan, how
+to read a policy, and how to score accordance. It owns **no citations of its own**. The
+current NPPF/PPG edition register, the verify-before-citing protocol, s.38(6) and plan
+primacy, the paragraph-11 presumption, emerging-plan weight and the conditions/obligations
+tests all live in the companion **national-planning-policy** skill — take them from there.
+The policies themselves are **per-instance data**: they come from the council's adopted plan
+at run time, and are quoted, never remembered.
+
+## The integrity principle (read first)
+
+- **The adopted plan is the local authority's own document, and it has primacy.** Adopted
+  policies are made and published by the **local planning authority** — on its own website,
+  under its own numbering, adopted on its own date. They are not published by central
+  government, and they are not the NPPF. This matters twice over: it tells you **where to
+  look** (the council's planning-policy pages, never a national source), and it fixes the
+  **hierarchy** — the development plan is the statutory starting point, and national policy is
+  a material consideration that informs the decision without displacing the plan. An
+  assessment that leads on the NPPF and treats the local plan as background has the
+  hierarchy upside down.
+- **"Adopted" is a formal term — establish it, don't assume it.** A plan is adopted when the
+  council has formally resolved to adopt it following independent examination. A published,
+  submitted, consulted-on or examined-but-not-yet-adopted plan is **not** adopted, and neither
+  is a supplementary planning document. Getting this wrong is the single most damaging error
+  available here: an assessment against draft policy numbers, or against policies that a
+  later plan superseded, is worthless and visibly so.
+- **Quote the policy; never recall it.** Policy wording and numbering vary between councils
+  and between editions of the same plan, and draft numbering rarely survives adoption. Every
+  policy in the output must be quoted from the adopted document, with the document name,
+  adoption date and policy reference recorded.
+- **A score is a reasoned judgement, not a measurement.** It is a shorthand for an argument
+  that must be stated alongside it. A score with no quoted requirement and no evidence from
+  the application is not an assessment.
+- **Never total or average the scores.** Section 38(6) requires accordance with the
+  development plan **read as a whole**, which is a planning judgement, not arithmetic. One
+  -2 against a policy central to the proposal can outweigh five +1s on peripheral ones; the
+  reverse is also true. Presenting a sum or a mean would manufacture false objectivity —
+  and would let a genuinely fatal conflict be averaged away.
+- **Missing evidence is not conflict.** Where a policy requires something the application
+  has not supplied, the honest output is "cannot be assessed" (flagged `?`), not a negative
+  score. That distinction is what separates "the proposal conflicts with Policy X" from "the
+  Council cannot yet conclude whether it complies with Policy X" — a different ask entirely.
+- **Score the proposal against the policy, not against a preference.** Record accordance
+  where it exists, at full strength. An analysis that finds only conflict will be read as
+  advocacy and discounted.
+
+## Workflow
+
+### Step 1 — Identify and verify the adopted development plan (do this first)
+
+Work through
+[`references/finding-the-development-plan.md`](references/finding-the-development-plan.md).
+In outline:
+
+1. **Confirm the local planning authority.** Usually the district, borough or unitary
+   council — but a **National Park authority** or the Broads Authority is the LPA for its
+   own area, and a development corporation may be. In two-tier areas, **minerals and waste**
+   policy sits with the county council. The wrong LPA means the wrong plan.
+2. **Assemble the development plan.** Under s.38 of the Planning and Compulsory Purchase Act
+   2004 it comprises the **adopted development plan documents taken as a whole** plus any
+   **made** neighbourhood plan for the area; in Greater London it also includes the Mayor's
+   spatial development strategy (the London Plan). It is often **several documents** — a core
+   strategy plus a site-allocations and/or development-management document, sometimes a joint
+   plan, plus the county minerals and waste plans. ⏳ *Verify the composition against the
+   current statute at run time — see the reference file's note on pending reforms.*
+3. **Record the adoption date and status of each document**, and find the **schedule of
+   superseded and saved policies** — a new plan usually replaces only *some* of its
+   predecessor's policies. Never cite a policy without checking it has not been superseded.
+4. **Read the policies map** for the site: settlement boundary, allocations, designations
+   and constraints. The map is part of the plan and often decides which policies apply.
+5. **Note what is *not* the development plan** but may still be a material consideration:
+   supplementary planning documents, design guides and codes, conservation area appraisals,
+   council strategies, and emerging or withdrawn plans. Keep these in a separate tier.
+
+Output a short **plan register** — document, adoption date, status, where obtained — before
+assessing anything.
+
+### Step 2 — Fix the plan's status
+Record the plan's **age and review position**: its adoption date, the plan period, whether a
+review or replacement is underway, and whether the council can demonstrate the required
+housing land supply. This governs how much weight a conflict carries, and whether the
+**tilted balance** is engaged or disapplied — take that test from the
+**national-planning-policy** skill rather than restating it here. A conflict with a policy
+that is out-of-date still counts, but at reduced weight; say so rather than silently
+discounting it.
+
+### Step 3 — Select the relevant policies
+Use [`references/policy-families.md`](references/policy-families.md) to work from the proposal
+and site to the policy families that ought to exist in any local plan, then find each one in
+*this* plan. Two disciplines:
+
+- **Relevance, not volume.** Include a policy because it applies to this development, on this
+  site, at this scale — not to lengthen the list. Check each policy's own scope: many apply
+  only to a development type, size threshold or designated area.
+- **Flag the "most important" policies** for determining this application — the handful the
+  decision turns on (typically the spatial strategy or settlement-boundary policy, the
+  site-specific allocation or designation, and the principal topic policies). This phrase
+  matters: it is what the presumption in national policy turns on.
+
+### Step 4 — Assess each policy
+For each policy: quote the **requirement** in its own words, then state what the
+**application documents show**, then conclude. Reading discipline:
+
+- **Distinguish mandatory from permissive wording.** "Will not be permitted", "must" and
+  "will be required" are requirements; "should", "will be encouraged", "where possible" and
+  "have regard to" are weaker. The strength of the wording sets the ceiling on the score.
+- **Criterion-based policies are assessed criterion by criterion.** Where a policy permits
+  development only if a list of criteria is met, failing one is conflict with the policy even
+  if the rest are met — identify *which* criterion and why.
+- **Read the whole policy**, including any exception or flexibility limb the proposal might
+  rely on. Supporting text and the reasoned justification are not policy, but are legitimate
+  aids to interpreting it — label them as such.
+- **Mitigation that is not yet secured is not compliance.** If a policy's requirement is met
+  only by something a condition or obligation would have to secure, say so — that is a (C)
+  point, and it belongs in the score's reasoning.
+
+### Step 5 — Score
+Apply the rubric in [`references/scoring-rubric.md`](references/scoring-rubric.md):
+
+| Score | Meaning |
+|---|---|
+| **+2** | **Strongly aligned** — the proposal actively delivers what the policy seeks; every criterion met. |
+| **+1** | **Accords** — meets the policy's requirements; no material tension. |
+| **0** | **Neutral** — engaged but the proposal neither advances nor offends it. |
+| **-1** | **Tension / partial conflict** — fails part of a criterion-based policy, or is contrary to its aim in a limited or mitigable way. |
+| **-2** | **Significant conflict** — breaches a mandatory requirement, or a criterion central to the policy's purpose; conflict goes to the heart of the policy. |
+| **?** | **Cannot be assessed** — the policy is engaged but the application lacks the evidence the policy itself requires. **Not a negative score.** |
+
+Alongside each score record the **weight tier** (adopted development plan / reduced —
+out-of-date plan policy / national policy / emerging plan / guidance) and, where the
+downstream skills need it, the **A/B/C** classification the repo uses: **(A)** demonstrated
+unacceptable impact, **(B)** insufficient evidence, **(C)** resolvable by condition or
+obligation. Every `?` is a (B).
+
+### Step 6 — Add national and emerging policy, at their proper weight
+Assess the relevant **NPPF/PPG** policies and any **emerging plan** policies the same way,
+in a **separate section** of the table, explicitly marked as material considerations that
+carry **less weight than the adopted plan**:
+
+- **National policy** — a material consideration, influential but not above the plan. Verify
+  every edition and paragraph reference through the **national-planning-policy** skill before
+  citing; ⏳ the framework is under revision and paragraph numbers will not survive it.
+- **Emerging plans** — weight depends on the stage of preparation, the extent of unresolved
+  objections, and consistency with national policy. Record the stage and reason the weight;
+  an emerging policy at early consultation carries very little, and saying so is part of the
+  assessment.
+- **Guidance** (SPDs, design codes, technical standards) — weight as guidance that
+  supplements plan policy; it cannot create policy the plan does not contain.
+
+### Step 7 — Conclude on the plan read as a whole
+Write a short **accordance statement** (a paragraph or two): the plan documents that govern,
+the policies the proposal conflicts with and how seriously, the policies it accords with, the
+matters that cannot yet be assessed, and a reasoned conclusion on whether the proposal
+accords with the development plan **read as a whole** — with no arithmetic. Then say what
+follows: whether material considerations (national policy, emerging policy, the scheme's
+benefits) might indicate a decision otherwise than in accordance with the plan, and hand off
+to **planning-balance** for that weighing and to **policy-representation** for drafting.
+
+## Output format
+
+1. **Plan register** — the development plan documents, adoption dates, status, source.
+2. **Site's plan status** — designations from the policies map; allocation or settlement
+   position; plan age and review position.
+3. **Policy table** — one row per policy: reference · source document · weight tier · quoted
+   requirement · assessment (with the document evidence) · **score** · most-important flag ·
+   A/B/C.
+4. **A second table** for national and emerging policy, marked as lower-weight material
+   considerations.
+5. **Accordance statement** — the reasoned whole-plan conclusion, no totals.
+6. **Verification note** — what was checked, when, and what needs re-checking at run time.
+
+## Reference files
+
+- [`references/finding-the-development-plan.md`](references/finding-the-development-plan.md)
+  — how to identify and verify the adopted plan: what counts, where to look, the traps
+  (superseded policies, draft numbering, SPDs, the wrong LPA), and emerging-plan stages.
+- [`references/scoring-rubric.md`](references/scoring-rubric.md) — the -2 to +2 anchors with
+  worked illustrations, the evidence-gap flag, the weight tiers, and the no-aggregation rule.
+- [`references/policy-families.md`](references/policy-families.md) — the policy families to
+  look for by proposal type, and which skill owns each one's technical evaluation.
+
+## Scope and limitations
+
+- **Not legal advice, and no warranty.** Policy interpretation is ultimately for the
+  decision-maker, and contested wording is a matter for a planning professional or a
+  solicitor; provided "as is", with no guaranteed outcome.
+- **Human review is necessary before use.** A person must check every quoted policy against
+  the adopted document and every assessment against the application documents.
+- **England-focused.** The development-plan framework cited is England's; Wales, Scotland and
+  Northern Ireland differ — flag and adjust outside England.
+- **Evidence-bound.** Quote policies and application documents; never invent a policy
+  reference, a plan date or a requirement. Where the plan is unclear, say it is unclear.
+- **Time-sensitive.** Plans are adopted, superseded and reviewed continuously, and the
+  national framework is under revision — re-resolve the plan and re-verify every citation at
+  run time.
+- **A UK planning representation is public and in the submitter's name** — this skill produces
+  an analysis rather than a submission, but carry that warning through to
+  **policy-representation** or whichever skill drafts from it.
+- **"It complies" is a valid, valuable output.** So is "the plan is silent on this."

--- a/policy-compliance-assessment/SKILL.md
+++ b/policy-compliance-assessment/SKILL.md
@@ -160,9 +160,53 @@ For each policy: quote the **requirement** in its own words, then state what the
 - **Read the whole policy**, including any exception or flexibility limb the proposal might
   rely on. Supporting text and the reasoned justification are not policy, but are legitimate
   aids to interpreting it — label them as such.
+- **Designated areas raise the bar — score them that way.** In a conservation area, or where
+  a listed building or other designated heritage asset (or its setting) is affected, the
+  plan's character, design and scale policies are not ordinary detail policies: a statutory
+  duty and national policy's "great weight" stand behind them (take the citations and the
+  harm framework from the **heritage-representation** skill — s.66/s.72 and the NPPF heritage
+  tests live there). Two consequences for this skill's procedure: **(a)** assess the
+  **cumulative volume of physical change** quantitatively from the drawings — footprint,
+  depth, height, plot coverage, extensions and alterations taken together, measured against
+  the plot and its neighbours, not merely described; **(b)** where that change fails a
+  character or scale criterion of a policy applying to the designated area, treat the
+  conflict as going to the heart of the policy (-2 territory, and normally one of the "most
+  important" policies) rather than softening it to a tension because only one limb fails or
+  because each individual alteration looks modest.
 - **Mitigation that is not yet secured is not compliance.** If a policy's requirement is met
   only by something a condition or obligation would have to secure, say so — that is a (C)
   point, and it belongs in the score's reasoning.
+
+Evidence disciplines — habits observed in officer practice that the assessment must match:
+
+- **Audit the openings window-by-window.** Compare existing and proposed elevations opening
+  by opening: every new or altered window and door, which neighbour it faces, and whether it
+  creates overlooking a condition (obscure glazing, non-opening) would have to control. A
+  narrative read of the elevations misses exactly the opening the decision turns on.
+- **Sweep the site's planning history first, and assess against any fallback.** Check the
+  register for the site's (and close precedents') history before assessing: an extant
+  permission is the controlling baseline, and the assessment narrows to the **delta**
+  between it and the current proposal; past refusals and appeals on the site or its
+  immediate context are weight-bearing precedent.
+- **Measure against the neighbour as well as the plot.** Amenity geometry is relative:
+  projection beyond the neighbour's rear building line, orientation to their windows and
+  garden, and relative levels — computed from the drawings, not asserted.
+- **Verify the basic site facts from more than one source.** Attachment status (detached /
+  semi / terrace), plot orientation and constraints — state them with their evidence, and
+  check the council's own GIS/policies-map layers as well as national datasets; local
+  designations (minerals belts, ecology zones) often appear only on the council's layers.
+- **Read the representations.** Consultee responses and neighbour/third-party comments are
+  part of the evidence: they surface issues, site knowledge and precedents the application
+  documents omit (handle any personal data minimally).
+- **Consultee positions are evidence, not conclusions.** Re-derive each element's assessment
+  from the documents; decision-makers routinely depart from their own specialists in both
+  directions, and a consultee's general dispensation still has to survive the policy's own
+  wording at this site's scale.
+- **Prefer a condition to a refusal reason for separable detail.** Where an element is
+  acceptable in principle and only its detail is missing, the officer's instinct is to
+  reserve it by condition — a (C) point — not to refuse; reserve refusal reasons for harm.
+  Likewise a missing supporting document on a minor scheme is a proportionate-information
+  ask (B), not automatically a refusal reason.
 
 ### Step 5 — Score
 Apply the rubric in [`references/scoring-rubric.md`](references/scoring-rubric.md):

--- a/policy-compliance-assessment/references/finding-the-development-plan.md
+++ b/policy-compliance-assessment/references/finding-the-development-plan.md
@@ -1,0 +1,182 @@
+# Finding and verifying the adopted development plan
+
+The first step of the assessment, and the one that invalidates everything downstream if it is
+wrong. The goal is a short, sourced **plan register**: which documents make up the development
+plan for this site, when each was adopted, which policies in them are still live, and what the
+policies map says about the site.
+
+**Start from the right place.** Adopted policies are written, examined, adopted and published
+by the **local planning authority itself** — they live on that council's own website, and
+nowhere else is authoritative for them. Central government publishes the NPPF and PPG, which
+are *national* policy and a material consideration; they are not part of the development plan
+and cannot be substituted for it. So: the council's planning-policy pages for the policies that
+have primacy, and gov.uk only for the national tier that sits alongside them.
+
+## 1. What "adopted" means
+
+A development plan document is **adopted** when the local planning authority has formally
+resolved to adopt it, following submission, independent examination by an inspector, and any
+main modifications. Adoption is a dated, minuted event, and the council publishes the adopted
+document.
+
+**None of these is an adopted development plan policy:**
+
+| Not the development plan | What it is instead |
+|---|---|
+| A draft, "publication", submission or examination-stage plan | An **emerging** plan — a material consideration whose weight depends on its stage (see §6) |
+| A supplementary planning document (SPD) | Guidance that supplements adopted policy; it cannot create new policy |
+| A design guide or design code adopted as an SPD | Guidance (a code's status depends on how it was adopted — check) |
+| A conservation area appraisal / management plan | Evidence and guidance |
+| A masterplan, development brief or village design statement | Guidance, unless adopted as a DPD |
+| A council strategy (housing, climate, economic) | Corporate policy; at most a material consideration |
+| A neighbourhood plan not yet **made** | Emerging; weight rises after a successful referendum |
+| A withdrawn or superseded plan | Nothing — but check the saved-policies schedule (§4) |
+| The NPPF / PPG | National policy: a material consideration, not part of the plan |
+
+⏳ **Pending reform — check at run time.** Reforms to the plan-making system provide for
+**national development management policies** and for **supplementary plans** (intended to
+replace SPDs and to form part of the development plan). Whether either is in force, and what
+it does to the table above, must be checked at run time; do not assume the position stated
+here still holds. Confirm the current framework through the **national-planning-policy**
+skill.
+
+## 2. Confirm the local planning authority
+
+Get this right before searching for a plan:
+
+- Normally the **district, borough, city or unitary council** for the site.
+- A **National Park authority** or the **Broads Authority** is the LPA within its boundary —
+  its own local plan applies, not the surrounding district's.
+- A **development corporation** or similar body may be the LPA for a designated area.
+- In **two-tier areas**, the **county council** is the minerals and waste planning authority:
+  those plans are part of the development plan even though the district determines the
+  application.
+- In **Greater London**, the borough is the LPA and the Mayor's **spatial development
+  strategy** also forms part of the development plan; large schemes may be referable to the
+  Mayor.
+
+Where a site sits on or near a boundary, confirm which authority determines it — the
+application reference and the portal that hosts it are the practical answer.
+
+## 3. Assemble the plan — expect several documents
+
+Under s.38 of the Planning and Compulsory Purchase Act 2004 the development plan for an area
+is the **adopted development plan documents taken as a whole**, together with any
+**made** neighbourhood plan; in Greater London it also includes the spatial development
+strategy. ⏳ *Verify the current statutory wording at run time — and note that older
+reproductions of s.38 found online still carry a spent reference to regional strategies,
+which were revoked.*
+
+In practice, look for:
+
+- the **adopted local plan** — one volume, or a **core strategy / strategic policies**
+  document plus a **site allocations** and/or **development management policies** document;
+- an **older plan with saved policies** still in force alongside a partial replacement;
+- a **joint or strategic plan** covering several authorities;
+- the **minerals local plan** and **waste local plan** (county or unitary);
+- any **made neighbourhood plan** for the parish or neighbourhood area — check whether the
+  site falls inside a neighbourhood area at all;
+- in London, the **spatial development strategy**.
+
+Record each as a register row: *document name · adopted (date) · status · where obtained*.
+
+## 4. The two traps that break assessments
+
+**Superseded and saved policies.** When a council adopts a new plan it usually replaces only
+*some* of the predecessor's policies; the rest are "saved" and remain part of the development
+plan. The adopted plan carries a **schedule or appendix of superseded / saved policies** —
+find it and use it. Symptoms of getting this wrong: citing a policy the plan itself abolished,
+or missing a saved policy that is the only one addressing the point.
+
+**Draft numbering versus adopted numbering.** Policy numbers routinely change between the
+consultation and publication drafts and the adopted plan, and two plans in the same area can
+each contain a "Policy H1". Always take the reference from the **adopted** document, and
+record the document name alongside the number so the citation is unambiguous.
+
+Two lesser traps worth a check: policies can be **quashed or modified by the courts**, and a
+plan can be **partially superseded** by a later strategic plan.
+
+## 5. Read the policies map for the site
+
+The **policies map** (formerly the proposals map) is part of the plan and often determines
+which policies apply at all. For the application site, record:
+
+- whether it is **inside or outside the settlement boundary** / urban area;
+- any **allocation** (housing, employment, mixed use, safeguarded land) and its policy
+  reference and requirements;
+- **designations and constraints**: conservation area, Green Belt, National Landscape, local
+  green space, green wedge/gap, open space, employment area, town-centre boundary and primary
+  shopping area, local wildlife site, minerals safeguarding area, flood-risk policy area;
+- **neighbourhood plan** designations, which may sit on a separate map.
+
+Interactive map viewers are common; where one exists, prefer it for the site check but confirm
+the designation's policy reference in the adopted written document. National datasets
+(for example the public planning-data service and the flood map for planning) usefully
+corroborate designations but are **not** the plan.
+
+## 6. Emerging plans — record the stage, then reason the weight
+
+Weight depends on the **stage of preparation**, the **extent of unresolved objections**, and
+**consistency with national policy** — take the test itself from the
+**national-planning-policy** skill. Record where the plan has actually got to:
+
+| Stage | Typical weight |
+|---|---|
+| Early / issues-and-options consultation | Very little |
+| Draft plan consultation | Little |
+| Publication / pre-submission version | Limited, and depends on objections |
+| Submitted for examination | Growing |
+| Examination hearings held; main modifications consulted on | Greater, where the relevant policy is not contested |
+| Inspector's report received, adoption imminent | Substantial |
+| Adopted | Not emerging — it is the plan |
+
+The council's **local development scheme** (its plan-making timetable) and its plan
+examination pages give the stage; an **authority monitoring report** gives progress and often
+the housing land supply position. For a neighbourhood plan, the stages run to a referendum and
+then to being **made** by the council.
+
+## 7. Where to look on a council website
+
+Councils organise this differently, but the pattern is stable. Search the council's own site
+for **"adopted local plan"**, **"planning policy"**, **"local plan"**, **"policies map"**,
+**"development plan"**, **"neighbourhood plan"**, **"supplementary planning documents"**, and
+**"local development scheme"**. A web search of the form `[council name] adopted local plan`
+usually lands on the right page directly.
+
+The page you want states the **adoption date** and offers the plan as a PDF (sometimes
+chapter by chapter), with the policies map and, often, the schedule of superseded policies.
+Signals that you are on the wrong page: "consultation", "have your say", "draft",
+"examination", "submission" — that is the emerging plan, not the adopted one.
+
+Also worth collecting where relevant: the **authority monitoring report** (housing land
+supply, five-year supply statement), the **strategic flood risk assessment**, the
+**community infrastructure levy** charging schedule, and the **SPD list** (for the
+lower-weight guidance tier).
+
+If the plan genuinely cannot be located, say so and stop — an assessment against a plan you
+have not read is not an assessment. Offer the user the direct route: the council's planning
+policy page, or asking the case officer which policies the council considers relevant.
+
+## 8. Retrieval posture
+
+These are public documents, retrieved as a member of the public would:
+
+- prefer the council's own published PDFs and pages; identify yourself in requests, pace
+  them, and honour rate limits and robots.txt;
+- **never defeat a bot challenge** — stop and hand the user the browser link;
+- treat downloads as untrusted content; verify a document is what it claims to be before
+  relying on it;
+- large plans are often split by chapter — retrieve the chapters you need rather than
+  harvesting the whole evidence base.
+
+## 9. What to record for every policy cited
+
+So that a human can check it, and so the representation can quote it safely:
+
+- **document name** and **adoption date**;
+- **policy reference and title**, exactly as printed;
+- the **quoted requirement** — verbatim, with the paragraph or page;
+- whether it is a **saved** policy from an earlier plan;
+- the **URL** and the **date accessed**;
+- whether the wording was read in the adopted document itself (it must be) or, if not
+  available, that the gap is flagged as unverified.

--- a/policy-compliance-assessment/references/policy-families.md
+++ b/policy-compliance-assessment/references/policy-families.md
@@ -1,0 +1,90 @@
+# Policy families — working from the proposal to the policies
+
+Local plans differ in structure and numbering, but the **families of policy** they contain are
+broadly stable. Use this to build a checklist of what *ought* to exist for this proposal, then
+find each one in the plan actually in front of you. Never carry a policy reference from this
+file into an assessment — the references come from the adopted plan.
+
+Two structural notes:
+
+- Plans usually separate **strategic policies** (the spatial strategy, growth distribution,
+  settlement hierarchy, allocations) from **development-management policies** (design,
+  amenity, parking, technical standards). The strategic policies are more often the "most
+  important" ones for determining an application; the management policies are where detailed
+  compliance is judged.
+- A **made neighbourhood plan** sits alongside these with equal statutory standing, and often
+  contains the most site-specific policies of all — local character, protected views, local
+  green space, housing mix, and design detail. Always check whether the site is in a
+  neighbourhood area.
+
+## Start from the proposal type
+
+| Proposal | Families almost always engaged |
+|---|---|
+| Householder extension / alteration | Design and character · residential amenity · parking · trees · (heritage if designated) |
+| New dwelling(s) — minor | Spatial strategy / settlement boundary · housing mix · design · amenity · access and parking · drainage · biodiversity |
+| Major housing | All of the above plus affordable housing · housing density and mix · open space and play · education and infrastructure contributions · transport assessment and travel plan · flood risk and drainage · biodiversity net gain · climate and energy · self-build where the plan requires it |
+| Change of use | Spatial strategy · the policy protecting the existing use (employment land, retail frontage, community facility, agricultural land) · amenity · parking · town-centre policies |
+| Employment / industrial | Employment land allocation and protection · access and servicing · amenity (noise, hours, lighting) · design · drainage · biodiversity |
+| Retail / town centre | Town-centre hierarchy and the sequential and impact approach · frontage and use-mix policies · shopfront design · parking and servicing |
+| HMO / student / build-to-rent | Any concentration or mix policy · amenity and standards · waste storage · parking · design |
+| Rural / agricultural | Countryside protection · agricultural land quality · rural workers' dwellings · farm diversification · landscape character · dark skies where the plan has one |
+| Renewable energy | Climate and renewable energy policies · landscape and visual impact · heritage setting · biodiversity · residential amenity |
+| Telecommunications / advertisements | The specific policy family · amenity · heritage and design |
+| Minerals or waste | The county or unitary minerals and waste plans (a separate part of the development plan) · safeguarding areas |
+| Listed building consent / conservation area | Heritage policies, with the statutory duties — see the heritage skill |
+
+Also check, for any proposal: whether the site is **allocated** (the allocation policy's own
+requirements are directly engaged, and often detailed), and whether any **site-specific** or
+area-based policy applies from the policies map.
+
+## The families
+
+| Family | Typically titled / covers | Engaged when | Technical evaluation owned by |
+|---|---|---|---|
+| **Spatial strategy / settlement boundary** | Development strategy, settlement hierarchy, growth distribution, "development in the countryside" | Almost always — and decisive where the site is outside a defined boundary | This skill (the plan question) |
+| **Site allocations** | Allocation policies with site-specific requirements and capacities | Site is allocated, or is being developed contrary to an allocation | This skill |
+| **Housing supply, mix and density** | Housing requirement, mix of types and tenures, density, specialist and older persons' housing, space standards | Any residential proposal | This skill |
+| **Affordable housing** | Proportion, tenure split, thresholds, off-site or commuted sums, viability | Residential above the plan's threshold | This skill (delivery and securing → obligation tests) |
+| **Design and local character** | Design quality, character and appearance, scale, massing, materials, layout, local design codes | Almost always | This skill; design guides sit in the guidance tier |
+| **Residential amenity** | Overlooking, privacy, overshadowing, overbearing impact, noise, light, hours, outlook and daylight standards | Development near existing homes, or creating homes | This skill |
+| **Heritage** | Listed buildings, conservation areas, scheduled monuments, archaeology, non-designated assets, setting | Designated asset or its setting affected; archaeological potential | **heritage-representation** |
+| **Transport, access and parking** | Sustainable transport, highway safety, access standards, parking and cycle standards, travel plans, servicing | Any development generating movement | **transport-representation** |
+| **Flood risk and drainage** | Flood zones, sequential approach, surface-water drainage and SuDS, water quality, foul drainage | Site in a flood-risk area, or any material increase in impermeable area | **flood-representation** |
+| **Biodiversity and green infrastructure** | Protected species and habitats, designated wildlife sites, net gain, green corridors, trees and hedgerows | Almost always for greenfield; frequently for brownfield | **ecological-representation** |
+| **Trees and landscape** | Protected trees, hedgerows, landscape character, important views, gaps between settlements | Trees on or adjoining the site; sensitive landscape | This skill (with the ecology skill on habitat value) |
+| **Open space, sport and recreation** | Provision standards, protection of existing open space, play space, allotments | Residential of any scale; any loss of open space | This skill |
+| **Green Belt** | Inappropriate development, openness, exceptions, very special circumstances | Site within the Green Belt — a gateway, not a balance | This skill (test) with **planning-balance** |
+| **Designated landscapes** | National Landscapes / National Parks, local landscape designations | Site within or affecting the setting of a designation | This skill |
+| **Employment land** | Protection and allocation of employment sites, loss of employment floorspace, rural employment | Loss or provision of employment use | This skill |
+| **Town centres and retail** | Centre hierarchy, sequential and impact approach, primary frontages, use mix, hot food and betting policies where present | Retail, leisure or main town-centre uses outside a centre | This skill |
+| **Community facilities** | Protection of pubs, shops, halls, schools, health facilities | Loss of, or need for, a facility | This skill |
+| **Climate change, energy and sustainable construction** | Carbon reduction, renewable energy, energy efficiency, overheating, water efficiency, electric vehicle charging | Increasingly, any new build | This skill |
+| **Pollution, contamination and land stability** | Air quality, noise, light, contaminated land, agricultural land quality | Sensitive receptors, previously developed land, air-quality management areas | This skill |
+| **Infrastructure and developer contributions** | Contributions, the levy, education, health, transport infrastructure, viability | Development generating infrastructure need | This skill (with the obligation tests) |
+| **Advertisements, shopfronts, telecoms** | Signage and shopfront design, mast siting | The relevant application type | This skill |
+| **Minerals and waste** | Safeguarding areas, waste capacity, restoration | Site in a safeguarding area, or a minerals/waste proposal | This skill |
+
+## Applying the checklist
+
+1. **Build the expected list** from the proposal type and the site's designations.
+2. **Find each family in the plan** — search the plan's contents and policy index for the
+   family's usual language. Record the actual policy reference and title.
+3. **Test each for scope** before including it: many policies apply only above a size
+   threshold, to a use class, or within a designated area. A policy that does not bite is
+   omitted, with a line in the verification note.
+4. **Note the gaps.** Where the plan has **no policy** in a family the proposal plainly
+   engages, that is a finding in itself: national policy and any guidance then carry the
+   argument, and the absence may be a sign the plan is out-of-date on that topic. Say so
+   rather than stretching an unrelated policy to cover it.
+5. **Do not stretch a policy.** Using an amenity policy as a proxy for a topic the plan does
+   not address invites the reply that the policy does not say what is claimed — and costs
+   credibility on the policies that do fit.
+
+## Boundary with the topic skills
+
+For the four families with a dedicated skill — heritage, transport, flood, ecology — this
+skill establishes **which policy applies and what it requires**, and the topic skill evaluates
+**whether the applicant's technical evidence satisfies it**. Run both: a policy conflict
+asserted without the technical evaluation is thin, and a technical criticism with no policy
+hook is weaker than it needs to be. Do not duplicate the topic catalogues here.

--- a/policy-compliance-assessment/references/scoring-rubric.md
+++ b/policy-compliance-assessment/references/scoring-rubric.md
@@ -1,0 +1,170 @@
+# Scoring rubric — accordance from -2 to +2
+
+The score is a **shorthand for an argument**, not a measurement. It exists so a reader can see
+at a glance where the proposal stands against each policy, and so the drafting skill can lead
+on the points that carry weight. It never replaces the reasoning, and it is never added up.
+
+## The scale
+
+### +2 — Strongly aligned
+The proposal actively delivers what the policy seeks, not merely avoids offending it. Every
+criterion is met, and the policy's own objective is advanced.
+
+*Signals:* the proposal is the type of development the policy positively promotes, on a site
+the plan allocated for it; it exceeds a policy standard (a higher affordable-housing
+proportion, biodiversity gain above the required minimum); the policy's supporting text
+describes the very outcome proposed.
+
+*A +2 needs:* the quoted policy aim, and the evidence from the application that the aim is
+delivered — a figure, a plan reference, a commitment capable of being secured.
+
+### +1 — Accords
+The proposal meets the policy's requirements. There is no material tension; it simply complies.
+
+*Signals:* each criterion is satisfied on the submitted evidence; a technical standard is met;
+a statutory consultee is content on the matter the policy addresses.
+
+*Note:* most policies in a competent application score +1. Recording that honestly is what
+makes the negatives credible.
+
+### 0 — Neutral
+The policy is relevant enough to list, but the proposal neither advances nor offends it.
+
+*Signals:* the policy is a general or strategic statement the proposal is indifferent to; the
+policy's requirement is not triggered at this scale but the policy is worth recording as
+considered.
+
+*Do not use 0 as a hiding place.* If a policy is genuinely not engaged, leave it out and say
+why in the verification note. If it is engaged but unassessable, use `?`.
+
+### -1 — Tension or partial conflict
+The proposal fails part of what the policy requires, or is contrary to its aim in a limited
+way, but the conflict is not central to the policy's purpose or is capable of being resolved.
+
+*Signals:* one criterion of a multi-criterion policy is not met while the rest are; the policy
+uses permissive wording ("should", "will be encouraged") and the proposal falls short of it;
+compliance depends on mitigation that is not yet secured; the shortfall is against a standard
+rather than a principle.
+
+*A -1 needs:* the specific criterion or expectation identified, quoted, and the document
+evidence of the shortfall.
+
+### -2 — Significant conflict
+The conflict goes to the heart of the policy: a mandatory requirement is breached, or a
+criterion central to the policy's purpose is failed, or the proposal is of a type the policy
+says will not be permitted in this location.
+
+*Signals:* "will not be permitted" / "must" / "will be refused" wording engaged directly;
+development outside a settlement boundary where the policy restricts it and no exception limb
+applies; a use the plan protects being lost; an allocation's core requirement not delivered;
+a designated area's protective policy engaged with no policy exception met.
+
+*A -2 needs:* the mandatory wording quoted, the applicable exception limbs examined and shown
+not to apply, and the document evidence of the breach. **If the exception limbs have not been
+checked, the score is not yet a -2.**
+
+### `?` — Cannot be assessed
+The policy is engaged, but the application does not contain the evidence the policy itself
+requires, so compliance can be neither confirmed nor denied.
+
+*Signals:* the policy requires an assessment, statement or survey that is absent; the
+submitted document does not address the policy's test; a consultee has asked for information
+that has not yet been provided.
+
+**`?` is not a negative score, and must never be presented as one.** It supports a different
+ask — that the application not be determined until the information is before the council. Every
+`?` is a **(B)** in the repo's A/B/C classification.
+
+## Calibration tests
+
+Two decisions cause most of the error. Apply these:
+
+**-1 or -2?** Ask: *if this were the only policy in the plan, would the proposal fail on it?*
+If yes — the conflict alone would justify refusal under that policy — it is a -2. If the
+policy would be pressed but not defeated, or mitigation could resolve it, it is a -1. Also
+check the wording ceiling: a policy expressed as encouragement can rarely support a -2.
+
+**0 or +1?** Ask: *did the proposal have to do something to satisfy this policy?* If yes and it
+did, that is +1. If the policy simply does not bite, 0 — or omit it.
+
+**-1 or `?`** Ask: *am I saying the proposal falls short, or that I cannot tell?* If the
+shortfall is shown in the documents, score it. If the documents are silent on a matter the
+policy requires them to address, that is `?`.
+
+**+1 or +2?** A +2 is for positive delivery of the policy's objective, not for competent
+compliance. If the honest description is "complies", it is +1.
+
+## Weight tiers — record alongside every score
+
+A score says how the proposal stands against a policy; the tier says how much that matters.
+Keep them in separate columns and never merge them.
+
+| Tier | What it covers | Standing |
+|---|---|---|
+| **Development plan** | Adopted local plan (and saved policies), made neighbourhood plan, minerals and waste plans, London's spatial development strategy | The statutory starting point — determination in accordance with it unless material considerations indicate otherwise |
+| **Development plan — reduced** | An adopted policy that is out-of-date (time-expired, or overtaken in substance by national policy) | Still part of the plan; conflict still counts, at reduced weight — state the reason for the reduction |
+| **National policy** | NPPF / PPG | Material consideration; influential, not above the plan. Verify edition and references through the **national-planning-policy** skill |
+| **Emerging plan** | Plan or neighbourhood plan not yet adopted / made | Material consideration; weight per stage, unresolved objections and consistency with national policy — record the stage |
+| **Guidance** | SPDs, design guides and codes, technical standards, appraisals | Supplements adopted policy; cannot create policy the plan does not contain |
+
+The order of that table is the hierarchy, and it is not negotiable: the **local authority's own
+adopted policies come first** and carry primacy, and the nationally published tiers sit beneath
+them as material considerations. A `-2` against an adopted plan policy is a more serious finding
+than a `-2` against an emerging or national one, and the output must make that visible rather
+than leaving a reader to weigh the rows equally.
+
+Also flag, per policy, whether it is one of the **most important policies for determining the
+application**. That set — usually the spatial strategy or settlement-boundary policy, the site
+allocation or designation, and the principal topic policies — is what the national presumption
+turns on, so mark it rather than leaving it implicit.
+
+## The no-aggregation rule
+
+**Do not total, average, or weight-and-sum the scores.** Section 38(6) asks whether the
+proposal accords with the development plan **read as a whole** — a planning judgement about
+the plan's strategy and the significance of each conflict, not a calculation.
+
+Why it matters, concretely: a proposal scoring `+1` on eight detailed policies (parking
+standards, refuse storage, boundary treatment, materials…) and `-2` on the settlement-boundary
+policy has a positive mean and is very likely contrary to the plan as a whole, because the
+one conflict defeats the plan's spatial strategy while the eight compliances are matters of
+detail. An arithmetic summary would invert the answer, and any planning officer reading it
+would discount the whole analysis.
+
+What to produce instead: an **accordance statement** naming the conflicts that matter, why
+they matter to the plan's strategy, what the proposal complies with, and what cannot yet be
+assessed — with a reasoned conclusion. It is legitimate to say "the position is finely
+balanced" where it is.
+
+Counting is allowed only as description ("three policies are engaged, two of them
+significantly in conflict"), never as the conclusion.
+
+## Output table
+
+One row per policy. Quote requirements; keep the assessment to a sentence or two with its
+evidence.
+
+| Policy | Source (adopted) | Tier | Requirement (quoted) | Assessment (evidence) | Score | Most important | A/B/C |
+|---|---|---|---|---|---|---|---|
+| `[Policy ref]` *settlement boundary* | `[Plan name]`, adopted `[date]` | Development plan | "Development outside the settlement boundary will not be permitted unless …" | Site lies outside the boundary on the policies map; none of the exception limbs (a)–(e) is engaged — see Planning Statement §`[x]` | **-2** | Yes | (A) |
+| `[Policy ref]` *design and character* | `[Plan name]`, adopted `[date]` | Development plan | "Proposals must respond to the character of the area in scale, form and materials" | Three storeys against a two-storey street frontage; Design and Access Statement §`[x]` does not address scale | **-1** | Yes | (A)/(C) |
+| `[Policy ref]` *biodiversity* | `[Plan name]`, adopted `[date]` | Development plan | "Development must deliver a measurable net gain in biodiversity" | No biodiversity metric submitted; the policy's requirement cannot be tested | **?** | No | (B) |
+| `[Policy ref]` *affordable housing* | `[Plan name]`, adopted `[date]` | Development plan | "Schemes of `[n]` or more dwellings will provide `[x]`% affordable housing" | `[x]`% offered, matching the requirement; not yet secured by obligation | **+1** | Yes | (C) |
+| `[Policy ref]` *parking* | `[Plan name]`, adopted `[date]` | Guidance-backed standard | "Parking will be provided in accordance with the adopted standards" | Provision meets the standard for the proposed mix | **+1** | No | — |
+
+Keep national and emerging policy in a **second table** with the same columns, so the
+lower-weight tier is visible on the page rather than mixed into the plan's rows.
+
+## Common scoring errors
+
+- **Averaging** — the error the rule above exists to prevent.
+- **Scoring an evidence gap as a conflict** — inflates the case and collapses under scrutiny.
+- **A -2 without checking the exception limbs** — most restrictive policies have them.
+- **Citing a superseded policy** — check the saved/superseded schedule first.
+- **Scoring the supporting text** — the policy is what is in the policy box.
+- **Listing every policy in the plan** — relevance, not volume; a padded table hides the
+  points that matter.
+- **All-negative tables** — if nothing scores positive, check whether the assessment has
+  become advocacy.
+- **Scores without quotes** — an unquoted requirement cannot be checked by a human, which is
+  the whole point of the table.

--- a/policy-compliance-assessment/references/scoring-rubric.md
+++ b/policy-compliance-assessment/references/scoring-rubric.md
@@ -57,7 +57,10 @@ says will not be permitted in this location.
 *Signals:* "will not be permitted" / "must" / "will be refused" wording engaged directly;
 development outside a settlement boundary where the policy restricts it and no exception limb
 applies; a use the plan protects being lost; an allocation's core requirement not delivered;
-a designated area's protective policy engaged with no policy exception met.
+a designated area's protective policy engaged with no policy exception met; a character or
+scale criterion failed **within a conservation area** or affecting another designated
+heritage asset, where the statutory duty and national "great weight" policy stand behind the
+plan policy.
 
 *A -2 needs:* the mandatory wording quoted, the applicable exception limbs examined and shown
 not to apply, and the document evidence of the breach. **If the exception limbs have not been
@@ -83,6 +86,14 @@ Two decisions cause most of the error. Apply these:
 If yes — the conflict alone would justify refusal under that policy — it is a -2. If the
 policy would be pressed but not defeated, or mitigation could resolve it, it is a -1. Also
 check the wording ceiling: a policy expressed as encouragement can rarely support a -2.
+
+*Designated-area uplift:* run this test **with the statutory context in**. In a conservation
+area (or affecting a listed building or other designated heritage asset), a character or
+scale policy carries a statutory duty and national "great weight" behind it, so a conflict
+that would read as a pressed-but-not-defeated -1 on an undesignated site is routinely
+refusal-strength there — decision-makers regularly refuse on such a conflict alone. Judge the
+**cumulative volume of change** from measured drawings, not the modesty of each element, and
+do not discount to -1 merely because only one criterion of the policy fails.
 
 **0 or +1?** Ask: *did the proposal have to do something to satisfy this policy?* If yes and it
 did, that is +1. If the policy simply does not bite, 0 — or omit it.
@@ -160,6 +171,10 @@ lower-weight tier is visible on the page rather than mixed into the plan's rows.
 - **Averaging** — the error the rule above exists to prevent.
 - **Scoring an evidence gap as a conflict** — inflates the case and collapses under scrutiny.
 - **A -2 without checking the exception limbs** — most restrictive policies have them.
+- **Under-scoring a designated-area conflict** — softening a character/scale breach in a
+  conservation area (or affecting another designated heritage asset) to -1 because only one
+  criterion fails or each alteration looks small; the statutory duty makes the cumulative
+  change the test.
 - **Citing a superseded policy** — check the saved/superseded schedule first.
 - **Scoring the supporting text** — the policy is what is in the policy box.
 - **Listing every policy in the plan** — relevance, not volume; a padded table hides the

--- a/policy-representation/CHANGELOG.md
+++ b/policy-representation/CHANGELOG.md
@@ -1,0 +1,72 @@
+# Changelog — policy-representation
+
+Design decisions per revision, newest first. See `../CLAUDE.md` for the format and the house
+rules. The **_Why_** lines record the rationale so a future editor understands the intent.
+
+## 0.1.0 — 2026-08-17 — Initial release
+
+### Added
+- **The skill itself: a policy-led representation drafter taking `policy-compliance-assessment`'s
+  scored table as input.** _Why:_ the four topic representation skills draft on a *technical*
+  ground (ecology, transport, heritage, flood) and each owns its own deficiency catalogue. None
+  of them drafts the **policy case** — conflict with, or accordance with, named adopted
+  development-plan policies — which is the strongest kind of point a representation can make and
+  the one a case officer must address in the report. Splitting the analysis (previous skill) from
+  the drafting (this skill) also lets the user review the policy findings before any letter
+  exists.
+- **Support as a first-class stance, not an afterthought.** Both skeletons, both worked examples
+  and the house-style rules cover support and objection at the same standard. _Why:_ the repo
+  had only ever drafted objections, and a support letter is not an objection with the polarity
+  flipped — it needs a declaration of interest, an "objections answered" section, and asks for
+  conditions that *secure the benefits relied on*. Treating support as a trivial inversion would
+  produce the kind of content-free "I think this is a good scheme" letter that councils rightly
+  disregard.
+- **The stance/evidence split as the governing principle:** the stance is the user's to choose,
+  the evidence is not. Includes a mismatch check before drafting and three honest routes when the
+  requested stance runs against the analysis (draft the supportable points only; adopt a fitting
+  hybrid stance; the opposite stance). _Why:_ a representation belongs to the person submitting
+  it, so refusing to draft a stance would be the wrong call — but so would inventing a policy
+  case to fit it. Naming the tension and resolving it procedurally keeps both the user's autonomy
+  and the repo's evidence discipline intact. It also mirrors the existing skills' posture that
+  "don't object" is a valid output, extended to "the policies don't support the letter you want".
+- **A rule that no point may overstate its score**, with `?` (cannot be assessed) never written
+  as a demonstrated breach and `-1` never written as a mandatory-requirement failure. _Why:_ the
+  scoring rubric's honesty is only worth having if it survives the trip into prose; this is where
+  a careful analysis would otherwise be inflated at the last step.
+- **A "declare an interest" rule for support letters** (applicant, agent, relative, employee,
+  prospective purchaser, competitor, campaign involvement) and an explicit instruction to write in
+  the user's own words rather than submit a circulated template. _Why:_ undisclosed interests and
+  identical form letters are the recognised failure modes of support campaigns, and both get the
+  representation discounted when noticed. Declaring the interest costs nothing and protects the
+  weight of everything else in the letter.
+- **A "the other side, answered" section required in both stances.** _Why:_ a representation that
+  argues only one way reads as advocacy. In objection, engaging the claimed benefits (and noting
+  which are unsecured or unquantified) is itself strong material; in support, answering the
+  objections is the only thing that makes the letter useful to the officer.
+- **The three-to-six point limit, with `0`s and peripheral `-1`s dropped.** _Why:_ the analysis is
+  deliberately comprehensive; the letter must not be. Filler dilutes the points that decide the
+  application, and a padded representation signals that the writer cannot tell which policies
+  matter.
+- **Development plan policies lead; national policy supports; emerging policy leads only where
+  nothing adopted covers the point.** _Why:_ the adopted plan has primacy, and a representation
+  that opens on the NPPF while the local plan sits in the background inverts the statutory
+  hierarchy — and invites the reply that the writer has not read the plan.
+- **The ask table mapped onto `planning-balance`'s outcomes** (grant / grant with conditions /
+  refuse / do not determine yet). _Why:_ the two skills must not give the user different
+  vocabularies for the same conclusion, and the A/B/C classification already flows from the
+  analysis through to the ask.
+
+### Changed
+- **No citations of its own: NPPF/PPG references, the presumption and the conditions and
+  obligations tests are taken from `national-planning-policy` at run time.** _Why:_ two-layers
+  house rule, and the drafting stage is exactly where a stale paragraph number would do the most
+  damage — the check list requires run-time verification before the draft leaves the skill.
+- **Reference files kept to two (`house-style.md`, `representation-templates.md`) rather than
+  cloning the four-file topic-skill layout.** _Why:_ this skill has no deficiency catalogue and no
+  topic guidance catalogue to own — the policies come from the council's plan as per-instance data
+  and the national layer lives elsewhere, so a `deficiency-catalogue.md` and a
+  `national-guidance.md` would have nothing legitimate in them.
+- **`representation-templates.md` (plural) rather than the family's `objection-template.md`.**
+  _Why:_ the file holds two skeletons and two worked examples because the skill has two stances;
+  the singular name would have understated the support path and invited a future editor to treat
+  it as secondary.

--- a/policy-representation/LICENSE
+++ b/policy-representation/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ian Howard
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/policy-representation/README.md
+++ b/policy-representation/README.md
@@ -1,0 +1,40 @@
+# policy-representation
+
+Draft the representation that actually gets sent — **in support or in objection, as the user
+chooses** — built on the policy analysis from
+[`policy-compliance-assessment`](../policy-compliance-assessment/).
+
+It takes the scored policy table and turns the policies that carry weight into a concise,
+evidenced letter:
+
+- **each point anchored twice** — to a quoted requirement from the **adopted** development plan
+  (named, with its adoption date), and to the application's own documents for the facts;
+- **led by the policies that decide applications** — the spatial strategy or settlement-boundary
+  policy, the site's allocation or designation, the principal topic policies — with national
+  policy in support rather than in the lead, and any emerging policy at its stated weight;
+- **the other side acknowledged and answered** — in objection, the policies complied with and the
+  benefits claimed; in support, the objections made and the conflicts the analysis found;
+- **a clear ask** — grant, grant subject to specified conditions, refuse, or *do not determine
+  yet* where a policy requirement cannot be assessed on the evidence submitted.
+
+This is the only skill in the repo that drafts **support** as well as objection, and it holds
+both to the same standard.
+
+## Stance and integrity
+
+**The stance is the user's to choose; the evidence is not.** The skill drafts what the user asks
+for, using only what the analysis supports. It will not manufacture policy compliance or
+conflict, overstate a score, misquote a policy, or present a gap in the evidence as a
+demonstrated breach. Where the requested stance runs against the analysis it says so plainly and
+offers the honest routes — draft on the supportable points only, adopt a stance that fits
+(*support subject to conditions*, *no objection but requesting conditions*, *objection limited to
+named policies*), or the opposite stance — then follows the user's decision.
+
+Support letters carry two extra rules: **declare any interest** (applicant, agent, relative,
+employee, prospective purchaser, competitor, campaign involvement), and **write in your own
+words** — circulated identical letters are recognised and given little weight.
+
+> **Not legal advice. No warranty. England only.** Output requires human review before
+> submission, and a UK planning representation is normally **published on the council's portal in
+> the submitter's name** and kept on the record — so it should contain only personal details the
+> user is content to make public. See the repo README for the full disclaimer.

--- a/policy-representation/SKILL.md
+++ b/policy-representation/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: policy-representation
+description: >-
+  Draft a policy-led representation on a UK planning application — in **support**
+  or in **objection**, as the user chooses — from a policy compliance assessment.
+  Each point is anchored to a quoted adopted development-plan policy and to the
+  application's own documents, the other side is acknowledged, and the ask is
+  clear (grant, grant subject to conditions, refuse, or do not determine yet). Will
+  not manufacture policy compliance or conflict to fit a stance, and flags any
+  mismatch between the stance and the evidence. Use for "write a letter of
+  support", "draft an objection based on the policies", "write my representation".
+  England-focused. Not legal advice; no warranty; output requires human review,
+  and a representation is normally published in the submitter's name.
+license: MIT
+---
+
+# Policy representation — support or objection
+
+Turn a policy analysis into the letter that actually gets sent. This skill takes the scored
+policy table from **policy-compliance-assessment** and drafts a representation that a case
+officer can lift into the officer report — **in support or in objection, according to the
+user's choice**.
+
+It is the only skill in this repo that drafts **support** as well as objection, and the
+discipline is the same either way: every point anchored to a quoted policy and to the
+application's own documents, the other side acknowledged, and an ask the analysis can carry.
+
+## When to use
+
+The user has a policy analysis (or the material for one) and asks: "write my representation",
+"draft a letter of support for this application", "draft an objection based on the local plan
+policies", "put this into a letter I can send to the council".
+
+Run **after** `policy-compliance-assessment`. If no policy analysis exists yet, run that skill
+first — this one does not assess policy, and a representation asserting policy conclusions that
+have not been worked through is precisely the thing councils discount.
+
+Not this skill: the four topic representation skills (`ecological-`, `transport-`, `heritage-`,
+`flood-representation`) draft **objections on their own technical grounds** and own the
+deficiency analysis for those topics. Where they have run, integrate their points here rather
+than restating them — or let them stand as their own representation and use this skill for the
+policy case.
+
+## What you need first
+
+- The **policy analysis** — the plan register, the scored policy table (with quoted
+  requirements, the evidence, the weight tiers and the A/B/C classification), and the
+  accordance statement. This is the skill's raw material.
+- The **user's chosen stance** — support or objection (see the next section before accepting
+  it).
+- The **application details** — reference, site address, proposal description, council, and the
+  case officer's name if known.
+- The **application documents** for the facts each point relies on, quoted.
+- The **consultation deadline** and the **submission route** — normally the comment form on the
+  council's planning portal, or an email quoting the application reference. Note that material
+  considerations can be raised at any time before the application is determined, so a missed
+  consultation deadline is not necessarily the end.
+- **Anything from `planning-balance`**, if it has run — its four outcomes map directly onto the
+  ask this skill states.
+- What the user is willing to make **public** (see the publication warning below).
+
+## Stance and integrity (read before drafting)
+
+**The stance is the user's to choose. The evidence is not.**
+
+A representation is the user's own; they are entitled to support or oppose an application for
+their own reasons, and this skill drafts what they ask for. What it will not do is invent the
+policy case for it.
+
+- **Only make points the analysis supports.** Every point must trace to a policy in the table,
+  with its quoted requirement and its evidence. No point may overstate a score — a `-1` tension
+  is not written as a breach, and a `+1` compliance is not written as a positive benefit.
+- **Never manufacture compliance or conflict**, misquote a policy, quote a requirement out of
+  its exception limbs, or present an unassessable point (`?`) as a demonstrated one.
+- **Where the requested stance runs against the analysis, say so plainly, then offer the
+  honest routes.** Set out which points do and do not support the stance, and offer:
+  1. draft on the supportable points only, with the mismatch stated to the user (and, where
+     integrity requires, acknowledged in the letter itself);
+  2. a stance that fits the evidence better — *support subject to conditions*, *no objection but
+     requesting conditions*, or *objection limited to named policies*;
+  3. the opposite stance.
+  Then follow the user's decision, and draft it properly.
+- **Do not hide the other side.** An objection that ignores the policies the scheme complies
+  with, or a letter of support that ignores a `-2` conflict, invites the reply that the writer
+  has not read the plan. Acknowledging and answering the contrary point is what makes a
+  representation credible.
+- **Declare an interest.** If the user is the applicant, their agent, a relative, an employee, a
+  competitor, a prospective purchaser, or is writing as part of an organised campaign, the
+  representation should say so. Undisclosed interests and identical template letters are
+  discounted when spotted — and rightly.
+- **Write in the user's own words.** The templates are skeletons, not text to submit verbatim.
+  A representation in the writer's own voice, on this application's facts, carries weight that a
+  circulated form letter does not.
+- **A representation is public.** In the UK it is normally **published on the council's portal
+  in the submitter's name** and kept on the record. Names are usually published; addresses,
+  emails and signatures are usually redacted, but practice varies — so include only personal
+  detail the user is content to see published, and say this before they send.
+
+## Workflow
+
+### Step 1 — Intake and confirm the stance
+Take the policy analysis and the stance. Before drafting, run the **mismatch check**: does the
+weight of the analysis point the same way as the requested stance? If not, apply the integrity
+routes above and settle the stance with the user before writing.
+
+### Step 2 — Select the points to lead on
+A representation is not the policy table restated. Choose **three to six points**, ordered by
+force:
+
+- lead with the highest-magnitude scores (`-2` / `+2`) on policies flagged **most important**;
+- include a `?` point where the gap is material — it carries the "do not determine yet" ask;
+- drop `0`s, and drop `-1`s on peripheral policies. Filler dilutes; a short letter making three
+  policy points well beats a long one making eleven.
+- prefer **development plan** policies to national or emerging ones. Where the plan carries the
+  point, national policy is support, not the lead — and an emerging policy leads only where
+  nothing adopted covers the matter, with its limited weight stated.
+
+### Step 3 — Build each point
+One point per numbered section, each with the same anatomy (see
+[`references/house-style.md`](references/house-style.md)):
+
+1. **The conclusion as the heading** — "The proposal conflicts with Policy `[ref]`…" or "The
+   proposal accords with Policy `[ref]`…".
+2. **The policy requirement, quoted**, with the plan name and adoption date.
+3. **The fact, from the application's own documents** — quoted, with the document, author, date
+   and paragraph or drawing reference.
+4. **The conclusion, reasoned** — why the fact does or does not satisfy the requirement.
+5. **The ask**, if the point carries one.
+
+### Step 4 — Answer the other side
+- **In objection:** acknowledge the policies the scheme complies with and the benefits it
+  claims, then explain why the conflicts nevertheless outweigh them. Where a benefit is
+  unsecured or unquantified, say so — with the applicant's own document quoted.
+- **In support:** acknowledge the principal objections and the conflicts the analysis found,
+  then explain why they are outweighed, are matters of detail, or can be secured by condition.
+  Support that engages with the objections is far more useful to a case officer than support
+  that does not.
+
+Frame both against the statutory starting point — determination in accordance with the
+development plan unless material considerations indicate otherwise — and take the current
+citations, including whether the presumption in national policy is engaged, from the
+**national-planning-policy** skill. Do not cite an NPPF paragraph number that has not been
+verified at run time.
+
+### Step 5 — State the ask
+The ask must be one the analysis can carry, and consistent with **planning-balance** where it
+has run:
+
+| Stance | Available asks |
+|---|---|
+| **Support** | Grant permission · grant subject to specified conditions or obligations securing the benefits relied on |
+| **Objection** | **Refuse**, where the analysis shows demonstrated conflict (A) · **do not determine yet**, where material policy requirements cannot be assessed on the submitted evidence (B) · **grant only subject to specified conditions**, where the point is resolvable (C) |
+
+Conditions and obligations asked for must themselves be capable of meeting the statutory tests
+— take those from the **national-planning-policy** skill. Over-asking (refusal where a
+condition would plainly do) weakens the whole representation.
+
+### Step 6 — Draft
+Draft to [`references/house-style.md`](references/house-style.md) and the matching skeleton in
+[`references/representation-templates.md`](references/representation-templates.md): header →
+RE line → opening (consultation status, stance, request to be placed on the file) → the policy
+framework as a short bulleted list → numbered points → the other side answered → numbered
+**summary of requests** → the stance sentence → sign-off.
+
+### Step 7 — Check before sending
+- Every policy quoted is from the **adopted** document, with its name, adoption date and
+  reference — and matches the analysis.
+- Every fact is quoted from an application document, correctly referenced.
+- No point overstates its score; no `?` is written as demonstrated; no `-1` is written as a
+  breach.
+- The other side is acknowledged and answered.
+- The stance, the points and the ask are consistent with each other.
+- Any **interest is declared**; the text is in the user's own words, not a form letter.
+- The ask is concrete, correctly timed ("before determination"), and passes the conditions and
+  obligations tests where it asks for them.
+- Any NPPF/PPG citation has been verified at run time against the current edition.
+- The **submission route and deadline** are given to the user.
+- **Hand back to a human, with the two warnings:** the draft must be read and checked, and
+  submitting it puts a **public document in the user's name** on the council's portal.
+
+## Reference files
+
+- [`references/house-style.md`](references/house-style.md) — how a strong policy-led
+  representation reads, in either stance: voice, structure, the anatomy of a policy point, and
+  the moves specific to support and to objection.
+- [`references/representation-templates.md`](references/representation-templates.md) — two
+  skeletons (objection and support) with condensed, annotated worked examples.
+
+## Scope and limitations
+
+- **Not legal advice, and no warranty.** A drafting aid for a lay representation; not a
+  substitute for a solicitor or a planning consultant; guarantees no outcome; provided "as is".
+- **Human review is necessary before submitting.** A person must check every quotation, policy
+  reference and figure against the actual documents.
+- **A UK planning representation is a public document in the submitter's name** — normally
+  published on the council's portal and kept on the record. Include only personal details the
+  user is content to make public.
+- **England-focused.** The policy framework cited is England's; flag and adjust elsewhere.
+- **Evidence-bound and stance-honest.** The user chooses the stance; the skill does not bend
+  the evidence to it, and says so when the two do not match.
+- **"The policies don't support the letter you want" is a valid, valuable output** — as is
+  advising a narrower stance than the one requested.

--- a/policy-representation/references/house-style.md
+++ b/policy-representation/references/house-style.md
@@ -1,0 +1,120 @@
+# House style — how a strong policy-led representation reads
+
+The goal is a representation a busy case officer can act on: **concise, specific, evidenced,
+and easy to lift into the officer report.** These are the writing rules applied at the drafting
+stage. They match the other representation skills in this repo, with the policy-led and
+support-specific moves flagged.
+
+## Voice and stance
+
+- **Measured, specific, and framed in policy.** The force comes from the plan's own words set
+  against the application's own documents — not from adjectives. "The scheme is unacceptable" is
+  an opinion; "Policy `[ref]` permits development outside the settlement boundary only where
+  (a)–(e) apply, and the Planning Statement engages none of them" is an argument.
+- **One voice, either stance.** A letter of support is written to the same standard as an
+  objection: policies quoted, facts referenced, the contrary case answered. Support that reads
+  as enthusiasm carries no weight; support that resolves a policy question for the officer does.
+- **Concede what is true.** In objection, say which policies the scheme complies with. In
+  support, say where the analysis found conflict and why it does not defeat the scheme. A
+  representation that only argues one way reads as advocacy and is discounted accordingly.
+- **Material considerations only.** Policy compliance, the evidence base, the effects the plan
+  addresses. Not property values, not a private view, not the applicant's identity or motives,
+  not competition with an existing business.
+- **Never overstate the analysis.** A tension is a tension; a gap in the evidence is a gap, not
+  a breach. The credibility of the strong points depends on the weak ones being described
+  accurately.
+
+## The policy-led spine
+
+- **The development plan leads.** Open on the statutory starting point — determination in
+  accordance with the development plan unless material considerations indicate otherwise — and
+  make the adopted plan's policies the backbone. National policy supports the point; it does not
+  usually lead it.
+- **Quote the policy, then the document.** Requirement first, fact second, conclusion third. The
+  officer can then verify both in seconds.
+- **Name the plan and its adoption date** the first time you cite it, so every reference is
+  unambiguous — plans are replaced, and saved policies from earlier plans are common.
+- **Lead with the most important policies.** The spatial strategy or settlement-boundary policy,
+  the site's allocation or designation, and the principal topic policies decide applications;
+  parking standards and refuse storage do not.
+- **Weight, honestly signalled.** If a policy is out-of-date, or a plan is only emerging, say so
+  and say what weight it should carry. Claiming full weight for an emerging policy is the
+  quickest way to lose the reader.
+- **Distinguish the three asks.** Demonstrated conflict → refusal. A policy requirement that
+  cannot be assessed on the submitted evidence → do not determine yet. A resolvable point →
+  the specific condition. Mixing them up is the most common failure in lay representations.
+
+## Structure
+
+1. **Header block**; **RE line** (application reference and site); **opening** — consultation
+   status, the stance in one sentence, the request that the representation be placed on the
+   file, and any **declaration of interest**.
+2. **Framework list** — a short **bulleted** list of the development plan documents and the
+   policies engaged, with national policy noted separately and at lower weight.
+3. **Numbered sections** — one policy point per numbered sub-section, each a **bold conclusion
+   heading** then one to three tight paragraphs.
+4. **The other side** — a short section acknowledging and answering the contrary case.
+5. **Summary of requests** — numbered and concrete.
+6. **Stance sentence** + sign-off.
+
+## Each point: the anatomy
+
+1. **State the conclusion in the heading** — naming the policy.
+2. **Quote the policy requirement**, with the plan name, adoption date and policy reference.
+3. **Quote or cite the application's own document** for the fact — document, author, date, and
+   the paragraph or drawing number.
+4. **Reason the conclusion** — why the fact does or does not satisfy the requirement, including
+   any exception limb relied on and why it does or does not apply.
+5. **State the ask** on a **Request:** line, with its timing.
+
+## Formatting discipline (keep it scannable)
+
+- **Shorter is stronger.** One point per paragraph; short sentences in preference to long ones
+  chained with semicolons.
+- **Break dense material out — don't run it into prose.**
+  - list the policies engaged, the criteria failed, or the missing documents as a **bulleted
+    list**;
+  - use **bold lettered sub-points** `(a)/(b)` for multi-limb policy tests and criterion-based
+    policies;
+  - present the framework list as bullets.
+- **Quote policy wording in italics or quotation marks**, and never paraphrase a requirement you
+  are relying on.
+- Bold each heading as a conclusion; end each point that carries one with a **Request:** line.
+- British spelling and a plain, formal register. Spell out an acronym once (NPPF, SPD, LPA).
+
+## Objection-specific moves
+
+- **Lead with the policy the proposal most clearly fails**, especially where it is a strategic
+  or settlement-boundary policy — a conflict there can be decisive on its own.
+- **Work through the exception limbs** of any restrictive policy and show why none applies. A
+  bare assertion of conflict invites the reply that limb (c) is met.
+- **Where the evidence is missing, argue the absence as such** — the Council cannot conclude
+  compliance with the policy, therefore the application should not be determined yet. Do not
+  dress it up as demonstrated harm.
+- **Engage the benefits.** Note where a claimed benefit is unquantified, unsecured, or already
+  required by policy, quoting the applicant's document.
+
+## Support-specific moves
+
+- **Be specific about what the scheme delivers, in policy terms.** "It provides `[n]` homes,
+  of which `[x]`% affordable, meeting the requirement of Policy `[ref]`" is worth more than any
+  amount of general approval.
+- **Answer the objections that have actually been made** where they are visible on the portal,
+  and the conflicts the analysis found — briefly, and on policy grounds.
+- **Ask for conditions that secure the benefits you are relying on.** Supporting a scheme
+  because of its affordable housing or public open space, while asking that both be secured, is
+  a stronger and more useful letter than unconditional support.
+- **Declare any interest** — applicant, agent, relative, employee, prospective purchaser,
+  competitor, or campaign involvement.
+- **Do not submit a circulated template.** Identical letters are recognised and discounted; the
+  letter should be in the writer's own words and on their own knowledge of the site.
+
+## What to leave out
+
+- Anything you cannot evidence from the plan or the application documents.
+- Non-material concerns — property values, loss of a private view, competition, the applicant's
+  identity, boundary or covenant disputes.
+- Policy references carried from memory, from a draft plan, or from a superseded plan.
+- An NPPF paragraph number that has not been verified against the current edition at run time.
+- Campaign- or consultant-specific framing — argue each point on this application's own facts.
+- Personal detail the user is not content to see published.

--- a/policy-representation/references/representation-templates.md
+++ b/policy-representation/references/representation-templates.md
@@ -1,0 +1,281 @@
+# Representation templates — objection and support
+
+Two **skeletons** to fill, and a condensed **worked example** of each showing the house style in
+practice. Match the examples' density, tone and layout — but every policy, quotation and figure
+must come from the adopted plan and the application documents in front of you. All references in
+square brackets are placeholders.
+
+---
+
+## Skeleton A — objection
+
+```
+[Your name]
+[Your address]
+[Email]
+
+[Date]
+
+[Planning department / Council name / address]
+[For the attention of [Case Officer], if known]
+
+RE: Application [ref] — [site address]
+[One-line description of the proposal]
+
+Dear [Sir or Madam / Mr/Ms Name],
+
+REPRESENTATION ON PLANNING POLICY GROUNDS — OBJECTION
+
+[Opening: that you are responding to the consultation; that you object; the request that this
+representation be placed on the application file. Any declaration of interest.]
+
+[The statutory starting point: the application falls to be determined in accordance with the
+development plan unless material considerations indicate otherwise. Name the development plan
+documents and their adoption dates.]
+
+The policies principally engaged are: [short bulleted list — the adopted plan policies, with
+national policy noted separately and at lower weight].
+
+## 1. [Conclusion naming the policy]
+[Quote the policy requirement. Quote the application document. Reason the conclusion. Request.]
+
+## 2. [Next point]
+…
+
+## [Matters relied on by the applicant]
+[Acknowledge the policies complied with and the benefits claimed; explain why the conflicts
+nevertheless outweigh them.]
+
+## Summary of requests
+[Numbered, concrete, each correctly timed.]
+
+For these reasons the proposal does not accord with the development plan read as a whole, and
+I object to the grant of planning permission.
+
+Yours [sincerely/faithfully],
+[Name]
+```
+
+---
+
+## Skeleton B — support
+
+```
+[Your name]
+[Your address]
+[Email]
+
+[Date]
+
+[Planning department / Council name / address]
+[For the attention of [Case Officer], if known]
+
+RE: Application [ref] — [site address]
+[One-line description of the proposal]
+
+Dear [Sir or Madam / Mr/Ms Name],
+
+REPRESENTATION ON PLANNING POLICY GROUNDS — SUPPORT
+
+[Opening: that you are responding to the consultation; that you support the application; the
+request that this representation be placed on the application file.]
+
+[Declaration of interest — state plainly if you are the applicant, their agent, a relative,
+an employee, a prospective purchaser, a competitor, or writing as part of a campaign. If you
+have no interest, a single sentence saying so is worth including.]
+
+[The statutory starting point: determination in accordance with the development plan unless
+material considerations indicate otherwise. Name the development plan documents and dates.]
+
+The policies principally engaged are: [short bulleted list, as above].
+
+## 1. [Conclusion naming the policy the scheme accords with]
+[Quote the policy requirement. Quote the application document showing it is met. Reason the
+conclusion. Any condition needed to secure it.]
+
+## 2. [Next point]
+…
+
+## [Objections and conflicts, answered]
+[Acknowledge the principal objections and any policy conflict the analysis found; explain why
+they are outweighed, are matters of detail, or can be secured or resolved by condition.]
+
+## Summary of requests
+[Numbered — normally that permission be granted, and the conditions that should secure the
+benefits relied on.]
+
+For these reasons the proposal accords with the development plan read as a whole, and I
+support the grant of planning permission[, subject to the conditions set out above].
+
+Yours [sincerely/faithfully],
+[Name]
+```
+
+---
+
+## Worked example A — objection (condensed; annotations in ⟨…⟩)
+
+> ⟨Header, RE line and opening omitted — see the skeleton. The opening states the stance in one
+> sentence and asks that the representation be placed on the file.⟩
+
+This application falls to be determined in accordance with the development plan unless material
+considerations indicate otherwise. The development plan comprises the **[Plan name]** (adopted
+**[date]**) and the **[Neighbourhood Plan name]** (made **[date]**). ⟨Name and date the plan —
+it makes every later reference unambiguous.⟩
+
+**The policies principally engaged are:** ⟨a bulleted list, not a semicolon-run⟩
+
+- Policy `[ref]` — development outside defined settlement boundaries;
+- Policy `[ref]` — design and local character;
+- Policy `[ref]` — biodiversity net gain;
+- Policy `[ref]` of the Neighbourhood Plan — `[local character / protected view]`;
+- national policy (NPPF) as a material consideration, at less weight than the adopted plan.
+
+### 1. Conflict with Policy `[ref]`: development outside the settlement boundary, no exception engaged
+⟨Lead with the strategic conflict — it can be decisive on its own.⟩
+
+Policy `[ref]` provides that *"development outside the defined settlement boundaries will not be
+permitted unless it falls within one of the exceptions at (a) to (e)"*. The site lies wholly
+outside the boundary shown on the adopted policies map. The Planning Statement (`[author]`,
+`[date]`, §`[x]`) relies on exception **(c)**, which applies only to `[the exception's terms]`;
+the proposal is not `[that]`, and no other exception is engaged. **Request:** that the
+application be refused as contrary to Policy `[ref]`.
+
+### 2. Conflict with Policy `[ref]`: scale and form not responsive to local character
+⟨A criterion-based policy — identify the criterion.⟩
+
+Policy `[ref]` requires proposals to *"respond to the character of the area in scale, form and
+materials"*. The submitted elevations (drawing `[no.]`, rev `[x]`) show a three-storey frontage
+on a street of two-storey dwellings; the Design and Access Statement (§`[x]`) addresses
+materials but not scale. Criterion `[(b)]` is therefore not met. **Request:** that the scale of
+the frontage be reduced to two storeys, or the application refused as contrary to Policy
+`[ref]`.
+
+### 3. Compliance with Policy `[ref]` (biodiversity) cannot presently be assessed
+⟨An evidence gap, argued as a gap — not as demonstrated harm.⟩
+
+Policy `[ref]` requires development to *"deliver a measurable net gain in biodiversity"*. No
+biodiversity metric or ecological appraisal has been submitted, so the Council has nothing
+against which to test the policy's requirement. This is not an assertion that the scheme fails
+the policy; it is that compliance cannot be concluded on the material before the Council.
+**Request:** that the application **not be determined** until a completed biodiversity metric
+and ecological appraisal have been submitted and consulted upon.
+
+### Matters relied on by the applicant
+⟨Engage the other side — this is what makes the rest credible.⟩
+
+I accept that the scheme complies with the adopted parking standards and with Policy `[ref]`
+on `[matter]`, and that it would deliver `[n]` dwellings, which carries weight. The affordable
+housing relied on at §`[x]` of the Planning Statement is not, however, secured by any
+completed obligation, and the economic benefits at §`[x]` are asserted without quantification.
+Neither outweighs a conflict with the plan's spatial strategy, which Policy `[ref]` exists to
+deliver.
+
+### Summary of requests
+
+1. That the application be **refused** as contrary to Policies `[ref]` and `[ref]` of the
+   `[Plan name]`;
+2. Alternatively, if the Council is minded to approve, that the frontage scale be reduced to
+   two storeys by condition;
+3. That the application **not be determined** until a biodiversity metric and ecological
+   appraisal are before the Council and have been consulted upon;
+4. That any affordable housing relied on be secured by a completed obligation before permission
+   is issued.
+
+For these reasons the proposal does not accord with the development plan read as a whole, and I
+object to the grant of planning permission.
+
+Yours faithfully,
+`[Name]`
+
+---
+
+## Worked example B — support (condensed; annotations in ⟨…⟩)
+
+> ⟨Header, RE line and opening omitted — see the skeleton.⟩
+
+I am writing in support of this application. I have no interest in the application or the site
+beyond living at the address given above. ⟨Declare the interest, or its absence, in one
+sentence — it is the first thing a reader wonders about a support letter.⟩
+
+The application falls to be determined in accordance with the development plan unless material
+considerations indicate otherwise. The development plan comprises the **[Plan name]** (adopted
+**[date]**).
+
+**The policies principally engaged are:** Policy `[ref]` (housing allocation for this site),
+Policy `[ref]` (affordable housing), Policy `[ref]` (design and local character), and Policy
+`[ref]` (open space provision).
+
+### 1. The proposal delivers the site's allocation under Policy `[ref]`
+⟨Lead with the strongest positive — accordance with an allocation is about as strong as support
+gets.⟩
+
+The site is allocated for residential development by Policy `[ref]`, which identifies an
+indicative capacity of `[n]` dwellings and requires `[the allocation's requirements]`. The
+proposal is for `[n]` dwellings and the Planning Statement (`[author]`, `[date]`, §`[x]`)
+demonstrates each of the allocation's requirements is addressed: `[list briefly]`. The proposal
+is therefore the development the plan envisaged on this site.
+
+### 2. The affordable housing exceeds the requirement of Policy `[ref]`
+⟨Specific, quantified, and tied to the policy — with the securing point made.⟩
+
+Policy `[ref]` requires `[x]`% affordable housing on schemes of `[n]` dwellings or more. The
+scheme offers `[y]`%, above the policy requirement, in the tenure split sought by the policy
+(Planning Statement §`[x]`). **Request:** that this be secured by a completed obligation, so
+that the benefit I rely on in supporting the application is delivered.
+
+### 3. The design responds to local character as Policy `[ref]` requires
+⟨Support on a design policy needs to be as evidenced as an objection would be.⟩
+
+Policy `[ref]` requires proposals to respond to the character of the area in scale, form and
+materials. The street elevations (drawing `[no.]`) show a two-storey frontage matching the
+prevailing height, and the materials schedule at §`[x]` of the Design and Access Statement uses
+`[materials]`, consistent with the `[local]` palette described in the policy's supporting text.
+
+### Objections and conflicts, answered
+⟨The section that distinguishes a useful support letter from a useless one.⟩
+
+I am aware that objections have been made on `[traffic / parking]` grounds, and that a
+`[shortfall against the open space standard in Policy [ref]]` has been identified. On the
+first, the Transport Statement (§`[x]`) shows the access geometry meets the adopted standard and
+the highway authority has raised no objection. On the second, the shortfall is `[extent]` and
+Policy `[ref]` itself allows for a commuted sum where on-site provision is not practicable;
+that is a matter capable of resolution by obligation rather than a reason to refuse a scheme
+that delivers an allocated site.
+
+### Summary of requests
+
+1. That planning permission be **granted**;
+2. That the affordable housing at `[y]`% and the tenure split be secured by a completed
+   obligation before permission is issued;
+3. That the materials and boundary treatments shown in the Design and Access Statement be
+   secured by condition;
+4. That any open space shortfall be addressed by a commuted sum under Policy `[ref]`.
+
+For these reasons the proposal accords with the development plan read as a whole, and I support
+the grant of planning permission, subject to the conditions and obligations set out above.
+
+Yours faithfully,
+`[Name]`
+
+---
+
+## Notes on adapting the examples
+
+- **Lead with the most important policy** — the spatial strategy or settlement-boundary policy,
+  or the site's allocation. Detailed standards belong further down or not at all.
+- **Three to six points.** Both examples make three and answer the other side. A longer letter
+  is usually a weaker one.
+- **Keep the three asks distinct** — refusal for demonstrated conflict, "do not determine yet"
+  for an unassessable policy requirement, and a condition where the point is resolvable. Example
+  A deliberately does all three, on different points.
+- **Support letters carry the declaration of interest and the "objections answered" section.**
+  Without them a support letter is easy to discount.
+- **Do not submit either example as a form letter.** Rewrite in the user's own words, on the
+  facts of the application in front of them; circulated identical letters are recognised and
+  given little weight.
+- **Before submitting:** a person must read and check the draft — every policy quotation against
+  the adopted plan, and every figure against the application documents — and be aware the
+  representation is normally **published on the council's portal in the submitter's name** and
+  kept on the record, so it should contain only personal details the user is content to make
+  public. This is a draft aid provided with no warranty; it is not legal advice.


### PR DESCRIPTION
## What this adds

Two new skills plus wiring into the existing chain:

- **`policy-compliance-assessment`** — the policy stage between triage and drafting: identify and verify the adopted development plan (gated first step, with its own reference file), select relevant policies, assess each on quoted wording vs the application documents, score accordance -2..+2 with `?`/A/B/C flags, and conclude on the plan read as a whole (no aggregation). Three reference files: finding the development plan, scoring rubric, policy families.
- **`policy-representation`** — drafts the representation from that assessment (house style + templates).
- Wiring updates to `application-triage`, `planning-balance`, `national-planning-policy`, `commands/planning-object`, and the README.

## Benchmark evidence

The compliance skill was blind-tested against five decided applications (one committee-decided major, one appealed major, three delegated householder schemes) — assessed as new applications with the officer report, decision notice and appeal papers withheld, then compared against the real decisions:

- **5/5 outcome matches** on every compared run (refuse ×2, grant ×2, plus a repeat run for stability), with the operative policy sets matching the officers' and no false-positive conflicts.
- Divergences found by the comparisons were fed back as two calibration commits on this branch:
  - **Designated-area scoring uplift** (0.1.1) — score conservation-area character/scale conflicts at full strength, cumulative change measured off the drawings. Validated out-of-sample on a case that played no part in the calibration (matched a single-issue refusal on exactly those policies).
  - **Seven Step-4 evidence disciplines** (0.1.2) — openings audit, history sweep + fallback delta assessment, neighbour-relative amenity geometry, multi-source site facts incl. council GIS, representations sweep, consultees as evidence not conclusions, condition-vs-refusal discipline.

## Also in this PR

- **`national-planning-policy` edition register updated for the NPPF republished 17 August 2026** (coded-policies restructuring, verified on gov.uk). The register now warns that all stored paragraph numbers are stale pending the repo-wide re-mapping tracked in #16, and adds the rule that past decisions are read against the edition in force at determination.

## Review notes

- Benchmark work products (assessments, downloaded application documents) are deliberately not in the repo, per house rule 7.
- Known follow-ups, not blocking: #16 (NPPF re-mapping); Mid Sussex portal registry entry for `planning-document-search` (vendor was detected by hand during the benchmark: Idox Public Access at pa.midsussex.gov.uk with documents on an NEC host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)