### PR TITLE
Add appeal-precedent-analysis skill with a 25-decision seed corpus

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ in its own folder with a `SKILL.md`, a `README.md`, and supporting reference fil
 | [`policy-compliance-assessment/`](policy-compliance-assessment/) | **Policy foundation.** Identify and verify the **adopted** development plan for the local planning authority (the council's own policies, which have primacy) — adoption dates, superseded/saved policies, the policies map — then assess the application policy by policy and score accordance from **-2** (significant conflict) to **+2** (strongly aligned), with `?` where the evidence submitted cannot answer the policy. NPPF/PPG and emerging plans assessed in a separate, lower-weight tier. |
 | [`policy-representation/`](policy-representation/) | Draft the representation from that analysis — **in support or in objection**, as you choose — each point anchored to a quoted adopted policy and the application's own documents, the other side answered, and a clear ask. Won't manufacture policy compliance or conflict to fit a stance. |
 | [`national-planning-policy/`](national-planning-policy/) | **Shared layer.** The current NPPF/PPG edition register with a verify-before-citing protocol, plus the decision-making core the other skills share — s.38(6) and the development plan's primacy, the presumption in favour of sustainable development (policies S3–S6 of the August 2026 coded NPPF: location-based — within/outside settlements — replacing the old para 11 "tilted balance"), emerging-plan weight, and the conditions/obligations tests. Includes a December 2024 → August 2026 crosswalk. |
+| [`appeal-precedent-analysis/`](appeal-precedent-analysis/) | Apply **decided appeal precedents** to the application: from a checked-in corpus of structured records extracted from published Inspectorate decisions, test whether a precedent genuinely applies (determinative finding, matching facts, still-current framework), grade its weight, surface adverse decisions, and draft the "the Inspector found Y because of Z — the same Z arises here" passage for the representation. |
 | [`planning-balance/`](planning-balance/) | **Final step.** The "so-what" test: anticipate the decision-maker's planning balance — governing framework, ground-specific gateways, harms vs benefits — and recommend what the representation should actually ask for (refusal, deferral for information, or conditions), or advise that the balance favours approval. |
 
 All England-focused. The skills chain:
@@ -47,7 +48,9 @@ All England-focused. The skills chain:
 4. a topic **representation** skill (`ecological-`, `transport-`, `heritage-`,
    `flood-representation`) which evaluates the technical evidence and drafts the objection;
 5. **`policy-representation`** drafts the policy case itself — in **support** or **objection**;
-6. **`planning-balance`** runs the final "so-what" test — whether the assembled case actually
+6. **`appeal-precedent-analysis`** reinforces the evidenced grounds with decided appeal
+   authority (or distinguishes the decisions the applicant relies on);
+7. **`planning-balance`** runs the final "so-what" test — whether the assembled case actually
    supports refusal, a request for further information, or conditions.
 
 (`national-planning-policy` sits under all of them as the shared NPPF/PPG layer.)

--- a/appeal-precedent-analysis/CHANGELOG.md
+++ b/appeal-precedent-analysis/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog — appeal-precedent-analysis
+
+Design decisions per revision, newest first. See `../CLAUDE.md` for the format and the
+house rules. The **_Why_** lines record the rationale so a future editor understands the
+intent.
+
+## Unreleased
+
+### Added
+- **Initial release: the skill, the comparability/weight reference, and a 25-record seed
+  corpus of June 2026 appeal decisions.** _Why:_ built off the back of a themes-and-bias
+  study of 1,505 June 2026 decision letters (200 read and coded in full). The study showed
+  precedents only move decision-makers under narrow conditions, and the skill encodes
+  those conditions rather than the naive "X decided Y, so Y" move.
+- **The workflow centres on a comparability test (the "Z-test"), not on citation.** _Why:_
+  the coded sample showed inspectors distinguish cited precedents almost by default ("I do
+  not have full details of these cases... before me"; "each decision is made on its
+  individual merits") — 12 of 60 allowed planning appeals in the sample expressly
+  distinguished a party's precedent. The one citation observed to receive "great weight"
+  was same-street, same-issue, same-policy, and quoted. So the skill tests
+  determinativeness, factual match on the operative conditions, framework currency, and
+  the available distinctions, before a citation is allowed out of the door.
+- **A mandatory adverse-precedent step.** _Why:_ the corpus itself contains near-mirror
+  pairs (informal-verge open space ✗ vs poor-quality open space ✓; substandard HMO rooms
+  ✗ vs standards-met HMO ✓). A representation citing only its half of a known pair invites
+  the officer to complete the pair; surfacing the adverse decision first is both honest
+  and tactically sound.
+- **Framework-currency field on every record, wired to the national-planning-policy
+  crosswalk.** _Why:_ every seed decision applied the December 2024 NPPF, which the
+  17 August 2026 edition replaced with coded policies — and some mechanisms changed
+  substantively (tilted balance → S3–S6). A precedent citing a superseded mechanism can
+  mislead; each record states what survives and what must be re-verified.
+- **Data layer is structured records, not decision letters; personal data minimised.**
+  _Why:_ repo rule 7 keeps downloaded documents out of the repo, and rule 2 puts
+  per-instance facts in data files. Records carry the public citation fields (reference,
+  date, LPA, site, outcome) and verbatim quotes with paragraph numbers, verified against
+  the letters on a stated date; appellant/agent/inspector names are omitted as unnecessary
+  to cite or verify a decision. The published letter remains the authority and the skill
+  requires re-verification before use.
+- **The consistency principle is stated with its authority (*North Wiltshire DC v SSE*
+  (1992) 65 P&CR 137), citation verified against published sources, with a ⏳ run-time
+  re-verification flag.** _Why:_ evidence-before-assertion (house rule 3); the case is the
+  standard consistency authority and the "or reasons given" limb is exactly the honest
+  form of the ask this skill drafts.
+- **Weight tiers (same site → same LPA/policy → same test → reasoning-only) with open
+  adjustments for recency, procedure, batches and subsequent history.** _Why:_ the study
+  found procedure correlates with scrutiny depth (inquiry 59% / hearing 52% / written reps
+  30% allowed — a selection effect, disclosed as such), and linked-batch decisions
+  masquerade as multiple concurring authorities (the Manchester advert batch); the tiers
+  make the claimed weight explicit and defensible.

--- a/appeal-precedent-analysis/LICENSE
+++ b/appeal-precedent-analysis/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ian Howard
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/appeal-precedent-analysis/README.md
+++ b/appeal-precedent-analysis/README.md
@@ -1,0 +1,49 @@
+# Appeal Precedent Analysis
+
+Find and apply relevant **planning appeal decisions** to a UK planning application, so a
+representation can argue: *"In appeal decision X, the Inspector found Y because of Z — the
+same Z is present here, so consistency in decision-making requires Y, or reasons for
+departing from it."*
+
+> **Not legal advice. No warranty.** Provided "as is"; **a human must verify every cited
+> decision against the published letter before use.** Anything submitted to a council is
+> normally published on its portal in the submitter's name.
+
+## What it does
+
+- Works from a **checked-in corpus of structured precedent records** (`precedents/`)
+  extracted from published Planning Inspectorate decision letters, plus any decision you
+  supply.
+- **Tests comparability** before citing: was the finding determinative, are the operative
+  facts present here, is the policy framework still the one the inspector applied, and
+  what will the other side use to distinguish it.
+- **Grades weight** (same site → same LPA/policy → same test elsewhere → reasoning only)
+  and surfaces **adverse precedents** honestly instead of hoping nobody finds them.
+- **Drafts the precedent passage** — citation, quoted finding with paragraph numbers,
+  evidenced parallel, consistency ask, pre-emption — for the representation skills to use.
+
+## Why the caution
+
+Appeal decisions are material considerations, not binding precedent. The governing
+principle is consistency (*North Wiltshire DC v SSE* (1992) 65 P&CR 137): like cases
+alike, or reasons given. In a coded sample of 200 June 2026 decision letters, inspectors
+distinguished party-cited precedents almost by default ("I do not have full details of
+that case before me") — while a directly comparable, properly quoted decision was called
+"a material consideration of great weight". This skill is built to produce the second
+kind of citation.
+
+## Contents
+
+| File | What it is |
+|---|---|
+| `SKILL.md` | The skill: the consistency principle, the six-step workflow, output format |
+| `references/comparability-and-weight.md` | The Z-test in detail, weight tiers, the adverse-precedent duty, drafting patterns |
+| `precedents/README.md` | Record schema, provenance/verification rules, personal-data policy, how to add records |
+| `precedents/INDEX.md` | One-line index of the corpus by topic |
+| `precedents/*.md` | The records — 25-seed corpus from June 2026 decisions (all under the December 2024 NPPF; every record carries a framework-currency note) |
+
+## Fits in the chain
+
+`application-triage` → `policy-compliance-assessment` → representation skills → **this
+skill** (strengthen the evidenced grounds with decided authority) → `planning-balance`.
+Also runs in reverse: to distinguish a decision the applicant or officer relies on.

--- a/appeal-precedent-analysis/SKILL.md
+++ b/appeal-precedent-analysis/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: appeal-precedent-analysis
+description: >-
+  Find and apply relevant planning appeal decisions to a UK planning
+  application, so a representation can say: "In appeal decision X, the
+  Inspector found Y because of Z — the same Z is present here, so consistency
+  in decision-making requires Y (or reasons for departing from it)." Works
+  from a checked-in corpus of structured precedent records extracted from
+  published Planning Inspectorate decision letters, tests each candidate
+  precedent for genuine comparability (same determinative issue, comparable
+  material circumstances, still-current policy framework), grades its weight,
+  surfaces adverse precedents honestly, and drafts the precedent passage for
+  the representation skills to use. Run after application-triage and
+  policy-compliance-assessment have identified the grounds.
+---
+
+# Appeal precedent analysis
+
+Use published appeal decisions as material considerations in a representation on a UK
+planning application — properly: tested for comparability, cited by reference with the
+decision's own words, and framed through the consistency principle rather than as binding
+precedent.
+
+> **Not legal advice. No warranty.** Provided "as is"; **a human must verify every cited
+> decision against the published letter before use.** Anything later submitted to a council
+> is normally published on its portal in the submitter's name.
+
+## The consistency principle (what a precedent is, legally)
+
+There is no doctrine of binding precedent in planning. A previous appeal decision is a
+**material consideration**, and the operative principle is consistency: in *North Wiltshire
+DC v Secretary of State for the Environment* (1992) 65 P&CR 137 (Mann LJ at 145), like cases
+should be decided in a like manner so that there is consistency in the appellate process —
+but the decision-maker must always exercise their own judgment, so a like case may be decided
+differently **provided reasons are given**. ⏳ Verify the citation at run time before quoting
+it in a submission.
+
+Two consequences drive everything below:
+
+- the persuasive form of the argument is **not** "X decided Y, therefore Y" — it is "X
+  decided Y because of Z; Z is present here; deciding differently without addressing X
+  would be inconsistent";
+- the argument only runs if the cases really are alike **on the point that decided X**, so
+  the work of this skill is the comparability test, not the citation.
+
+Inspectors' own practice confirms this (observed across a coded sample of 200 June 2026
+decision letters):
+
+- precedents cited without their full facts are dismissed almost as a reflex — "I do not
+  have full details of that case before me… each decision is made on its individual merits";
+- the precedents that carried weight — in one case "**a material consideration of great
+  weight**" — were directly comparable: same street or same site, same issue, same policies,
+  quoted from the decision itself;
+- councils' own precedent citations are distinguished just as readily, which cuts both ways:
+  expect the applicant to do to your precedent what you would do to theirs.
+
+## When to use
+
+- After **application-triage** and **policy-compliance-assessment** have established the
+  grounds and the governing policies, to reinforce a ground with decided authority.
+- When rebutting an applicant's (or council officer's) reliance on an appeal decision —
+  run the same comparability test in reverse to distinguish it.
+- When a **prior appeal exists on the appeal site itself or nearby** — always check: a
+  same-site decision is the strongest precedent there is, for either side.
+- Not useful before the grounds exist: a precedent cannot create a ground, only strengthen
+  one.
+
+## What you need first
+
+- The application's facts: proposal, site, constraints, the engaged policies (from
+  **policy-compliance-assessment**), and the ground the precedent should support.
+- The precedent corpus in [`precedents/`](precedents/) — structured records extracted from
+  published decision letters (see the schema in `precedents/README.md`), plus any decision
+  the user supplies directly.
+- The **national-planning-policy** skill's edition register and crosswalk
+  (`references/nppf-crosswalk-2026.md` there) — most stored precedents predate the
+  17 August 2026 coded NPPF and cite superseded paragraph numbers.
+
+## Workflow
+
+### Step 1 — Frame the target proposition
+State, in one sentence, what the representation needs a precedent **for**: the finding Y
+("a full-width box dormer is not subordinate"; "unsecured habitats mitigation bars
+permission") and the ground it supports. A precedent search without a target proposition
+returns noise.
+
+### Step 2 — Gather candidates
+Search the corpus by the frontmatter keys (issue tags, development type, outcome,
+constraint context), and check for:
+
+- decisions on the **appeal site itself** or in the same street/settlement (search the
+  council's portal and PINS records too — the corpus is a seed, not the universe);
+- decisions applying the **same policy or its close analogue** (same wording matters more
+  than same council);
+- decisions in **both directions** — collect adverse candidates now, not after drafting.
+
+### Step 3 — Test comparability (the Z-test)
+For each candidate, answer four questions from the record and, where it matters, the full
+decision letter. Details and worked examples: `references/comparability-and-weight.md`.
+
+1. **Was Z determinative in X?** The reasoning must have decided the appeal (or that issue),
+   not been an aside. A finding the inspector made *obiter*, or on an issue the appeal did
+   not turn on, persuades no one.
+2. **Is Z actually present here?** Match the *conditions* the record lists ("applies when"),
+   against the application's documents — not the vibe. If the inspector's reasoning relied
+   on a site fact (an unlit lane, a screened boundary, a failed marketing campaign), the
+   representation must show the same fact with its own evidence.
+3. **Is the framework still the one X applied?** Check the record's edition fields against
+   the **national-planning-policy** register. A precedent applying a superseded mechanism
+   (e.g. the pre-August-2026 "tilted balance") may survive as reasoning or may not survive
+   at all — the record's *framework currency* note says which; re-verify at run time.
+4. **What distinguishes this case from X?** List the differences the applicant (or officer)
+   will raise — the record's "distinguish when" bullets are the starting point. If a
+   difference goes to the reason Z operated, the precedent fails; say so and drop it.
+
+### Step 4 — Grade the weight
+Grade each surviving precedent so the representation leads with the strongest:
+
+- **Tier 1 — same site** (or a linked/adjoining site): the consistency principle at full
+  strength; a decision-maker departing from it must explain why.
+- **Tier 2 — same LPA, same policy, comparable context**: strong, especially if recent and
+  post-dating the current plan.
+- **Tier 3 — same policy wording or national test, elsewhere**: persuasive for how a test
+  is applied (e.g. what "subordinate" or "surplus open space" requires), not for outcome.
+- **Tier 4 — reasoning only**: use the logic without leaning on the citation.
+
+Recency, procedure (an inquiry decision tested evidence more thoroughly than written
+representations), and whether the decision has been judicially considered all adjust the
+grade — see `references/comparability-and-weight.md`.
+
+### Step 5 — Face the adverse precedents
+Search the corpus (and the same-site history) for decisions pointing the **other way** and
+deal with them in the representation, not in the hope no one finds them:
+
+- if distinguishable, distinguish them expressly, on the record's terms;
+- if not distinguishable, the ground is weaker than triage thought — report that honestly
+  back to the planning-balance step rather than suppressing it.
+
+### Step 6 — Draft the precedent passage and hand off
+Draft the passage for the representation skill that owns the ground (heritage, flood,
+transport, ecology, or policy-representation). The canonical shape:
+
+1. **the citation** — full published reference, decision date, and site, so the case can be
+   pulled up: "Appeal ref ⟨X⟩, ⟨site⟩, decision of ⟨date⟩";
+2. **the finding, in the decision's own words** — quote the operative sentences with their
+   paragraph numbers; never paraphrase what can be quoted;
+3. **the parallel, evidenced** — "the same ⟨Z⟩ arises here: ⟨this application's document,
+   paragraph/drawing⟩ shows ⟨fact⟩";
+4. **the consistency ask** — "consistency in decision-making requires the same conclusion,
+   or reasons for departing from it";
+5. **the pre-emption** — one or two sentences answering the obvious distinction before it
+   is made.
+
+Attach or link the full decision letter where the portal allows it — the observed failure
+mode is the inspector or officer discounting a precedent because its details were not
+before them.
+
+## Output format
+
+1. **Precedent match table** — one row per surviving candidate: reference · date · tier ·
+   the Y/Z proposition · the matching facts here · the distinctions to pre-empt. Keep each
+   cell to one or two short sentences; overflow goes in a bulleted note below the table
+   keyed to the reference.
+2. **Adverse precedent note** — what was found, and whether it is distinguished or
+   concessive; "none found" is stated, not implied.
+3. **Drafted precedent passages** — one per ground, in the five-part shape above, ready for
+   the representation skill.
+4. **Verification note** — which quotes were checked against which letters and when; which
+   records carry stale-framework flags needing run-time re-verification.
+
+**Output style.** Enumerations of three or more items go in a bulleted or numbered list,
+never strung through a paragraph with semicolons; one point per paragraph, paragraphs
+short (see repo house rule 9).
+
+## The precedent corpus (data layer)
+
+Per-decision records live in [`precedents/`](precedents/) — schema, sourcing rules and the
+personal-data policy are in `precedents/README.md`. The records are **analysis, not the
+decisions themselves**: every quote carries its paragraph number and a verification date,
+and the published letter remains the authority — pull it and re-verify before submitting.
+To add records (e.g. from a new month's decisions), follow the pipeline in
+`precedents/README.md`.
+
+## Reference files
+
+- [`references/comparability-and-weight.md`](references/comparability-and-weight.md) — the
+  Z-test in detail, the weight tiers with adjustments, the adverse-precedent duty, drafting
+  patterns, and the observed inspector practice this skill is calibrated against.
+
+## Scope and limitations
+
+- **Not legal advice, and no warranty.** Whether a precedent applies is ultimately a matter
+  of planning judgment for the decision-maker; contested comparability is a matter for a
+  planning professional or solicitor; provided "as is", no outcome guaranteed.
+- **Human review is necessary before use.** A person must read every cited decision letter
+  in full — the records are extracts, and an unread precedent is a liability, not an asset.
+- **England-focused.** Appeal mechanics and the policy framework cited are England's; the
+  devolved nations differ — flag and adjust outside England.
+- **Evidence-bound.** Quote decisions verbatim with paragraph numbers; never invent, embellish
+  or round up a finding. If the record and the letter disagree, the letter wins — fix the
+  record.
+- **Time-sensitive.** Policy editions turn over (most recently the August 2026 NPPF
+  recoding) and decisions can be quashed on legal challenge — re-verify the framework
+  currency and, for load-bearing precedents, check the decision still stands. ⏳
+- **A precedent strengthens a ground; it does not create one.** If the underlying ground is
+  weak, say so — "no sufficiently comparable precedent" is a valid, valuable output.
+- **A UK planning representation is public and in the submitter's name** — carry that
+  warning through to whichever skill drafts from this analysis.

--- a/appeal-precedent-analysis/precedents/3374870-grey-belt-footnote7-exclusion.md
+++ b/appeal-precedent-analysis/precedents/3374870-grey-belt-footnote7-exclusion.md
@@ -1,0 +1,47 @@
+---
+ref: "APP/C3620/W/25/3374870"
+decision_date: 2026-06-10
+lpa: Mole Valley District Council
+site: Greystones, Chalkpit Lane, Brockham, Surrey
+development: Erection of a single detached dwelling
+outcome: dismissed
+procedure: written-representations
+nppf_edition: December 2024
+issues: [green-belt, grey-belt, national-landscape, sssi, habitats, previously-developed-land]
+verified: 2026-08-19
+---
+
+**Finding (Y).** A Green Belt site within a National Landscape and close to an SSSI/SAC is
+not grey belt, because the footnote-7 exclusion bites; and historic industrial remains that
+have "blended into the landscape" are not previously developed land.
+
+**Reasoning (Z).** "Grey belt excludes land where the application of policies relating to
+the areas or assets in footnote 7 (other than Green Belt) would provide a strong reason for
+refusing or restricting development" (para 7). The proposed design "would be an
+incongruous feature within the protected landscape which would neither conserve or enhance
+the natural beauty of the SHNL" (para 11); missing ecological surveys meant SSSI/SAC
+impacts could not be excluded (paras 14–17). "Given my findings above on NL and the
+potential impact on the SSSI/SAC, the site does not meet the definition of grey belt. As
+such, the proposal cannot be considered under the exception at paragraph 155" (para 18).
+On PDL: "I do not consider the land previously developed as the remains of any permanent
+structure or fixed surface structure have since blended into the landscape" (para 22).
+
+**Applies when:**
+
+- a grey belt claim is made for land within a National Landscape, SSSI, or other
+  footnote-7 asset, and the proposal harms (or has unresolved impacts on) that asset;
+- ecological surveys requested by statutory consultees are missing at determination;
+- a PDL claim rests on historic structures now assimilated into the landscape, temporary
+  structures, or structures without evidence of lawful permanence.
+
+**Distinguish when:**
+
+- the footnote-7 asset is present but the proposal demonstrably conserves/enhances it (the
+  exclusion needs a *strong reason for refusal*, not the mere designation);
+- permanent lawful structures remain evident on the site.
+
+**Framework currency:** decided under the December 2024 NPPF (grey belt at paras 143/155,
+footnote 7). The August 2026 edition recodes Green Belt and grey belt policy — verify the
+current codes and the footnote-7 equivalent via the national-planning-policy crosswalk
+before citing; the structure of the exclusion (protected-asset policies as a strong reason)
+survived in substance. ⏳

--- a/appeal-precedent-analysis/precedents/6001258-gb-spatial-openness-garage.md
+++ b/appeal-precedent-analysis/precedents/6001258-gb-spatial-openness-garage.md
@@ -1,0 +1,45 @@
+---
+ref: "6001258"
+decision_date: 2026-06-02
+lpa: Coventry City Council
+site: Land to the rear of 260a Hawkes Mill Lane, Coventry
+development: Erection of a double garage
+outcome: dismissed
+procedure: written-representations
+nppf_edition: December 2024
+issues: [green-belt, openness, very-special-circumstances, outbuildings]
+verified: 2026-08-19
+---
+
+**Finding (Y).** Even a small, barely visible outbuilding in the Green Belt is dismissed
+where no exception applies: loss of *spatial* openness is harm regardless of limited
+visual impact, absence of other harms weighs neutrally, and private convenience is not a
+very special circumstance.
+
+**Reasoning (Z).** With no exception claimed, the garage was inappropriate development.
+Despite "limited effect on visual openness" (para 8), "the proposal would result in built
+development where there is currently none and so it would result in a loss of spatial
+openness... whilst limited in size, the proposal would represent a form of encroachment
+into the countryside causing moderate spatial harm" (para 9). "The absence of harm in
+these respects, weighs neutrally in the planning balance" (para 10). Parking convenience
+"would be a largely private benefit, to which I attach limited weight. Moreover, the
+presence of other outbuildings in the vicinity of the site would not justify the proposal"
+(para 11).
+
+**Applies when:**
+
+- a Green Belt proposal fits no exception and the applicant's case is smallness, low
+  visibility, neighbour precedent, or absence of other harms;
+- the openness argument needs its spatial limb: new built volume where there is none.
+
+**Distinguish when:**
+
+- an exception is genuinely engaged (e.g. proportionate extension, appropriate PDL
+  redevelopment) — the balance never arises;
+- the "other considerations" are public, not private (the private/public benefit
+  distinction did the work here).
+
+**Framework currency:** decided under December 2024 NPPF paras 152–154 (inappropriateness,
+substantial weight, VSC). Green Belt policy was recoded in August 2026 — cite the current
+codes via the crosswalk; the spatial-and-visual reading of openness and the VSC structure
+survive in substance. ⏳

--- a/appeal-precedent-analysis/precedents/6001638-rounding-off-purposive.md
+++ b/appeal-precedent-analysis/precedents/6001638-rounding-off-purposive.md
@@ -1,0 +1,46 @@
+---
+ref: "6001638"
+decision_date: 2026-06-18
+lpa: Cornwall Council
+site: Land West of The Haven, Carnkie, Helston
+development: Permission in Principle, erection of a dwelling
+outcome: allowed
+procedure: written-representations
+nppf_edition: December 2024
+issues: [settlement-boundary, rounding-off, infill, permission-in-principle, habitats]
+verified: 2026-08-19
+---
+
+**Finding (Y).** "Rounding off" is judged on the site's overall relationship to the
+settlement, not boundary-by-boundary: a weak edge on one side does not defeat the
+exception where the site is substantially enclosed and development would not project
+beyond the existing built envelope.
+
+**Reasoning (Z).** "Rounding off does not require all boundaries to be hard or defensible"
+(para 11); settlement edges "are often irregular, and... the assessment must be based on
+the overall appearance of the site in relation to the settlement rather than the strength
+of any single boundary" (para 11). "Despite the weaker western boundary, the site is
+substantially enclosed by existing development and long-standing boundaries on its other
+sides, and it reads as part of the settlement's irregular but coherent southern spur"
+(para 14). The council's officer advice note on infill/rounding-off was "not part of the
+adopted development plan and therefore carries limited weight" (para 9). Habitats: the
+appeal passed Appropriate Assessment because the SAC contribution was *already paid* under
+a s111 agreement (paras 24–26).
+
+**Applies when:**
+
+- a rounding-off/infill policy is applied mechanically against one open boundary despite
+  substantial enclosure on the others;
+- the council elevates a non-adopted advice note to policy status;
+- (habitats limb) mitigation is secured and paid before determination — the mirror of
+  [`6004999`](6004999-unsecured-habitats-mitigation.md).
+
+**Distinguish when:**
+
+- development would extend the built form outward beyond the depth of neighbouring
+  buildings (the decision's own test);
+- the policy's rounding-off definition contains hard criteria the site fails.
+
+**Framework currency:** turns on Cornwall Local Plan Policy 3 and para 1.68 — local
+policy, so check the plan is still adopted and unamended before citing; the NPPF role is
+peripheral. ⏳

--- a/appeal-precedent-analysis/precedents/6002147-alien-typology-listed-setting.md
+++ b/appeal-precedent-analysis/precedents/6002147-alien-typology-listed-setting.md
@@ -1,0 +1,50 @@
+---
+ref: "6002147"
+decision_date: 2026-06-29
+lpa: Isle of Wight Council
+site: Land adjacent 3 Brickfield Cottages, East Cowes Road, East Cowes
+development: Construction of a detached dwelling and garage
+outcome: dismissed
+procedure: written-representations
+nppf_edition: December 2024
+issues: [heritage, listed-building-setting, less-than-substantial-harm, design-typology]
+verified: 2026-08-19
+---
+
+**Finding (Y).** A new dwelling whose borrowed typology (a faux converted barn) has no
+basis in the site's history harms the setting of an adjacent listed building even at the
+lower end of less-than-substantial harm — and surrounding modern development does not
+license further encroachment.
+
+**Reasoning (Z).** The barn-style dwelling was proposed beside Grade II listed 1853
+workers' cottages: "the appeal site has no clear physical or visual connection of a
+farmstead which would justify the presence of such a built form in this location. It
+would, therefore, jar starkly with the vernacular of the listed building and its historic
+function" (para 13). "Together with its scale, bulk and typology, the proposal would
+introduce a contrived and incongruous feature into the setting of the listed building
+which would result in harm to its significance" (para 15) — less than substantial,
+"towards the lower end" (para 18), still requiring "clear and convincing justification"
+and the public-benefits balance. A stadium under construction nearby did "not... justify
+the introduction of a built form which harms the setting of a designated heritage asset,
+even if the stadium has an urbanising effect on the character of the wider surroundings"
+(para 16).
+
+**Applies when:**
+
+- a proposed design imports a rural/agricultural or other typology with no evidenced local
+  basis into a listed building's setting;
+- the applicant argues nearby modern development has already compromised the setting;
+- the harm is lower-end less-than-substantial and the claimed benefits are private or
+  modest — the balance still requires considerable importance and weight to the harm.
+
+**Distinguish when:**
+
+- the typology genuinely reflects the site's historic function or an established local
+  form;
+- benefits are substantial and public (housing at scale under a supply shortfall — see the
+  mirror balance in [`6002414`](6002414-heritage-balance-housing.md)).
+
+**Framework currency:** December 2024 NPPF heritage chapter (great weight; LTS harm vs
+public benefits) and s66(1) of the Listed Buildings Act (statutory, unchanged). August
+2026 recodes heritage policy (HE-series; "substantial weight" formulation) — the
+statutory duty and the balance survive; re-cite via the crosswalk. ⏳

--- a/appeal-precedent-analysis/precedents/6002414-heritage-balance-housing.md
+++ b/appeal-precedent-analysis/precedents/6002414-heritage-balance-housing.md
@@ -1,0 +1,48 @@
+---
+ref: "6002414"
+decision_date: 2026-06-17
+lpa: Mid Sussex District Council
+site: 19 Estcots Drive, East Grinstead, West Sussex
+development: One pair of semi-detached houses with parking and new shared access
+outcome: allowed
+procedure: written-representations
+nppf_edition: December 2024
+issues: [heritage, less-than-substantial-harm, listed-building-setting, conservation-area, housing-land-supply, habitats, cured-at-appeal]
+verified: 2026-08-19
+---
+
+**Finding (Y).** Lower-end less-than-substantial harm to listed buildings' setting and a
+conservation area can be outweighed by just two dwellings where the council lacks a
+five-year housing land supply — and a habitats refusal reason evaporates once a Unilateral
+Undertaking is completed during the appeal.
+
+**Reasoning (Z).** Harm to the setting of the Grade II farmstead was "less than
+substantial... at the lower end of the scale" (para 12), yet the inspector stressed such
+harm "would not equate to less than substantial importance and weight; indeed, I attach
+considerable importance and weight to these harms" (para 13). On the balance: with no
+five-year supply undisputed, "small and medium sized sites can make an important
+contribution to meeting the housing requirement of an area and are often built-out
+relatively quickly. Cumulatively, these important benefits would outweigh the harm"
+(para 14). The Ashdown Forest SANG/SAMM reason was cured by a signed UU submitted during
+the appeal, after which "the reason for refusal is no longer contested" (para 3).
+
+**Applies when:**
+
+- (for applicants/supporters) modest housing schemes face lower-end LTS heritage
+  objections in an authority without a five-year supply;
+- (for objectors, in reverse) the harm is above the lower end, the supply position is
+  healthy, or the benefits are private — then the considerable-importance-and-weight
+  language is yours (pair with [`6002147`](6002147-alien-typology-listed-setting.md));
+- a habitats objection can be extinguished by completing the strategic-mitigation
+  obligation before determination.
+
+**Distinguish when:**
+
+- harm reaches the middle/upper LTS range or affects highly graded assets;
+- the authority demonstrates a five-year supply (the counterweight came from the
+  shortfall).
+
+**Framework currency:** December 2024 NPPF paras 212/215 (great weight; LTS harm vs public
+benefits). Heritage recoded August 2026 (HE-series, "substantial weight") and the housing
+presumption re-mechanised (S3–S6) — the statutory s66(1) duty and the harm/benefit balance
+survive; the supply trigger works differently now. Re-cite both limbs via the crosswalk. ⏳

--- a/appeal-precedent-analysis/precedents/6002934-statutory-regime-deference.md
+++ b/appeal-precedent-analysis/precedents/6002934-statutory-regime-deference.md
@@ -1,0 +1,50 @@
+---
+ref: "6002934"
+decision_date: 2026-06-05
+lpa: Cotswold District Council
+site: Land East of Cotswold Business Village, South of London Road, Moreton-in-Marsh
+development: Outline, up to 195 dwellings with access and active travel measures
+outcome: allowed
+procedure: inquiry
+nppf_edition: December 2024
+issues: [sewerage-capacity, flooding, statutory-regimes, grampian-conditions, infrastructure]
+verified: 2026-08-19
+---
+
+**Finding (Y).** Inadequate wastewater treatment capacity is not a reason to refuse where
+occupation-trigger conditions tie development to the upgrade, because the water company is
+under a statutory duty and planning must assume other regulatory regimes operate
+effectively.
+
+**Reasoning (Z).** The treatment works admittedly lacked capacity and already sometimes
+exceeded permitted discharges, but: "under the Water Industry Act 1991 Thames Water has a
+legal duty to accept connections to the public sewers from new development, and to
+provide, maintain, and extend public sewer systems and sewage treatment works" (para 13).
+"I see no reason why such condition(s) should not be relied upon to ensure that the WWTW
+are adequately upgraded to accommodate the proposed development. If they were with a
+trigger prior to occupation, then the condition(s) would ensure that there would be no
+harm" (para 16). "Planning decisions should not be based on the control of processes that
+are the subject of control through separate regimes, and I must assume that the regimes
+will operate effectively" (para 18, applying NPPF para 201) — with both the Environment
+Agency and the undertaker raising no objection in full knowledge of the problems. Note the
+council withdrew its entire case pre-inquiry; the contest came from town/parish councils
+and campaign groups.
+
+**Applies when:**
+
+- (mostly for rebutting objections, or for supporters) sewerage/utility capacity
+  objections are made against schemes where the statutory undertaker and the EA do not
+  object and a Grampian/occupation-trigger condition is available;
+- (for objectors, in reverse) the undertaker *does* object, no upgrade path exists, or the
+  regime demonstrably is not operating — the deference assumption is rebuttable and this
+  decision shows what its application needs.
+
+**Distinguish when:**
+
+- the statutory consultees object or are silent on capacity;
+- the harm claimed is within planning's own competence (flood risk from the site's design)
+  rather than a separately regulated process.
+
+**Framework currency:** December 2024 NPPF para 201; the Water Industry Act duty is
+statutory and unchanged. Verify the current NPPF code for the separate-regimes principle
+via the crosswalk. ⏳

--- a/appeal-precedent-analysis/precedents/6003059-pip-article-5b-habitats-bar.md
+++ b/appeal-precedent-analysis/precedents/6003059-pip-article-5b-habitats-bar.md
@@ -1,0 +1,46 @@
+---
+ref: "6003059"
+decision_date: 2026-06-22
+lpa: Somerset Council
+site: 4 Rope Walk, Coleford, Radstock
+development: Permission in Principle for 6 detached dwellings and garages
+outcome: dismissed
+procedure: written-representations
+nppf_edition: December 2024
+issues: [permission-in-principle, habitats, sac, bats, ecology-survey-gap]
+verified: 2026-08-19
+---
+
+**Finding (Y).** Permission in Principle cannot be granted at all where the development is
+"habitats development" — likely significant effects on a European site that cannot be
+screened out bar the PiP route as a matter of law, regardless of the planning merits.
+
+**Reasoning (Z).** Article 5B of the Permission in Principle Order 2017: "in circumstances
+where a proposed permission in principle development is likely to have a significant effect
+on a qualifying European site the scheme would be deemed habitats development unless
+suitable mitigation measures are in place" (para 5). The site sat in the Greater Horseshoe
+Bat Consultation Zone band C of the Mells Valley SAC; the appellant proposed to defer
+ecology to the technical details stage, so "there is no ecological survey undertaken by a
+suitably qualified expert before me" (para 10). "Adopting a precautionary approach, I
+cannot be satisfied that the appeal proposal would not adversely affect the foraging
+habitat and commuting routes" (para 14). "The proposal would constitute habitats
+development for the purposes of Article 5B of the Order. Accordingly, it lies outside of
+the remit of the permission in principle regime" (para 15). Every other issue was expressly
+left undecided (para 16) — cite this decision only for the gateway point.
+
+**Applies when:**
+
+- a PiP application sits within a European-site consultation/influence zone and no
+  ecological survey or secured mitigation accompanies the *PiP-stage* application;
+- the applicant argues habitats matters can wait for Technical Details Consent.
+
+**Distinguish when:**
+
+- mitigation is already secured at PiP stage (e.g. a completed strategic-scheme payment),
+  allowing likely significant effects to be ruled out;
+- the site is outside any zone of influence and no impact pathway is identified.
+
+**Framework currency:** turns on Article 5B of the PiP Order 2017 (as amended) and
+Regulation 63 of the Habitats Regulations 2017 — statutory instruments, not the NPPF, so
+the August 2026 NPPF recoding does not affect it. Verify the Order's current text at run
+time. ⏳

--- a/appeal-precedent-analysis/precedents/6003217-np-shield-attenuated.md
+++ b/appeal-precedent-analysis/precedents/6003217-np-shield-attenuated.md
@@ -1,0 +1,49 @@
+---
+ref: "6003217"
+decision_date: 2026-06-26
+lpa: South Oxfordshire District Council
+site: Land rear of 79a and 81 Lower Icknield Way, Chinnor
+development: Permission in Principle, 8–9 custom/self-build dwellings
+outcome: allowed
+procedure: written-representations
+nppf_edition: December 2024
+issues: [neighbourhood-plan, tilted-balance, self-build, settlement-boundary, permission-in-principle]
+verified: 2026-08-19
+---
+
+**Finding (Y).** The neighbourhood-plan protection against the tilted balance weakens
+where the NP's housing allocations are already largely delivered and it makes no provision
+for the housing type in shortfall — policy conflict was found, and the presumption still
+prevailed.
+
+**Reasoning (Z).** The site conflicted with the spatial strategy (outside the boundary,
+not infill, not PDL — paras 11–21), and the NP was under five years old with delivered
+allocations, engaging the para 14 shield. But: "the evidence before me indicates that the
+plan's housing allocations have largely been delivered and its ability to respond to
+ongoing and emerging housing needs, particularly in respect of SBCH, is therefore more
+limited. In these circumstances, I find that the degree to which paragraph 14 indicates
+that conflict should significantly and demonstrably outweigh the benefits is reduced"
+(para 36). "Significant weight is given to the delivery of 8–9 SBCH plots addressing a
+clear shortfall" (paras 33, 43). A previous dismissal of a PiP on the same site was
+distinguished because that scheme "did not involve SBCH, and was determined on a different
+evidential basis" (para 40).
+
+**Applies when:**
+
+- (applicant/supporter side) the NP's allocations are delivered and the scheme meets an
+  evidenced unmet need (self-build registers, specialist housing) the NP does not address;
+- a same-site dismissal exists but the new scheme changes the *need* case, not just the
+  design;
+- (objector side, in reverse) the NP is recent with undelivered allocations addressing the
+  claimed need — then the shield holds at full strength.
+
+**Distinguish when:**
+
+- the NP still has headroom or makes provision for the housing type claimed;
+- the claimed shortfall is asserted rather than evidenced from the statutory register.
+
+**Framework currency:** December 2024 NPPF paras 11(d) and 14. The August 2026 edition
+replaced the tilted balance with the location-based S3–S6 presumption and restructured NP
+protection — the *reasoning* (a plan that has done its job protects less against needs it
+cannot meet) may transfer, but the mechanism is different. Check the crosswalk carefully;
+outcome-level reliance is unsafe. ⏳

--- a/appeal-precedent-analysis/precedents/6003242-informal-land-is-open-space.md
+++ b/appeal-precedent-analysis/precedents/6003242-informal-land-is-open-space.md
@@ -1,0 +1,51 @@
+---
+ref: "6003242"
+decision_date: 2026-06-01
+lpa: Cornwall Council
+site: Land at Reeves Close, Porthleven
+development: Outline, erection of a self-build dwelling
+outcome: dismissed
+procedure: written-representations
+nppf_edition: December 2024
+issues: [open-space, surplus-assessment, replacement-provision, self-build]
+verified: 2026-08-19
+---
+
+**Finding (Y).** Undesignated, privately owned land in public use is still NPPF "open
+space"; building on it requires a positive, evidenced surplus assessment or genuinely
+equivalent replacement — neither an above-average local quantity nor an unspecific
+financial contribution suffices.
+
+**Reasoning (Z).** "The definition of an open space in the Framework is a simple one: It
+is all open space of public value... Even if the extent of public use and the degree of
+value are both modest, that is nevertheless sufficient to meet the definition" (para 8) —
+despite no designation, private ownership, and a failed s106 transfer. On surplus: "it is
+not clear to me that a larger than average quantity is the same as a surplus; it may
+simply mean that other, comparable settlements have too little open space" (para 9); the
+submissions "do not evidently serve as an assessment of whether the appeal site is surplus"
+(para 14). On replacement: a contribution with no identified project, an uncertain
+protocol, and a signed sum (£12,081.56) below the officer's figure (£16,855) was not
+"equivalent or better provision" (paras 16–19). A cited appeal that succeeded on a similar
+contribution was distinguished because there the parish had confirmed specific improvement
+projects (para 20).
+
+**Applies when:**
+
+- development would take informal green land with any evidence of public use (photographs,
+  local testimony suffice);
+- the applicant's surplus case is comparative quantity, non-designation, or officer
+  remarks not amounting to an assessment;
+- a replacement contribution lacks an identified, confirmed project or matches no
+  quantified loss.
+
+**Distinguish when:**
+
+- the land genuinely lacks public value or function — see the mirror decision
+  [`6004601`](6004601-poor-quality-open-space.md), where poor quality and limited function
+  reduced the loss to limited weight;
+- replacement funds are tied to confirmed, specific projects (the distinction the
+  inspector drew expressly).
+
+**Framework currency:** December 2024 NPPF para 104(a)/(b). Open-space protection was
+re-coded in August 2026 — verify the current code via the crosswalk; the
+definition-then-exceptions structure survives in substance. ⏳

--- a/appeal-precedent-analysis/precedents/6003735-gb-disproportionate-cumulative.md
+++ b/appeal-precedent-analysis/precedents/6003735-gb-disproportionate-cumulative.md
@@ -1,0 +1,47 @@
+---
+ref: "6003735"
+decision_date: 2026-06-04
+lpa: St Albans City and District Council
+site: 27 Highfield Road, Sandridge, Hertfordshire
+development: New roof and loft extensions with ground floor extensions and alterations
+outcome: dismissed
+procedure: written-representations
+nppf_edition: December 2024
+issues: [green-belt, disproportionate-additions, cumulative-extensions, openness, householder]
+verified: 2026-08-19
+---
+
+**Finding (Y).** Extensions are measured cumulatively against the *original* dwelling; a
+244% floorspace / 1,046m³ volume increase is "plainly disproportionate" however designed,
+and the later expansion of permitted development rights does not stretch a Green Belt
+SPG's numeric guidelines.
+
+**Reasoning (Z).** Against SPG guidance of 20–40% floorspace / 90–180m³ for side and rear
+extensions, the undisputed figures were "a cumulative increase in floorspace of around
+244% and an increase in volume of approximately 1,046m3" (para 7). On the PD-rights
+argument: "the appellant has provided no clear evidence to demonstrate that permitted
+development rights could or would be likely to provide for increases in size approaching,
+far less comparable to, the considerable magnitude that would result from the appeal
+proposal" (para 8). "Increases of the level proposed here would be plainly
+disproportionate to the host dwelling and would undoubtedly result in a significantly
+larger building" (para 9). Upper-level bulk filling the visual gaps between dwellings
+"would notably diminish open views through the site" and so harmed openness (para 14).
+
+**Applies when:**
+
+- cumulative additions (all extensions since original construction, plus the proposal)
+  substantially exceed the local numeric guideline — do the arithmetic from the planning
+  history and put it in the representation;
+- the applicant argues newer PD rights justify exceeding an older SPG's ranges without
+  evidencing what PD could actually deliver on that dwelling;
+- roof-level bulk would infill visual gaps that give the street its openness.
+
+**Distinguish when:**
+
+- the increase sits within or near the guideline range and other SPG criteria are met;
+- a real, quantified PD fallback approaches the proposal's scale (evidence, not assertion).
+
+**Framework currency:** December 2024 NPPF extension exception ("disproportionate
+additions over and above the size of the original building"). Green Belt recoded August
+2026 — the original-building baseline and cumulative approach survive in substance;
+re-cite via the crosswalk. ⏳

--- a/appeal-precedent-analysis/precedents/6004263-class-q-scope-discipline.md
+++ b/appeal-precedent-analysis/precedents/6004263-class-q-scope-discipline.md
@@ -1,0 +1,49 @@
+---
+ref: "6004263"
+decision_date: 2026-06-19
+lpa: North Somerset Council
+site: Land to the south of Winford Lane, Dundry
+development: Class Q prior approval, change of agricultural building to 5 dwellings
+outcome: allowed
+procedure: written-representations
+nppf_edition: December 2024
+issues: [permitted-development, class-q, prior-approval-scope, car-dependency, habitats]
+verified: 2026-08-19
+---
+
+**Finding (Y).** Class Q prior approval cannot be refused on locational sustainability:
+the transport limb tests only the direct highway impacts, and rural car dependence is
+inherent to the right; nor can obligations (a school-transport contribution) be demanded
+of development that is permitted in principle by the GPDO.
+
+**Reasoning (Z).** "The permitted development right does not apply a test in relation to
+the sustainability of location. In doing so, the permitted development right recognises
+that many agricultural buildings will not be in villages or other settlements" (para 7,
+following the PPG). On the council's safe-routes-to-school case: "the only safe and
+suitable access to the site would be via private vehicle. This would not however lead to
+an inherent unacceptable highway effect. Many Class Q proposals are in rural locations
+where access to facilities including schools are not within a realistic walking or cycling
+distance... This is acknowledged by the PPG and would not prevent prior approval being
+granted" (para 13). Safe access and trivial trip generation satisfied NPPF paras 115–116
+(paras 10–14). The requested home-to-school contribution "would not be reasonable or
+necessary" for PD (para 16). Habitats (bats SAC) was left to the separate GPDO Article
+3(1)/Regulation 75–78 pre-commencement mechanism (paras 17–19).
+
+**Applies when:**
+
+- a council imports development-plan or NPPF locational tests into a prior approval whose
+  statutory matters do not include them (the same discipline runs through Class MA and
+  Part 6 decisions in this corpus);
+- prior approval is resisted for want of obligations the GPDO does not authorise;
+- habitats objections to PD are raised as refusal reasons rather than routed through the
+  Regulation 77 process.
+
+**Distinguish when:**
+
+- the impact genuinely falls within a listed prior-approval matter (e.g. unsafe access,
+  severe residual highway impact);
+- the development fails a Q.1 limitation — scope discipline cuts both ways.
+
+**Framework currency:** turns on the GPDO Schedule 2 Part 3 Class Q and the PPG — verify
+the current GPDO text and PPG paragraphs at run time (the PPG lags NPPF recoding); the
+NPPF paras 115–116 cited are the December 2024 numbering, re-cite via the crosswalk. ⏳

--- a/appeal-precedent-analysis/precedents/6004335-hmo-fallback-neutralises.md
+++ b/appeal-precedent-analysis/precedents/6004335-hmo-fallback-neutralises.md
@@ -1,0 +1,48 @@
+---
+ref: "6004335"
+decision_date: 2026-06-02
+lpa: Portsmouth City Council
+site: 21 Fraser Road, Southsea, Portsmouth
+development: Change of use from C4 HMO to 8-person sui generis HMO
+outcome: allowed
+procedure: written-representations
+nppf_edition: December 2024
+issues: [hmo, fallback, concentration-threshold, habitats, nutrient-neutrality, emerging-plan]
+verified: 2026-08-19
+---
+
+**Finding (Y).** A realistic fallback resets the baseline: where permitted-development
+works underway would lawfully allow 6 HMO occupants, an 8-person proposal is assessed as
++2 — and with no nuisance evidence, exceeding the 10% HMO concentration threshold did not
+itself establish harm. Habitats obligations (recreation and nutrients) completed during
+the appeal passed the Appropriate Assessment.
+
+**Reasoning (Z).** With extension works in progress under PD: "I consider that the
+fallback position is a greater than theoretical possibility, and that there is compelling
+evidence that if the appeal were dismissed, the fallback would be pursued. Therefore, the
+potential increase in residential occupancy at the property would be 2 occupants"
+(para 11). Additional disturbance "would not necessarily be greater than might occur if
+the property were occupied by up to 6 unrelated individuals" (para 13); no statutory
+nuisance complaints or environmental-health concerns existed (para 12). The emerging
+plan's stricter HMO policy carried only limited weight pre-adoption (paras 5, 15). A s111
+agreement secured Bird Aware Solent and nutrient-neutrality contributions, so the AA
+concluded no adverse effect on the Solent sites (paras 17–22).
+
+**Applies when:**
+
+- (applicant/supporter side) a lawful or PD fallback is *evidenced as real* — works
+  underway, certificates, extant permissions — and the proposal's delta over it is small;
+- an HMO threshold policy is breached but the guidance directs the assessment to amenity
+  harm, and none is evidenced;
+- (objector side, in reverse) the fallback is theoretical or unevidenced — this decision
+  states the test the applicant must meet ("greater than theoretical possibility" +
+  "compelling evidence" it would be pursued).
+
+**Distinguish when:**
+
+- no realistic fallback exists, so the comparison is with the unintensified use;
+- nuisance/amenity evidence exists (complaints records, EHO concerns).
+
+**Framework currency:** fallback doctrine is caselaw-based and unaffected by NPPF
+recoding. Habitats obligations are statutory (Reg 63). The saved-plan and emerging-plan
+weight points follow NPPF paras 48–49 (December 2024) — re-cite via the crosswalk. ⏳

--- a/appeal-precedent-analysis/precedents/6004388-grey-belt-site-specific.md
+++ b/appeal-precedent-analysis/precedents/6004388-grey-belt-site-specific.md
@@ -1,0 +1,51 @@
+---
+ref: "6004388"
+decision_date: 2026-06-22
+lpa: North Warwickshire Borough Council
+site: Land between 10 and 32 Birmingham Road, Whitacre Heath
+development: Permission in Principle, limited infill residential (1–9 dwellings)
+outcome: allowed
+procedure: hearing
+nppf_edition: December 2024
+issues: [green-belt, grey-belt, flood-risk, sequential-test, housing-land-supply, permission-in-principle]
+verified: 2026-08-19
+---
+
+**Finding (Y).** Grey belt status is established by site-specific assessment of the
+paragraph 143 purposes — a council's strategic-scale Green Belt study that never assessed
+the parcel cannot rebut it; and a failed flood-risk sequential test is a strong reason to
+refuse but not an automatic one, capable of being outweighed in an acute housing shortfall.
+
+**Reasoning (Z).** On the council's late-produced study: "The Green Belt Study is a
+strategic scale analysis; it clearly confirms that it is not an assessment of defined
+parcels of land" (para 36); "There is no evidence before me that the Green Belt Study has
+assessed the contribution the appeal site plays to the purposes of the Green Belt,
+separate to the purpose the appeal site plays as part of a wider area" (para 38). The
+site-specific assessment found no strong contribution to purposes (a), (b) or (d)
+(para 39), and paragraph 155(a)–(c) was met (paras 40–43). On flood risk: the sequential
+test was inadequate (no neighbouring-settlement search), yet "Following the Gladman and
+Mead Realisation caselaw the failure of the sequential test can be a strong reason to
+refuse but this does not automatically remove the requirement to carry out a planning
+balance" (para 17). The local infill definition stricter than the Framework attracted only
+limited weight in a 0.82–2.2-year supply context (para 49).
+
+**Applies when:**
+
+- (applicant/supporter side) a council resists grey belt with strategic-scale evidence
+  while the parcel-level facts (enclosure, settlement relationship, containment) point the
+  other way;
+- a sequential-test deficiency is being treated as an automatic bar rather than weighed;
+- local policy definitions exceed the Framework and supply is short.
+
+**Distinguish when:**
+
+- a parcel-level Green Belt assessment exists and finds strong contribution;
+- footnote-7 assets are engaged (the mirror decision:
+  [`3374870`](3374870-grey-belt-footnote7-exclusion.md));
+- the sequential-test failure is total (no assessment at all) — this inspector expressly
+  distinguished two such dismissals.
+
+**Framework currency:** December 2024 NPPF paras 143/155 and the flood sequential test;
+*Gladman v SSHCLG* [2026] EWHC 51 (Admin) and *Mead Realisations* [2024] EWHC 279 are
+court authority and survive. Grey belt and flood policy recoded August 2026 (F-series,
+Annex F) — verify codes and any test changes via the crosswalk before citing. ⏳

--- a/appeal-precedent-analysis/precedents/6004523-car-dependent-location-pip.md
+++ b/appeal-precedent-analysis/precedents/6004523-car-dependent-location-pip.md
@@ -1,0 +1,46 @@
+---
+ref: "6004523"
+decision_date: 2026-06-17
+lpa: Wychavon District Council
+site: 7 Top Street, Charlton, Worcestershire
+development: Permission in Principle for up to 6 bungalows
+outcome: dismissed
+procedure: written-representations
+nppf_edition: December 2024
+issues: [location-sustainability, car-dependency, backland, settlement-boundary, permission-in-principle]
+verified: 2026-08-19
+---
+
+**Finding (Y).** A village-edge site fails on location where occupiers would be highly car
+dependent — evidenced at the level of the bus timetable and the footway network — and
+backland form disconnected from the settlement pattern compounds the harm; adjacency to
+the settlement boundary is not enough.
+
+**Reasoning (Z).** "The future occupants of the proposed development would be highly car
+dependent" (para 9). The inspector walked the routes: "The timetable at the bus stop
+displayed a very limited service with no standard departures on any day of the week"
+(para 12); occupants "would... still remain heavily reliant on the car" (para 13). On
+form: "The position and form of this backland site, where the development would not front
+a road, would constitute an incongruous line of dwellings disconnected from the wider
+village" and "simply abutting the settlement boundary would not make the proposed
+development contextually appropriate" (paras 18, 15–18). *Bramshill* and *Braintree*
+(isolation caselaw) did not assist: not being isolated is not the same as being suitable.
+
+**Applies when:**
+
+- a rural/edge site's accessibility case rests on a nominal bus service or footway-less
+  lanes — check the actual timetable and walk the routes; the evidence is collectable;
+- the layout is backland behind established frontages, served by a long private access;
+- the applicant equates "adjacent to the boundary" with "sustainable location".
+
+**Distinguish when:**
+
+- genuine non-car options exist (regular services, safe walking routes) — compare
+  [`6004388`](6004388-grey-belt-site-specific.md), where village facilities in walking
+  distance carried the day;
+- the settlement pattern itself contains backland development.
+
+**Framework currency:** decided under December 2024 NPPF (para 110 cited). Transport and
+location policy re-coded August 2026 (TR-series; location-based presumption S3–S6) — the
+car-dependency reasoning transfers, but re-cite via the crosswalk and note the presumption
+mechanism changed. ⏳

--- a/appeal-precedent-analysis/precedents/6004601-poor-quality-open-space.md
+++ b/appeal-precedent-analysis/precedents/6004601-poor-quality-open-space.md
@@ -1,0 +1,49 @@
+---
+ref: "6004601"
+decision_date: 2026-06-11
+lpa: Northumberland County Council
+site: 1 Oulton Close, Eastfield Green, Cramlington
+development: Change of use of side land to residential curtilage and erection of 2m boundary fence
+outcome: allowed
+procedure: written-representations
+nppf_edition: December 2024
+issues: [open-space, green-infrastructure, character, bng]
+verified: 2026-08-19
+---
+
+**Finding (Y).** Enclosing a small grassed area was allowed because the land was not good
+quality open space: too small to contribute significantly to character, too constrained to
+function as usable open space — and an acknowledged open-space policy conflict attracted
+only limited weight against the plan read as a whole.
+
+**Reasoning (Z).** "The benefits of this particular grassed area are limited. It is not of
+substantial enough size to make a significant positive contribution to the character or
+appearance of the area and its small size and position between existing residential
+properties and the footway means that its use as functional open space is limited. It is
+not good quality open space" (para 8). Three comparable side-garden fences observed nearby
+on the site visit supported the character judgment (paras 9–10). On the open-space policy:
+"the proposal would involve the loss of open space, the loss of which has not been
+justified under parts a-c of that Policy. However, given the characteristics of the land
+and existing fencing arrangements in the immediate area, the weight I can afford to the
+conflict with this Policy is limited and the proposal would not conflict with the
+development plan as a whole" (para 14). The BNG refusal reason resolved to the statutory
+pre-commencement biodiversity gain plan condition (para 4).
+
+**Applies when:**
+
+- (applicant/supporter side) the land in question is small, functionally constrained, and
+  demonstrably not serving open-space purposes — the quality/function analysis is the
+  route past the policy;
+- comparable enclosures exist in the immediate street scene (observable, not asserted).
+
+**Distinguish when:**
+
+- the land has evidenced public use or value — the mirror decision
+  [`6003242`](6003242-informal-land-is-open-space.md) holds that even modest public value
+  meets the NPPF open-space definition and demands a surplus assessment;
+- the space forms part of a designed network of estate greens whose cumulative erosion is
+  the harm.
+
+**Framework currency:** local open-space and character policies did the work; NPPF role
+peripheral. Verify the plan policies remain adopted; the statutory BNG condition mechanism
+is unchanged. ⏳

--- a/appeal-precedent-analysis/precedents/6004999-unsecured-habitats-mitigation.md
+++ b/appeal-precedent-analysis/precedents/6004999-unsecured-habitats-mitigation.md
@@ -1,0 +1,53 @@
+---
+ref: "6004999"
+decision_date: 2026-06-19
+lpa: Tewkesbury Borough Council
+site: 124 Cheltenham Road, Bishops Cleeve, Cheltenham
+development: Detached single-storey self/custom-build dwelling and car port (backland)
+outcome: dismissed
+procedure: written-representations
+nppf_edition: December 2024
+issues: [habitats, sac, unsecured-mitigation, backland, character, tilted-balance, space-standards]
+verified: 2026-08-19
+---
+
+**Finding (Y).** Willingness to complete a habitats mitigation obligation is worthless
+until completed: without a secured contribution the competent authority cannot pass the
+Regulation 63 test, the habitats policies supply a footnote-7 "strong reason" for refusal,
+and the tilted balance is never reached. Separately: a second tier of development behind
+long rear gardens harms an area's spatial character even when barely visible.
+
+**Reasoning (Z).** "The appellant indicates a willingness to enter into a Unilateral
+Undertaking to secure the necessary mitigation, but no completed obligation has been
+submitted. In the absence of a secured and scientifically validated mitigation package, I
+am unable to ascertain that the proposal would avoid adverse effects on the integrity of
+the Cotswold Beechwoods SAC" (para 17). Hence "the habitats and biodiversity policies in
+the Framework provide a strong reason for refusing the development proposed. Paragraph
+11(d)(ii) is not therefore engaged" (para 20) — despite no five-year housing land supply.
+On character: the proposal "would introduce a deeper, second tier of development behind
+long rear gardens, where no comparable built form exists" (para 7, distinguishing a nearby
+permission that "rounds off" an adjoining estate); the layout "appears engineered to fit
+the confines of the plot rather than arising naturally from its context" (para 5). Note
+also: the council's space-standards refusal reason *failed* — a bed drawn at realistic
+proportions showed the room met the standard (paras 10–11); do not cite this decision for
+that issue.
+
+**Applies when:**
+
+- a scheme in a European-site zone of influence reaches determination without a completed,
+  paid or executed mitigation obligation — promises, drafts and willingness do not count;
+- the applicant relies on housing-supply shortfall: the habitats gateway precedes the
+  tilted balance;
+- backland/garden-grab proposals would breach a consistent frontage-plus-long-gardens
+  pattern (pair with [`6004523`](6004523-car-dependent-location-pip.md) on backland form).
+
+**Distinguish when:**
+
+- the obligation is completed before decision (the June 2026 sample shows exactly this
+  converting refusals to allowals — e.g. [`6002414`](6002414-heritage-balance-housing.md));
+- the area already contains comparable second-tier development.
+
+**Framework currency:** December 2024 NPPF para 11(d)(i)/footnote 7; Habitats Regulations
+Reg 63 (statutory, unaffected by NPPF recoding). The presumption mechanism changed in
+August 2026 (S3–S6) — the gateway logic (protected-asset policies precede any balance)
+survives; re-cite via the crosswalk. ⏳

--- a/appeal-precedent-analysis/precedents/6005058-care-home-fallback-psed.md
+++ b/appeal-precedent-analysis/precedents/6005058-care-home-fallback-psed.md
@@ -1,0 +1,50 @@
+---
+ref: "6005058"
+decision_date: 2026-06-26
+lpa: Oadby and Wigston Borough Council
+site: 53 Fox Hollow, Oadby, Leicester
+development: Change of use from C3 dwelling to C2 children's care home (3 children, staffed)
+outcome: allowed
+procedure: written-representations
+nppf_edition: December 2024
+issues: [care-home, c2-use, need, fallback, psed, fear-of-crime, family-housing]
+verified: 2026-08-19
+---
+
+**Finding (Y).** A children's care home was allowed despite a found conflict with the
+local need policy, because a Certificate of Lawfulness created a fallback with the same
+policy conflict, no amenity harm was evidenced beyond a typical household, and the
+equality-duty benefits of specialist accommodation carried significant weight.
+
+**Reasoning (Z).** The HEDNA identified no borough need, so conflict with the specialist
+accommodation policy was found (paras 3–6). But a Certificate of Lawfulness existed for
+care of three children by one carer: "the Certificate of Lawfulness does establish a
+potential fallback position. The number and age of children would be the same and such a
+use would result in a similar conflict with Local Plan policy 11 as the proposal before
+me" (para 19). On neighbours: "no substantive evidence to show that there would be
+disruption to the existing neighbouring occupiers... over and above that which might occur
+from children forming part of a typical household", given the small scale and constant
+professional supervision (para 13); the Framework's crime paragraph "is focused on
+measures that can be taken through the design of the built environment" (para 14). On
+PSED: "In providing supported accommodation for those with the protected characteristics
+of age and potential disability... I give significant weight to these benefits" (para 21).
+
+**Applies when:**
+
+- small C2/care uses face fear-of-crime or character objections with no evidence beyond
+  the use's label — the family-household comparator plus supervision levels answer them;
+- a lawful fallback carries the same policy conflict as the proposal, neutralising the
+  conflict's practical force;
+- specialist accommodation for protected groups engages s149 Equality Act benefits.
+
+**Distinguish when:**
+
+- the scale or care model departs from a family-home analogue (large institutions, low
+  supervision);
+- evidence of actual disturbance exists;
+- no fallback exists and the need policy conflict stands alone (see
+  [`6005371`](6005371-strategy-beats-assertion.md) for the need-evidence route instead).
+
+**Framework currency:** need policies are local; PSED is statutory (s149 Equality Act
+2010, unchanged). The NPPF specific-housing-requirements support survives recoding —
+re-cite via the crosswalk. ⏳

--- a/appeal-precedent-analysis/precedents/6005080-hmo-substandard-rooms.md
+++ b/appeal-precedent-analysis/precedents/6005080-hmo-substandard-rooms.md
@@ -1,0 +1,46 @@
+---
+ref: "6005080"
+decision_date: 2026-06-09
+lpa: Wolverhampton City Council
+site: 3 Woden Road, Wolverhampton
+development: Extensions and change of use of dwelling (C3) to 6-person HMO (C4)
+outcome: dismissed
+procedure: written-representations
+nppf_edition: December 2024
+issues: [hmo, internal-space-standards, living-conditions, noise]
+verified: 2026-08-19
+---
+
+**Finding (Y).** An HMO with bedrooms below the council's adopted space standards and a
+communal area doubling as the circulation route provides substandard living conditions for
+future occupiers — and HMO licensing does not cure the planning failure.
+
+**Reasoning (Z).** Against a 10m² single-bedroom minimum in the council's amenity
+standards guide, "Three of the bedrooms would have 8m2 of usable space and one would have
+only 6.5m2" (para 4). Licensing "does not avoid the need for the proposal to provide
+satisfactory living conditions in planning terms" (para 5). The communal room, "given its
+dual role as a thoroughfare and its limited size... appears cramped and impractical"
+(para 7), producing "a poor quality and substandard residential environment" (para 8). On
+neighbours: a six-bedroom HMO "would be likely to result in a much greater intensity and
+frequency of activity than a single household in a dwelling of this size" where the
+end-terrace proximity concentrated it (para 11).
+
+**Applies when:**
+
+- HMO bedrooms fall measurably below the adopted local standard (or the nationally
+  described space standard where that is the operative benchmark);
+- communal space is undersized or doubles as circulation;
+- objectors can point to the plans' own dimensions — the argument is arithmetical.
+
+**Distinguish when:**
+
+- rooms meet the applicable standards (see the mirror decision
+  [`6005230`](6005230-hmo-intensity-not-harm.md): "greater intensity does not, in itself,
+  amount to harm" where standards were met);
+- the alleged undersizing rests on the objector's scaling rather than the plans (see
+  `6004999`, where a bed drawn at realistic proportions defeated the council's own
+  space-standard reason).
+
+**Framework currency:** turns on local amenity standards and generic amenity policy; the
+NPPF's role is the general high-standard-of-amenity expectation, which survives the August
+2026 recoding — cite the current code for amenity via the crosswalk. ⏳

--- a/appeal-precedent-analysis/precedents/6005193-threshold-without-policy-basis.md
+++ b/appeal-precedent-analysis/precedents/6005193-threshold-without-policy-basis.md
@@ -1,0 +1,49 @@
+---
+ref: "6005193"
+decision_date: 2026-06-02
+lpa: Birmingham City Council
+site: 71 Church Hill Road, Birmingham
+development: Change of use C3 dwelling to C2 small care home (up to two 16–24-year-olds)
+outcome: allowed
+procedure: written-representations
+nppf_edition: December 2024
+issues: [care-home, c2-use, concentration-threshold, balanced-communities, need, family-housing]
+verified: 2026-08-19
+---
+
+**Finding (Y).** A concentration objection fails where the threshold has no basis in
+adopted policy and its input data is undefined; and the commissioning body's confirmation
+of need for community-embedded small care homes answers the loss-of-family-housing
+objection.
+
+**Reasoning (Z).** Against the council's claim that 12.5% of properties within 100m would
+be non-family uses: "there is no policy support for using a 10% figure within a 100m as a
+threshold; and it is unclear from the evidence what 'supported exempt accommodation'
+includes" (para 10). Birmingham Children's Trust "confirms that there is also a need for
+small care homes, and that the proposal would be broadly in line with its strategy which
+seeks to place such homes within the community" (para 9). With no external changes, a
+two-resident cap conditioned, high supervision, and total occupancy "broadly similar to a
+typical family home", neither character nor amenity harm was made out (paras 12–18); a
+police service-demand consultation response was not evidence that the *C2 use* would cause
+greater concerns than the existing C3 use (para 17). A suggested condition restricting the
+property to supported-living only was refused for want of justification (para 25).
+
+**Applies when:**
+
+- a refusal or objection deploys a numeric concentration threshold that appears in no
+  adopted policy, or feeds undefined categories into the count — attack the instrument,
+  not just its application;
+- the statutory commissioning body (children's trust, county council) supports
+  community-located provision in writing;
+- generalised police/service-demand responses are offered as evidence of use-specific
+  harm.
+
+**Distinguish when:**
+
+- the threshold is in an adopted policy or made SPD with a proper evidence base — then the
+  fight is about the facts, not the instrument;
+- occupancy or supervision materially departs from the family-home analogue.
+
+**Framework currency:** turns on local policy (Birmingham BDP/DMB) and evidence
+discipline; NPPF role (needs of different groups) survives recoding — re-cite via the
+crosswalk. ⏳

--- a/appeal-precedent-analysis/precedents/6005230-hmo-intensity-not-harm.md
+++ b/appeal-precedent-analysis/precedents/6005230-hmo-intensity-not-harm.md
@@ -1,0 +1,48 @@
+---
+ref: "6005230"
+decision_date: 2026-06-29
+lpa: Bolton Metropolitan Borough Council
+site: 18 Wardle Street, Bolton
+development: Change of use C3 to 5-bed HMO (C4) with rear dormer
+outcome: allowed
+procedure: written-representations
+nppf_edition: December 2024
+issues: [hmo, internal-space-standards, over-intensification, living-conditions]
+verified: 2026-08-19
+---
+
+**Finding (Y).** "Over-intensive use" is not a freestanding harm: where rooms meet the
+nationally described space standards, communal provision is adequate, and no neighbour,
+character or highway harm is alleged, greater intensity than a family household is not of
+itself a reason to refuse.
+
+**Reasoning (Z).** "It is likely that up to five adults living independently would
+generate a greater frequency of comings and goings than a typical family household. I
+therefore accept that the use would be more intensive... However, the pattern of activity
+would not be fundamentally different from that associated with a family occupation, and
+**greater intensity does not, in itself, amount to harm**. Notably, the Council does not
+allege adverse effects on neighbouring living conditions, the character and appearance of
+the area, or highway safety" (para 6). Each bedroom "would meet comparable minimum space
+standards" (the 2015 nationally described space standard, para 7) with en-suites, light
+and outlook; the external yard, while modest, sufficed because "the likely needs of five
+adults living independently would be less demanding" than a family's (para 9). A 5-bedroom
+cap was conditioned.
+
+**Applies when:**
+
+- (applicant/supporter side) an HMO refusal rests on intensity language without an
+  evidenced amenity, character or highway harm, and the plans demonstrably meet the
+  operative space standards;
+- external amenity space is criticised against standards that do not exist for HMOs
+  locally.
+
+**Distinguish when:**
+
+- rooms or communal space fall below the applicable standards — the mirror decision is
+  [`6005080`](6005080-hmo-substandard-rooms.md);
+- concentration or neighbour-harm evidence exists (complaints, EHO input) — this decision
+  turned on their absence.
+
+**Framework currency:** turns on local amenity policy and the nationally described space
+standard (2015, still current — verify). NPPF role generic; unaffected in substance by
+the August 2026 recoding. ⏳

--- a/appeal-precedent-analysis/precedents/6005371-strategy-beats-assertion.md
+++ b/appeal-precedent-analysis/precedents/6005371-strategy-beats-assertion.md
@@ -1,0 +1,50 @@
+---
+ref: "6005371"
+decision_date: 2026-06-22
+lpa: London Borough of Havering
+site: 23 Ellis Avenue, Rainham
+development: Change of use C3 to children's home (C2) for two children
+outcome: allowed
+procedure: written-representations
+nppf_edition: December 2024
+issues: [care-home, c2-use, need, evidence-discipline, parking]
+verified: 2026-08-19
+---
+
+**Finding (Y).** A council's published needs evidence beats its officers' unpublished
+assertions: where the adopted Children's Sufficiency Strategy identifies a need for new
+children's homes, an unreferenced verbal claim of "oversupply" — unsupported by any
+analysis — cannot displace it.
+
+**Reasoning (Z).** The council's case rested on its delegated report recording that "the
+council's Strategic Commissioner indicated that there is an oversupply of children's homes
+in the borough"; its appeal statement "simply refers to the previously reported verbal
+comment... No reference is made to the Strategy" (para 7). The 2023 Sufficiency Strategy's
+Key Action was to create new children's homes: "as no evidence has been provided to
+explain why the Strategy should not be relied upon, I have considered the Key Action of
+the Strategy, to create new children's homes, as evidence that children's homes are
+needed" (para 8) — "in the absence of any analysis by the council" (para 12). The
+Framework points decision-makers to exactly this document for looked-after children's
+needs (para 5). Operationally the home would function like a family household; staff
+changeovers and one on-site space did not create parking harm (paras 17–21); an
+environmental-health noise-management-plan condition was refused as unnecessary (para 17).
+
+**Applies when:**
+
+- a need (or oversupply) claim in either direction is contradicted by the authority's own
+  published strategy, register or evidence base — put the document against the assertion;
+- the published evidence is dated but unreplaced: age reduces robustness, yet it prevails
+  over nothing;
+- conditions are proposed (noise management plans etc.) without evidence the use differs
+  from a household.
+
+**Distinguish when:**
+
+- the authority produces an updated, published analysis supporting its position;
+- the strategy on its face excludes the provision proposed (e.g. private provision where
+  the strategy limits itself to in-house capacity — argued here and rejected on the
+  wording).
+
+**Framework currency:** the December 2024 NPPF's direction to Children's Social Care
+Sufficiency Strategies for looked-after children's needs — verify the equivalent provision
+in the August 2026 edition via the crosswalk; the evidence-discipline point is general. ⏳

--- a/appeal-precedent-analysis/precedents/6005514-temporary-trial-condition.md
+++ b/appeal-precedent-analysis/precedents/6005514-temporary-trial-condition.md
@@ -1,0 +1,48 @@
+---
+ref: "6005514"
+decision_date: 2026-06-18
+lpa: Royal Borough of Kensington and Chelsea
+site: Ground Floor, 153 Earl's Court Road, London
+development: s73 variation — removal of hours condition on adult gaming centre (24-hour operation)
+outcome: conditions-varied
+procedure: written-representations
+nppf_edition: December 2024
+issues: [conditions, operating-hours, noise, cumulative-impact, temporary-permission]
+verified: 2026-08-19
+---
+
+**Finding (Y).** Where technical evidence shows extended hours are unlikely to harm
+amenity but residual uncertainty and local concern remain, a temporary trial period is the
+proportionate answer — 24-hour operation granted for 12 months so actual effects can be
+reviewed, rather than refusal on asserted cumulative impact.
+
+**Reasoning (Z).** The noise assessment predicted 2–10 customers per hour at night with no
+discernible amenity loss (paras 9–10); "the Council's Licensing Team indicates that it had
+received no formal complaints regarding any gambling premises on Earl's Court Road at the
+time of the application. Moreover, the Council's Environmental Health Team also confirmed
+it had no objections to the removal of condition No 3" (para 11). Nevertheless: "I
+recognise the legitimate concerns raised by interested parties and the Council regarding
+the potential for additional noise and disturbance to arise, over and above that
+identified in the evidence. Accordingly... I consider it appropriate that a temporary 24/7
+trading period of 12 months be granted as suggested by both main parties. This will enable
+the actual effects of the extension to the trading hours to be reviewed at the end of this
+period, in line with the Planning Practice Guidance" (para 13, PPG Ref ID 21a-014). Crime
+and gambling-harm objections were unsubstantiated or outside the appeal's scope
+(paras 17–20).
+
+**Applies when:**
+
+- (either side) an intensification's real-world effects are genuinely uncertain and a
+  time-limited permission would let them be tested — objectors can offer this as the
+  fallback ask where outright refusal looks unlikely;
+- a cumulative-impact case is asserted against a no-complaints record and non-objecting
+  statutory teams — this decision shows what that case needs and lacked.
+
+**Distinguish when:**
+
+- harm is already evidenced (complaints history, EHO objection) — a trial merely defers a
+  known harm;
+- the use, once established, would be practically irreversible.
+
+**Framework currency:** rests on the PPG's temporary-permission guidance (verify the Ref
+ID at run time — PPG pages lag the NPPF recode) and the standard condition tests. ⏳

--- a/appeal-precedent-analysis/precedents/6006625-marketing-evidence-condition-removal.md
+++ b/appeal-precedent-analysis/precedents/6006625-marketing-evidence-condition-removal.md
@@ -1,0 +1,50 @@
+---
+ref: "6006625"
+decision_date: 2026-06-29
+lpa: Torridge District Council
+site: Moorview Cottage, Pyworthy, Devon
+development: s73 removal of holiday-occupancy condition on 2003 barn conversion
+outcome: conditions-varied
+procedure: written-representations
+nppf_edition: December 2024
+issues: [conditions, holiday-occupancy, marketing-evidence, tourism, rural-housing]
+verified: 2026-08-19
+---
+
+**Finding (Y).** A holiday-occupancy condition is no longer reasonable or necessary where
+sustained genuine marketing produced no offers, the tourism loss is negligible, and the
+building is already lawfully residential — and a policy's *supporting text* cannot impose
+evidence requirements the policy itself does not contain.
+
+**Reasoning (Z).** On the council's insistence on 12 months' pre-application marketing and
+wider demand evidence drawn from supporting text: "such text does not have the force of
+policy, and it is appropriate to apply planning judgement here" (para 10). The property
+was marketed for 20 months with staged price reductions (about 7 months below £500,000
+against a £512,500 appraisal): "this nevertheless shows a concerted effort to market the
+property and adapt the strategy to stimulate interest and activity. Despite these efforts,
+I am not aware any firm offers were made" (para 13). A comparable local property had also
+failed as holiday accommodation, reflecting the remote location's weak tourism appeal
+(para 11). On the supply point: "the appeal proposal would not result in a net increase in
+the number of dwellings, as the building is already in a residential use... the proposal
+does not engage the supply of housing in the manner anticipated by the Framework"
+(para 15). Transport parity between holiday and permanent occupation was found on the
+facts (para 7).
+
+**Applies when:**
+
+- occupancy-condition removal is supported by a marketing campaign that was realistic in
+  price, sustained, adaptive, and offer-free — this decision calibrates what "compelling
+  evidence" accepts;
+- a council reads procedural requirements out of supporting text rather than policy;
+- (objector side, in reverse) the marketing was short, overpriced against appraisals, or
+  post-decision — the inspector noted post-refusal marketing "would not align with the
+  spirit of the policy's intentions".
+
+**Distinguish when:**
+
+- the accommodation trades successfully or sits in a strong tourism market;
+- the condition's removal would create a *new* dwelling in an unsustainable location (here
+  the residential baseline already existed via a certificate of lawfulness).
+
+**Framework currency:** local tourism policy plus the NPPF condition tests; the
+supporting-text point is general interpretation. Re-cite current codes via the crosswalk. ⏳

--- a/appeal-precedent-analysis/precedents/6007017-box-dormer-not-subordinate.md
+++ b/appeal-precedent-analysis/precedents/6007017-box-dormer-not-subordinate.md
@@ -1,0 +1,47 @@
+---
+ref: "6007017"
+decision_date: 2026-06-15
+lpa: Three Rivers District Council
+site: 252 Baldwins Lane, Croxley Green, Hertfordshire
+development: Loft conversion with roof extension (part-retrospective; enlarged rear box dormer)
+outcome: dismissed
+procedure: written-representations
+nppf_edition: December 2024
+issues: [householder, dormer, subordination, fallback, retrospective]
+verified: 2026-08-19
+---
+
+**Finding (Y).** A near-full-width rear box dormer is not subordinate to the main roof and
+harms the host's architectural integrity; a smaller lawful-development fallback attracts
+only limited weight when the proposal exceeds it; and neighbours' existing large dormers
+are no justification.
+
+**Reasoning (Z).** The enlarged dormer would "extend to 8.2 meters in width... set only
+marginally down from the ridge line, extend virtually across the full width of the rear
+roof slope and be only set just above the eaves line. Given its overall size,
+three-dimensional form and location on the roof I do not consider that it would appear as
+subordinate to the main roof" (para 8). On the extant Lawful Development Certificate (a
+5.5m dormer): "the proposed dormer is larger and therefore more prominent than that
+approved... Accordingly, I have given the fall-back position limited weight in the
+planning balance" (para 10). On local examples: "the existence of other large box dormers
+is not an appropriate justification for permitting another here" (para 13). Mixed street
+character did not save it (para 12), and the absence of amenity/highway harm was "a
+neutral factor" (para 11).
+
+**Applies when:**
+
+- a dormer (or roof addition) approaches full roof-slope width, sits close to the ridge,
+  or lands at the eaves — the subordination tests in local design guidance are the hook;
+- the applicant leans on a PD/LDC fallback that is materially smaller than the proposal;
+- the applicant's precedent is neighbouring built examples rather than decisions.
+
+**Distinguish when:**
+
+- the proposal matches or is smaller than a real, evidenced fallback (the fallback then
+  works *for* the applicant — see [`6004335`](6004335-hmo-fallback-neutralises.md) for the
+  doctrine operating in that direction);
+- local guidance contains subordination exceptions the scheme meets.
+
+**Framework currency:** turns on local design policy and generic design expectations;
+unaffected in substance by the August 2026 NPPF recoding — cite the current design code
+via the crosswalk. ⏳

