### PR TITLE
README: drop Gemini from the quick-start list; note tested tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## The Super Quick Start Guide
 
-Open ChatGPT / Claude / Gemini or other general purpose AI tool and type:
+Open ChatGPT / Claude or other general purpose AI tool and type:
 
 ```text
 Read the UK planning skills at https://github.com/SeagullTwo/uk-planning-skills.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Read the UK planning skills at https://github.com/SeagullTwo/uk-planning-skills.
 
 **You can find more prompt examples below — see [How to use](#how-to-use).**
 
+*We test with Claude and ChatGPT; other tools may work.*
+
 A small collection of skills for working with the UK planning system, each self-contained
 in its own folder with a `SKILL.md`, a `README.md`, and supporting reference files.
 


### PR DESCRIPTION
Two quick-start commits that just missed the #19 merge:

- Drop Gemini from the tool list — it doesn't fetch and follow the repo out of the box the way ChatGPT and Claude do.
- Add the expectations note beneath the quick-start prompt: *"We test with Claude and ChatGPT; other tools may work."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)