### PR TITLE
README: Super Quick Start points readers at the prompt examples below

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Open ChatGPT / Claude / Gemini or other general purpose AI tool and type:
 Read the UK planning skills at https://github.com/SeagullTwo/uk-planning-skills.
 ```
 
+**You can find more prompt examples below — see [How to use](#how-to-use).**
+
 A small collection of skills for working with the UK planning system, each self-contained
 in its own folder with a `SKILL.md`, a `README.md`, and supporting reference files.
 


### PR DESCRIPTION
Follow-up to #18 (this commit just missed that merge): adds a bold line to the Super Quick Start Guide directly under the opening prompt —

> **You can find more prompt examples below — see [How to use](#how-to-use).**

— so a reader landing on the quick start finds the staged prompts and worked examples without scrolling blind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)