--- a/appeal-precedent-analysis/precedents/6007437-self-build-duty-gap.md
+++ b/appeal-precedent-analysis/precedents/6007437-self-build-duty-gap.md
@@ -1,0 +1,49 @@
+---
+ref: "6007437"
+decision_date: 2026-06-29
+lpa: South Holland District Council
+site: Land off Northgate, Pinchbeck, Spalding
+development: Single-storey 3-bedroom self-build dwelling
+outcome: allowed
+procedure: hearing
+nppf_edition: December 2024
+issues: [self-build, statutory-duty, spatial-strategy, car-dependency, design-innovation]
+verified: 2026-08-19
+---
+
+**Finding (Y).** Where a council cannot robustly demonstrate compliance with its statutory
+self-build duty, a UU-secured self-build plot attracts significant weight — enough, in a
+finely balanced case, to outweigh a found spatial-strategy conflict and accessibility
+harm. Separately: the "outstanding or innovative design" uplift is a high bar that
+established sustainability technology does not clear.
+
+**Reasoning (Z).** The burden of demonstrating duty-compliance rests with the council
+(agreed at the hearing, para 25); after a register purge by email exercise and
+inconsistent figures, "there is no consistent and robustly evidenced assessment which
+demonstrates, with sufficient clarity, that the statutory duty is now being met" (para 26)
+— so "I attach significant weight to that benefit" (para 27). This prevailed despite the
+inspector finding *against* the appellant on the spatial strategy (self-build has no
+functional need for a countryside location, paras 8–10), on accessibility (car-dominant,
+paras 18–23), and on design: "paragraph 139 is concerned with innovation in design rather
+than the incorporation of advanced or ambitious engineering solutions" (para 31). "This is
+a finely balanced case. However... the benefits, and in particular the provision of a
+secured self-build dwelling, outweigh the identified harm" (para 46).
+
+**Applies when:**
+
+- (applicant/supporter side) the authority's self-build register practice is challengeable
+  (purges, unexplained base-period figures) and the dwelling is secured as self-build by
+  obligation;
+- (objector side) an applicant claims the para-139 design uplift for conventional
+  architecture with bolt-on technology — this decision states the test;
+- (objector side) a self-build claim is unsecured — the weight followed the UU.
+
+**Distinguish when:**
+
+- the council evidences duty compliance with a consistent published assessment;
+- the harms are more than "finely balanced" against a single dwelling's benefits.
+
+**Framework currency:** the Self-build and Custom Housebuilding Act 2015 duty is statutory
+and unchanged. Para 139 (December 2024) and the spatial-strategy framework were recoded in
+August 2026 — verify the design-uplift equivalent and presumption mechanics via the
+crosswalk. ⏳

