### PR TITLE
Enforce the bullet discipline in the assessment/triage/balance skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,16 @@ Repo root also has a top-level `README.md` and `LICENSE`.
 8. **Freshness.** Portals migrate and guidance editions turn over. Re-resolve/re-verify at
    run time; note verification dates in the reference files, not as a coverage boast.
 
+9. **Output style: bullets, not semicolon-runs.** Every skill that produces a report,
+   summary or representation must instruct its output style, and the instruction must
+   demonstrate it: enumerations of three or more items go in a bulleted or numbered list,
+   never strung through a paragraph (or a table cell) with semicolons; one point per
+   paragraph, paragraphs short. The representation skills carry this in
+   `references/house-style.md`; analysis skills state it in their output-format section.
+   When writing a skill's output instructions, don't pack the required elements into a
+   single prose sentence — the model mirrors the register of its instructions, so an
+   instruction written as a semicolon-run produces output written as semicolon-runs.
+
 ## CHANGELOG format
 
 Each skill's `CHANGELOG.md` follows this shape. Newest entry on top. Each entry is dated

--- a/application-triage/CHANGELOG.md
+++ b/application-triage/CHANGELOG.md
@@ -7,6 +7,14 @@ intent.
 ## Unreleased
 
 ### Changed
+- **Step 6's hand-off summary rewritten as a bulleted spec (#22): ranked grounds each on
+  their own line, non-material concerns as a short list with reasons, or the plain
+  no-strong-ground statement — with an explicit ban on stringing grounds through a prose
+  paragraph with semicolons.** _Why:_ the old instruction ("Tell the user: the grounds …,
+  which skill …, the non-material concerns …, and …") was a colon-enumeration in a single
+  sentence, and outputs mirrored that register. The bullet discipline the representation
+  skills carry in `references/house-style.md` now applies to this skill's summary too
+  (repo house rule 9 in `../CLAUDE.md`).
 - **Re-mapped to the August 2026 coded NPPF (verified against the official PDF, 18 August
   2026): the "tilted balance" framing is gone.** Step 2 now describes the presumption as the
   location-based S3–S6 scheme (within-settlement S4 vs the outside-settlement S5 categories,

--- a/application-triage/SKILL.md
+++ b/application-triage/SKILL.md
@@ -159,10 +159,16 @@ Recommend an order (lead with the decision-critical grounds). Note where two ski
 both run (a scheme often engages several).
 
 ### Step 6 — Hand off / summarise
-Tell the user: the grounds worth objecting on (ranked, each anchored to the development-plan
-policies it engages and classified A/B/C), which skill will draft each, the non-material
-concerns to drop, and — if that's the honest answer — that there is no strong ground and an
-objection would not be sustainable.
+Give the user a summary they can scan, not a paragraph. Present:
+
+- the **grounds worth objecting on** — a ranked list, each ground on its own line with the
+  development-plan policies it engages, its A/B/C class, and the skill that will draft it;
+- the **non-material concerns to drop**, as a short list with the one-line reason each;
+- or — if that's the honest answer — a plain statement that there is no strong ground and an
+  objection would not be sustainable.
+
+Any enumeration of three or more items goes in a bulleted or numbered list; never string
+grounds, policies or asks through a prose paragraph with semicolons.
 
 ## Reference files
 

--- a/planning-balance/CHANGELOG.md
+++ b/planning-balance/CHANGELOG.md
@@ -7,6 +7,14 @@ intent.
 ## Unreleased
 
 ### Changed
+- **The Step 4 balance-statement instruction restructured to enforce the bullet discipline
+  (#22): framework sentence → harms as weighted bullets (when more than two) → benefits
+  sentence → conclusion-and-ask sentence, replacing "a paragraph, two at most" followed by
+  a four-item enumeration.** _Why:_ the old instruction was itself a semicolon-run
+  packing four required elements into one prescribed paragraph, and outputs mirrored it —
+  the representation skills' house-style discipline ("a bulleted list, not a
+  semicolon-run") never reached this skill. The instruction now demonstrates the format it
+  wants (repo house rule 9 in `../CLAUDE.md`).
 - **Step 1 re-mapped to the August 2026 coded NPPF (verified against the official PDF,
   18 August 2026): the "tilted balance" bullet replaced by the location-based presumption.**
   The governing-framework step now runs plan-led (S3(1)(c), with the Annex A(2) very-limited-

--- a/planning-balance/SKILL.md
+++ b/planning-balance/SKILL.md
@@ -152,11 +152,17 @@ One of four honest outcomes, driving what the representation requests:
 4. **The balance favours approval** — say so, and advise not objecting (or a short
    representation supporting conditions only).
 
-Output a **short balance statement** (a paragraph, two at most) the user can lift into the
-representation's opening or closing: the framework that governs, the decisive harms with
-their weights, the benefits acknowledged, and the conclusion with the ask. Then hand back
-to a human with the standard warnings: **review before use, and anything submitted is
-normally published on the council's portal in the submitter's name.**
+Output a **short balance statement** the user can lift into the representation's opening or
+closing. Structure it — don't run it into one long paragraph:
+
+- **one sentence** naming the framework that governs (s.38(6) and the operative test);
+- the **decisive harms, each with its weight** — as short bullets if there are more than
+  two, never chained through a paragraph with semicolons;
+- **one sentence** acknowledging the benefits and the weight they carry;
+- **one sentence** with the conclusion and the ask.
+
+Then hand back to a human with the standard warnings: **review before use, and anything
+submitted is normally published on the council's portal in the submitter's name.**
 
 ## Scope and limitations
 

--- a/policy-compliance-assessment/CHANGELOG.md
+++ b/policy-compliance-assessment/CHANGELOG.md
@@ -6,6 +6,17 @@ rules. The **_Why_** lines record the rationale so a future editor understands t
 ## Unreleased
 
 ### Changed
+- **Step 7 and the output format rewritten to enforce the bullet discipline (#22): the
+  accordance statement is now a conclusion sentence + supporting bullets + what-follows
+  sentence instead of "a paragraph or two"; the policy-table assessment cell is capped at
+  one or two short sentences with overflow as a bulleted note below the table; and an
+  explicit output-style rule added.** _Why:_ the drafting discipline enforced on the
+  representation skills (see transport-representation's changelog) never reached this
+  skill, and its own instruction — five required elements packed into one prescribed
+  paragraph — modelled exactly the long semicolon-run style it produced: in ten benchmark
+  reports, the semicolon-run offenders clustered in the accordance statement and the
+  policy-table cells this skill prescribes. The instruction must demonstrate the format it
+  wants (now also repo house rule 9 in `../CLAUDE.md`).
 - **Re-mapped to the August 2026 coded NPPF (verified against the official PDF, 18 August
   2026): Step 2's plan-status mechanics rebuilt around Annex A(2)/(3).** The "tilted
   balance engaged or disapplied" framing is removed — the presumption is now location-based

--- a/policy-compliance-assessment/SKILL.md
+++ b/policy-compliance-assessment/SKILL.md
@@ -264,13 +264,19 @@ carry **less weight than the adopted plan**:
   supplements plan policy; it cannot create policy the plan does not contain.
 
 ### Step 7 — Conclude on the plan read as a whole
-Write a short **accordance statement** (a paragraph or two): the plan documents that govern,
-the policies the proposal conflicts with and how seriously, the policies it accords with, the
-matters that cannot yet be assessed, and a reasoned conclusion on whether the proposal
-accords with the development plan **read as a whole** — with no arithmetic. Then say what
-follows: whether material considerations (national policy, emerging policy, the scheme's
-benefits) might indicate a decision otherwise than in accordance with the plan, and hand off
-to **planning-balance** for that weighing and to **policy-representation** for drafting.
+Write the **accordance statement**. Open with **one sentence stating the conclusion** —
+whether the proposal accords with the development plan **read as a whole** (no arithmetic).
+Then support it with short bullets, not a run-on paragraph:
+
+- the plan documents that govern;
+- the policies conflicted with, each with a one-line severity;
+- the policies accorded with (a compact list is fine);
+- anything that cannot yet be assessed, and why.
+
+Close with **one sentence on what follows** — whether material considerations (national
+policy, emerging policy, the scheme's benefits) might indicate a decision otherwise than in
+accordance with the plan — and hand off to **planning-balance** for that weighing and to
+**policy-representation** for drafting.
 
 ## Output format
 
@@ -279,11 +285,20 @@ to **planning-balance** for that weighing and to **policy-representation** for d
    position; plan age and review position.
 3. **Policy table** — one row per policy: reference · source document · weight tier · quoted
    requirement · assessment (with the document evidence) · **score** · most-important flag ·
-   A/B/C.
+   A/B/C. **Keep the assessment cell to one or two short sentences.** If a policy needs more,
+   put the detail in a bulleted note *below* the table keyed to the policy reference — never
+   a semicolon-run inside the cell.
 4. **A second table** for national and emerging policy, marked as lower-weight material
-   considerations.
-5. **Accordance statement** — the reasoned whole-plan conclusion, no totals.
+   considerations. Same cell discipline.
+5. **Accordance statement** — conclusion sentence, supporting bullets, what-follows sentence
+   (Step 7); no totals.
 6. **Verification note** — what was checked, when, and what needs re-checking at run time.
+
+**Output style.** This report is read by busy people: any enumeration of three or more items
+goes in a bulleted or numbered list, never strung through a paragraph with semicolons. One
+point per paragraph; keep paragraphs to three sentences or fewer. The representation skills'
+`references/house-style.md` files state the same discipline for drafted representations —
+this skill's analysis output follows it too.
 
 ## Reference files
 


### PR DESCRIPTION
Closes #22.

## Problem

The bullet / lettered-sub-point drafting discipline enforced on the five representation skills (per-skill `references/house-style.md` + inline template reminders) never reached the analysis skills added later. Worse, three of them actively modelled the semicolon-run style: their output instructions packed four or five required elements into a single prose sentence and prescribed "a paragraph or two". A model mirrors the register of its instructions, so generated reports mirrored it back — in ten benchmark assessment reports, 15 of 65 prose paragraphs and ~20 policy-table cells were long semicolon-runs, clustered exactly in the sections these skills prescribe as prose.

## Changes

- **policy-compliance-assessment** — Step 7 accordance statement restructured: one conclusion sentence → supporting bullets (governing documents / conflicts with severity / accordances / cannot-assess) → one what-follows sentence. Policy-table assessment cells capped at 1–2 short sentences, overflow as a bulleted note below the table. Explicit output-style rule added to the output-format section.
- **planning-balance** — Step 4 balance statement restructured: framework sentence → decisive harms as weighted bullets (when more than two) → benefits sentence → conclusion-and-ask sentence.
- **application-triage** — Step 6 hand-off summary rewritten as a bulleted spec (ranked grounds each on their own line; non-material concerns as a short list with reasons; or the plain no-strong-ground statement).
- **CLAUDE.md** — new house rule 9 so future skills inherit the discipline, including the mechanism: don't write output instructions as semicolon-runs, because the instruction's own register is what gets imitated.
- **CHANGELOGs** — rationale recorded for all three skills per house rule 6.

The representation skills are untouched — their house-style files already carry the discipline and their outputs are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dg62ktGPUauVwt8qNuQHQ8