--- a/appeal-precedent-analysis/precedents/INDEX.md
+++ b/appeal-precedent-analysis/precedents/INDEX.md
@@ -1,0 +1,70 @@
+# Precedent index
+
+One line per record; full analysis in the linked file. Outcome key: ✗ dismissed ·
+✓ allowed · § conditions varied. All seed records are June 2026 decisions under the
+December 2024 NPPF (see each record's framework-currency note).
+
+## Green Belt / grey belt
+
+| Ref | Outcome | Principle |
+|---|---|---|
+| [APP/C3620/W/25/3374870](3374870-grey-belt-footnote7-exclusion.md) | ✗ | Footnote-7 assets (National Landscape, SSSI) exclude grey belt; remains "blended into the landscape" are not PDL |
+| [6004388](6004388-grey-belt-site-specific.md) | ✓ | Grey belt won on site-specific purposes assessment; strategic GB study that never assessed the parcel cannot rebut it; failed sequential test not automatic refusal |
+| [6001258](6001258-gb-spatial-openness-garage.md) | ✗ | Small invisible outbuilding still harms *spatial* openness; private benefit and neighbour examples are not VSC |
+| [6003735](6003735-gb-disproportionate-cumulative.md) | ✗ | Cumulative 244%/1,046m³ additions plainly disproportionate vs original dwelling; PD-rights growth doesn't stretch SPG guidelines |
+
+## Heritage
+
+| Ref | Outcome | Principle |
+|---|---|---|
+| [6002147](6002147-alien-typology-listed-setting.md) | ✗ | Borrowed typology with no local basis harms listed setting even at lower-end LTS; nearby modern development is no licence |
+| [6002414](6002414-heritage-balance-housing.md) | ✓ | Lower-end LTS harm outweighed by two dwellings absent a five-year supply; habitats reason cured by UU during appeal |
+
+## Location, settlement strategy and open land
+
+| Ref | Outcome | Principle |
+|---|---|---|
+| [6004523](6004523-car-dependent-location-pip.md) | ✗ | Car dependency evidenced at timetable level + backland form; boundary adjacency ≠ suitability |
+| [6001638](6001638-rounding-off-purposive.md) | ✓ | Rounding-off judged in the round, not boundary-by-boundary; officer advice notes carry limited weight |
+| [6003217](6003217-np-shield-attenuated.md) | ✓ | NP protection attenuates once its allocations are delivered and it cannot meet the evidenced need (self-build) |
+| [6003242](6003242-informal-land-is-open-space.md) | ✗ | Informal private land in public use is NPPF open space; surplus must be positively assessed; vague contributions fail |
+| [6004601](6004601-poor-quality-open-space.md) | ✓ | Poor-quality, functionless grassed area — loss attracts limited weight (mirror of 6003242) |
+
+## Habitats and ecology
+
+| Ref | Outcome | Principle |
+|---|---|---|
+| [6003059](6003059-pip-article-5b-habitats-bar.md) | ✗ | Article 5B bars PiP outright where SAC effects can't be screened out at PiP stage; ecology cannot wait for technical details |
+| [6004999](6004999-unsecured-habitats-mitigation.md) | ✗ | Willingness to complete mitigation ≠ secured mitigation; habitats gateway precedes any housing-supply balance |
+
+## HMOs and specialist accommodation
+
+| Ref | Outcome | Principle |
+|---|---|---|
+| [6005080](6005080-hmo-substandard-rooms.md) | ✗ | Bedrooms below standard + communal-room-as-corridor = substandard living conditions; licensing doesn't cure it |
+| [6005230](6005230-hmo-intensity-not-harm.md) | ✓ | Standards met → "greater intensity does not, in itself, amount to harm" (mirror of 6005080) |
+| [6004335](6004335-hmo-fallback-neutralises.md) | ✓ | Evidenced PD fallback resets the baseline to +2 occupants; threshold breach without amenity evidence is not harm |
+| [6005058](6005058-care-home-fallback-psed.md) | ✓ | LDC fallback with the same policy conflict + PSED benefits outweigh a no-identified-need conflict |
+| [6005193](6005193-threshold-without-policy-basis.md) | ✓ | Concentration threshold with no adopted-policy basis rejected; commissioning body's need evidence decisive |
+| [6005371](6005371-strategy-beats-assertion.md) | ✓ | Council's published Sufficiency Strategy beats its officer's unpublished "oversupply" assertion |
+
+## Permitted development and prior approval
+
+| Ref | Outcome | Principle |
+|---|---|---|
+| [6004263](6004263-class-q-scope-discipline.md) | ✓ | No locational-sustainability test in Class Q; obligations can't be demanded of PD; habitats routed via Reg 77 |
+
+## Conditions
+
+| Ref | Outcome | Principle |
+|---|---|---|
+| [6005514](6005514-temporary-trial-condition.md) | § | Uncertain intensification → 12-month temporary trial rather than refusal; cumulative-impact assertion vs no-complaints record |
+| [6006625](6006625-marketing-evidence-condition-removal.md) | § | 20-month adaptive, offer-free marketing = compelling evidence; supporting text lacks the force of policy |
+
+## Infrastructure, design and other
+
+| Ref | Outcome | Principle |
+|---|---|---|
+| [6002934](6002934-statutory-regime-deference.md) | ✓ | WWTW capacity: occupation-trigger conditions + statutory-undertaker duty; planning assumes other regimes work |
+| [6007017](6007017-box-dormer-not-subordinate.md) | ✗ | Near-full-width box dormer not subordinate; smaller LDC fallback = limited weight; neighbours' dormers no justification |
+| [6007437](6007437-self-build-duty-gap.md) | ✓ | Unevidenced self-build duty compliance → significant weight to a secured plot; para-139 design uplift is a high bar |

--- a/appeal-precedent-analysis/precedents/README.md
+++ b/appeal-precedent-analysis/precedents/README.md
@@ -1,0 +1,81 @@
+# Precedent corpus
+
+Structured records extracted from published Planning Inspectorate appeal decision letters.
+This is the skill's **data layer** (see repo rule: method in `../SKILL.md`, per-instance
+facts here). Records are analysis of public decisions — the published letter is always the
+authority; **re-verify every quote against the letter before it goes into a submission**.
+
+## Provenance and verification
+
+- Every record is drawn from a decision letter published by the Planning Inspectorate
+  (obtainable by appeal reference via the Inspectorate's public appeal services or the
+  LPA's planning register).
+- Every quote carries the decision letter's paragraph number, and each record carries the
+  date its quotes were verified against the letter.
+- The seed corpus (25 records) was extracted from June 2026 decision letters, verified
+  19 August 2026. All June 2026 decisions applied the **December 2024 NPPF** (paragraph
+  numbers) — the 17 August 2026 edition replaced these with coded policies, so every seed
+  record carries a framework-currency note. ⏳ Re-check currency at run time via the
+  **national-planning-policy** skill.
+
+## Personal data policy
+
+Decision letters are public documents, but records here are kept minimal:
+
+- **included**: appeal reference, decision date, LPA, site address (all part of the formal
+  public citation), development description, outcome, procedure;
+- **excluded**: appellant and agent names, and any other personal detail — they are not
+  needed to cite or verify a decision.
+
+## Record schema
+
+One file per decision, named `<ref>-<slug>.md`:
+
+```markdown
+---
+ref: "6004388"                  # the published appeal reference, quoted exactly
+decision_date: 2026-06-22
+lpa: North Warwickshire Borough Council
+site: Land between 10 and 32 Birmingham Road, Whitacre Heath
+development: Permission in Principle, limited infill residential (1–9 dwellings)
+outcome: allowed                # allowed | dismissed | split | conditions-varied
+procedure: hearing              # written-representations | hearing | inquiry
+nppf_edition: December 2024     # the edition the decision applied
+issues: [green-belt, grey-belt, flood-risk, housing-land-supply]
+verified: 2026-08-19            # date quotes were checked against the letter
+---
+
+**Finding (Y).** What the inspector concluded, in one or two sentences.
+
+**Reasoning (Z).** Why — with the decision's own words, quoted, with paragraph numbers.
+
+**Applies when:** bullets — the facts the reasoning ran on, phrased as testable conditions.
+
+**Distinguish when:** bullets — the differences that would defeat the parallel.
+
+**Framework currency:** which cited instruments/paragraphs are superseded, what the
+current equivalent is (via the national-planning-policy crosswalk), and whether the test
+survived in substance.
+```
+
+Keep the `issues` tags to the shared vocabulary already in use across records (grep before
+inventing a new tag).
+
+## Adding records (the pipeline)
+
+1. Obtain the month's decision letters (public record; observe the responsible-use rules in
+   the repo — identify yourself, pace requests, never defeat a bot challenge).
+2. Read the letter in full; only record findings that were **determinative** of the appeal
+   or of a main issue.
+3. Extract the record: quote the operative sentences verbatim with paragraph numbers;
+   derive "applies when" from the facts the inspector actually relied on, and "distinguish
+   when" from the facts the inspector said mattered (including any precedent the inspector
+   distinguished).
+4. Note the NPPF edition in force at the decision date and write the framework-currency
+   note against the current edition.
+5. Strip personal names; keep the citation fields.
+6. Date-stamp `verified:` and add the record to `INDEX.md`.
+
+A record that merely repeats a policy test with no site-specific reasoning adds nothing —
+the policy itself is the better citation. Record decisions whose reasoning *turns facts
+into conclusions* in a way a future case can match.

--- a/appeal-precedent-analysis/references/comparability-and-weight.md
+++ b/appeal-precedent-analysis/references/comparability-and-weight.md
@@ -1,0 +1,140 @@
+# Comparability and weight
+
+How to decide whether an appeal decision genuinely applies to the application in front of
+you, how much weight to claim for it, and how to draft it so it survives contact with the
+case officer. Calibrated against observed inspector practice in a coded sample of 200
+June 2026 decision letters (references below are to records in `../precedents/`).
+
+## 1. What inspectors actually do with cited precedents
+
+The evidence from the coded sample, in both directions:
+
+- **The default is to distinguish.** Where a party cited an appeal decision without its
+  full facts, the standard response was: *"I do not have full details of these cases, or
+  plans showing the proposals, before me"* (appeal ref 6005048, decision of 3 June 2026,
+  para 9), followed by determination on the case's own merits. Twelve of sixty allowed
+  planning appeals in the sample expressly distinguished a cited precedent.
+- **Consistency is acknowledged, then bounded.** From an inquiry decision (appeal ref
+  6002485, decision of 11 June 2026, para 26): *"While I am mindful of the importance of
+  consistency in appeal decision making, it is also important that each decision is made
+  on its individual merits."*
+- **What worked**: a directly comparable decision — same street, same issue, same policies
+  — was *"a material consideration of great weight"* and was followed on both disputed
+  issues (appeal ref 6004619, decision of 24 June 2026, paras 14 and 20).
+- **Local mimicry is not comparability**: *"the existence of other large box dormers is not
+  an appropriate justification for permitting another here"* ([`6007017`](../precedents/6007017-box-dormer-not-subordinate.md)) —
+  physical examples nearby are not decisions, and even decisions nearby fail if the
+  reasoning does not transfer.
+
+Design consequences: quote the decision, attach or link the letter, argue the reasoning
+not the outcome, and pre-empt the distinction.
+
+## 2. The Z-test in detail
+
+A precedent applies only if all four limbs pass.
+
+### 2.1 Determinativeness
+Read the decision's "main issues" and its conclusion. The finding you rely on must be one
+the appeal (or a main issue) actually turned on. Warning signs:
+
+- the finding appears under "Other Matters";
+- the inspector says the point "is not determinative";
+- the appeal was decided on a different issue and your point was never resolved (e.g. a
+  Permission in Principle dismissed on the habitats gateway where every other issue was
+  expressly left undecided — [`6003059`](../precedents/6003059-pip-article-5b-habitats-bar.md)).
+
+### 2.2 Factual match on the operative conditions
+Each precedent record lists **applies-when** conditions — the facts the reasoning ran on.
+Match them against this application's documents, and cite the matching evidence
+(document, paragraph, drawing) next to each condition. If a condition cannot be evidenced
+here, the precedent drops a tier or drops out.
+
+### 2.3 Framework currency
+Most stored decisions were made under superseded national policy: every pre-August-2026
+decision cites NPPF **paragraph numbers**, which the 17 August 2026 edition replaced with
+coded policies — and some mechanisms changed substantively, not just editorially. Check the
+record's `nppf_edition` and **Framework currency** note, then verify through the
+**national-planning-policy** skill's register and crosswalk. Three situations:
+
+- **Test unchanged in substance** (e.g. Green Belt openness/VSC, heritage
+  less-than-substantial balance, HMO amenity standards): the precedent's reasoning
+  transfers; cite the current code alongside the decision's own wording.
+- **Test re-mechanised** (e.g. the paragraph-11 "tilted balance" replaced by the
+  location-based S3–S6 presumption): outcome-level reliance fails; component findings
+  (e.g. what weight a car-dependent location attracts) may still transfer — say which and
+  why.
+- **Test abolished or new**: the precedent is history, not authority. Drop it.
+
+### 2.4 The distinctions
+Write down, before drafting, the best case *against* the parallel: scale, constraint
+context, fallback positions, evidence posture (what was and wasn't before that inspector),
+plan status then vs now. If a distinction goes to the reason the finding was made, the
+precedent fails the test — a distinction that is merely present but did not drive the
+reasoning can be pre-empted in a sentence.
+
+## 3. Weight tiers
+
+| Tier | Relationship | Claim you can make |
+|---|---|---|
+| 1 | Same site / linked site | Departure without reasons is inconsistency on its face |
+| 2 | Same LPA + same policy + comparable context | Strong material consideration; expect it to be followed or expressly distinguished |
+| 3 | Same policy wording or national test, elsewhere | Persuasive on how the *test* is applied, not on outcome |
+| 4 | Transferable reasoning only | Use the logic; do not lean on the citation |
+
+Adjustments, applied openly rather than silently:
+
+- **Recency** — a decision under the current plan and current NPPF edition outranks an
+  older one on the same point.
+- **Procedure** — inquiry > hearing > written representations, as a proxy for how hard the
+  evidence was tested (the June 2026 sample ran 59% / 52% / 30% allowed — a selection
+  effect, but also a signal of scrutiny depth).
+- **Batch caution** — linked decisions (advert batches, paired appeals) are one decision's
+  reasoning, not several concurring authorities; cite one and note the batch.
+- **Subsequent history** — a decision quashed by the courts, or overtaken by a later
+  same-site decision, is not authority. Check before relying on it. ⏳
+- **Costs decisions** — an accompanying costs award against a council for unreasonable
+  refusal sharpens a Tier 1–2 precedent; note it where it exists.
+
+## 4. The adverse-precedent duty
+
+Run every search in both directions. The coded sample contains near-mirror pairs — the
+same test passing on one set of facts and failing on another:
+
+- *open space*: an informal verge held to be NPPF open space, dismissal
+  ([`6003242`](../precedents/6003242-informal-land-is-open-space.md)) vs a poor-quality
+  grassed area enclosed with limited weight to the loss
+  ([`6004601`](../precedents/6004601-poor-quality-open-space.md));
+- *HMO intensity*: rooms below standard, dismissal
+  ([`6005080`](../precedents/6005080-hmo-substandard-rooms.md)) vs rooms meeting the
+  nationally described space standards, allowed — *"greater intensity does not, in itself,
+  amount to harm"* ([`6005230`](../precedents/6005230-hmo-intensity-not-harm.md)).
+
+If the adverse decision is the closer match, the honest advice is that the ground is weak —
+route that conclusion to **planning-balance**, do not bury it. A representation that cites
+only the favourable half of a known pair invites the officer to complete the pair.
+
+## 5. Drafting patterns
+
+The five-part passage (citation → quoted finding → evidenced parallel → consistency ask →
+pre-emption), worked:
+
+> In appeal ⟨ref⟩ (⟨site⟩, decision of ⟨date⟩, attached), the Inspector dismissed a
+> proposal for ⟨development⟩, finding at paragraph ⟨n⟩ that *"⟨operative words⟩"*. The
+> same circumstances arise here: ⟨this application's document ref⟩ shows ⟨fact matching
+> the applies-when condition⟩. Consistency in decision-making requires like cases to be
+> determined alike or reasons given for departure; the Council is asked to reach the same
+> conclusion, or to explain the material difference. The ⟨obvious distinction⟩ does not
+> assist the applicant, because ⟨one-sentence answer⟩.
+
+Rules that keep it credible:
+
+- **quote, don't characterise** — the decision's words with paragraph numbers; a
+  paraphrase invites "that is not what the Inspector said";
+- **one precedent per point, best tier first** — three weak citations read as padding and
+  invite three distinctions;
+- **never claim it binds** — "requires consistency or reasons" is the strongest honest
+  formulation;
+- **attach the letter** (or give the public reference and source) — the observed failure
+  mode is discounting for want of the full decision;
+- **cite the current policy code alongside the decision's citation** where the framework
+  has been recoded since the decision.

--- a/application-triage/CHANGELOG.md
+++ b/application-triage/CHANGELOG.md
@@ -6,6 +6,12 @@ intent.
 
 ## Unreleased
 
+### Added
+- **Step 5 routing table gains a row for the new `appeal-precedent-analysis` skill.**
+  _Why:_ the router should know the whole chain; the row states the ordering constraint
+  (run after a ground is evidenced) and the limit (a precedent strengthens a ground, it
+  cannot create one) so triage doesn't route to it prematurely.
+
 ### Changed
 - **Step 6's hand-off summary rewritten as a bulleted spec (#22): ranked grounds each on
   their own line, non-material concerns as a short list with reasons, or the plain

--- a/application-triage/SKILL.md
+++ b/application-triage/SKILL.md
@@ -153,6 +153,7 @@ For each ground worth pursuing, name the representation skill that handles it an
 | Other material considerations (design, amenity, Green Belt, landscape, …) | *no dedicated skill yet — see the map for the framework and argue on the documents' own facts* |
 | Compliance with the adopted development plan, policy by policy | **policy-compliance-assessment** (the policy foundation — run early; it underpins every ground) |
 | Drafting the policy case, in support **or** objection | **policy-representation** (after the policy assessment) |
+| Reinforcing an evidenced ground with decided appeal authority — or distinguishing a decision the applicant cites | **appeal-precedent-analysis** (after the ground is evidenced; a precedent strengthens a ground, it cannot create one) |
 | Final check — does the assembled case justify the ask? | **planning-balance** (run last, after the representation skills) |
 
 Recommend an order (lead with the decision-critical grounds). Note where two skills should

--- a/commands/README.md
+++ b/commands/README.md
@@ -10,7 +10,7 @@ invoke it by name:
 - `/policy-compliance-assessment` · `/policy-representation`
 - `/ecological-representation` · `/transport-representation` · `/heritage-representation` ·
   `/flood-representation`
-- `/national-planning-policy` · `/planning-balance`
+- `/national-planning-policy` · `/planning-balance` · `/appeal-precedent-analysis`
 
 So you do **not** need a wrapper command for a single skill — the skill *is* the command.
 (Custom commands and skills are the same system now: a `.claude/commands/x.md` and a


### PR DESCRIPTION
New skill: apply decided appeal precedents to a planning application, so a representation can argue *"In appeal decision X, the Inspector found Y because of Z — the same Z arises here, so consistency requires Y, or reasons for departing from it."*

## Design (evidence-led)

Built from the June 2026 decision-letter study (1,505 letters, 200 read and coded in full). The study's key lesson shaped the skill: **inspectors distinguish cited precedents almost by default** ("I do not have full details of these cases… before me" — 12 of 60 allowed planning appeals expressly distinguished a party's precedent), while the one citation that received "**a material consideration of great weight**" was same-street, same-issue, same-policy, and quoted. So the skill's centre of gravity is a **comparability test**, not the citation:

1. was the finding **determinative** in the precedent;
2. are the operative facts (**applies-when** conditions) evidenced in this application;
3. is the **framework still current** — every seed decision predates the 17 Aug 2026 NPPF recoding, so each record carries a framework-currency note wired to the national-planning-policy crosswalk;
4. what will the other side use to **distinguish** it.

Plus: weight tiers (same site → same LPA/policy → same test → reasoning-only), a **mandatory adverse-precedent step** (the corpus deliberately contains mirror pairs — e.g. open-space loss dismissed vs allowed, HMO rooms below standards vs meeting them), and a five-part drafting shape ending with the *North Wiltshire* consistency ask (citation verified: (1992) 65 P&CR 137).

## Data layer

`precedents/` — 25 structured seed records (10 dismissals, 15 allowals/variations) extracted from June 2026 decisions across Green Belt/grey belt, heritage, location/open space, habitats, HMOs/care homes, PD scope, and conditions. Every quote is verbatim with its paragraph number, verified 19 Aug 2026 against the letters. Records carry only public citation fields (reference, date, LPA, site, outcome) — no appellant, agent, or inspector names. Schema + provenance rules + a pipeline for adding future months in `precedents/README.md`.

## Wiring

- `application-triage`: new routing row (run after a ground is evidenced; a precedent strengthens a ground, it cannot create one) + changelog entry.
- Root `README.md`: skill table entry and chain step 6.
- `commands/README.md`: slash-command list.

House rules observed: bullet discipline (rule 9) in the skill's own output instructions, two-layer method/data split (rule 2), evidence-before-assertion with ⏳ flags (rule 3), personal data minimised (rules 1/4), changelog with rationale (rule 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dg62ktGPUauVwt8qNuQHQ8