### PR TITLE
Archive the December 2024 NPPF edition skills (nppf-2024-12/)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,15 @@ Repo root also has a top-level `README.md` and `LICENSE`.
    single prose sentence — the model mirrors the register of its instructions, so an
    instruction written as a semicolon-run produces output written as semicolon-runs.
 
+10. **Edition archives are frozen.** `nppf-YYYY-MM/` directories are snapshots of the
+    NPPF-dependent skills as they stood under a superseded NPPF edition (currently
+    `nppf-2024-12/`). Never edit, re-map, or backport fixes into them — their value is
+    being exactly what ran under that edition (the only permitted deltas are the
+    collision-safety name suffix and ARCHIVED description prefix applied at snapshot
+    time). When a future NPPF edition lands: **snapshot the then-current skills into a
+    new `nppf-YYYY-MM/` directory first, then re-map** — the routing rule lives in
+    `national-planning-policy`'s edition register and the archive README.
+
 ## CHANGELOG format
 
 Each skill's `CHANGELOG.md` follows this shape. Newest entry on top. Each entry is dated

--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ Considerations without a dedicated skill yet (design, residential amenity, Green
 landscape, trees, air quality…) are covered by the triage skill's framework map, to argue on
 the application's own facts.
 
+## Older NPPF editions
+
+The skills above are written for the **17 August 2026 NPPF** (coded policies). A frozen
+snapshot of the nine NPPF-dependent skills as written for the **December 2024 edition**
+lives in [`nppf-2024-12/`](nppf-2024-12/) — for retrospective work on applications and
+appeals decided before 17 August 2026. They are offered only when you explicitly ask to
+work under the old framework (and are asked to confirm); live applications always use the
+current skills. See that directory's README for the rules and the known limitations of
+the frozen snapshot.
+
 ## How to use
 
 These are **skills for Claude** — instruction sets Claude follows when you ask it to do

--- a/national-planning-policy/CHANGELOG.md
+++ b/national-planning-policy/CHANGELOG.md
@@ -6,6 +6,18 @@ intent.
 
 ## Unreleased
 
+### Added
+- **Edition register now routes explicit prior-edition requests to the frozen archive at
+  `../nppf-2024-12/` (#31), behind an ask-first gate.** _Why:_ the August 2026 re-map made
+  the December 2024 edition skills reachable only through git history; users doing
+  retrospective work (pre-Aug-2026 decisions, era-pinned analysis) need them on main. The
+  gate is deliberately narrow — only an explicit request to *work under* the old framework
+  triggers the offer; incidental old paragraph numbers in dated documents keep using the
+  current skills plus the crosswalk, and live applications always use the current edition.
+  The archive is frozen (no re-mapping, no fix backports — see the new house rule in
+  `../CLAUDE.md`), and its skills carry `-nppf-2024-12` name suffixes so installed copies
+  cannot collide with current ones.
+
 ### Changed
 - **The decision-making core is re-mapped to the 17 August 2026 coded-policy edition and
   re-verified against the official PDF (18 Aug 2026).** Every citation now uses the new

--- a/national-planning-policy/SKILL.md
+++ b/national-planning-policy/SKILL.md
@@ -95,6 +95,20 @@ Before a draft leaves any companion skill:
   determination (the crosswalk file maps between the two). Annex A also carries transitional
   rules for plan-making — some emerging plans continue under the December 2024 text (Annex
   A(4)–(8)).
+- **Archived December 2024 edition skills** live at [`../nppf-2024-12/`](../nppf-2024-12/)
+  — a frozen snapshot of the nine NPPF-dependent skills as written for the prior edition.
+  The rule for offering them:
+  - only an **explicit** request to work under the December 2024 framework triggers the
+    offer — the user asks for "NPPF 2024" / "the old NPPF", deliberately cites old
+    paragraph numbers as the framework to apply, or asks to assess a pre-August-2026
+    decision "under the framework it was decided under";
+  - then **ask** whether they want the archived edition skills; use them for that task
+    only if they say yes, and state clearly in any output that it cites a superseded
+    framework;
+  - an **incidental** mention of old paragraph numbers (a dated document quoting them, a
+    consultee response, an old officer report) is *not* such a request — stay on the
+    current skills and translate via the crosswalk;
+  - live applications determined from 17 August 2026 use the current edition regardless.
 - **PPG**: web-based guidance suite, revised page-by-page — no single edition; rely on
   per-page "last updated" dates. ⏳ Expect a lag before PPG pages cross-refer to the new
   policy codes — verify each page's currency when citing it alongside the new NPPF.

--- a/nppf-2024-12/README.md
+++ b/nppf-2024-12/README.md
@@ -1,0 +1,42 @@
+# Archived skills — December 2024 NPPF edition
+
+**Frozen snapshot.** These are the nine NPPF-dependent skills exactly as they stood before
+the repository was re-mapped to the 17 August 2026 coded-policies NPPF (issue #16 /
+PR #21) — i.e. as written for the **December 2024 NPPF** (paragraph-numbered, in force
+12 December 2024 to 16 August 2026). Snapshot taken from commit `eadf859`; the only
+changes made to the frozen content are the `-nppf-2024-12` name suffix and the "ARCHIVED"
+description prefix in each `SKILL.md`, to prevent collisions with the current skills.
+
+> **Not for live applications.** Applications determined from 17 August 2026 are decided
+> under the current NPPF — use the current skills in the repository root for those, even
+> when older documents in the case cite old paragraph numbers (the current
+> `national-planning-policy` skill carries a December 2024 → August 2026 crosswalk for
+> exactly that situation).
+
+## When these archived skills are the right tool
+
+- Retrospective analysis of applications or appeals **decided before 17 August 2026**,
+  in the framework the decision-maker actually applied.
+- Understanding or checking a pre-August-2026 officer report, decision notice, or
+  inspector decision on its own terms.
+- Era-pinned test fixtures and academic comparison of the two frameworks.
+
+## How they are invoked
+
+Only on an **explicit** request to work under the December 2024 framework, and only after
+confirming that is what the user wants — the rule lives in the current
+`national-planning-policy` skill. An incidental mention of old paragraph numbers is not a
+request to use these skills. Any output produced with them must say clearly that it cites
+a superseded framework.
+
+## Frozen means frozen
+
+- Nothing here is maintained: no re-mapping, no fix backports. Known artefact: this
+  snapshot predates the output-style discipline added under issue #22, so drafted output
+  may show the older long-paragraph style.
+- Future NPPF editions follow the same pattern: snapshot the then-current skills into a
+  new `nppf-YYYY-MM/` directory **before** re-mapping (see the house rule in
+  `../CLAUDE.md`).
+
+The excluded skills: `planning-document-search` is edition-neutral (use the live copy);
+`appeal-precedent-analysis` post-dates the re-map and has no December 2024 edition.

--- a/nppf-2024-12/application-triage/CHANGELOG.md
+++ b/nppf-2024-12/application-triage/CHANGELOG.md
@@ -1,0 +1,79 @@
+# Changelog — application-triage
+
+Design decisions per revision, newest first. See `../CLAUDE.md` for the format and the
+house rules. The **_Why_** lines record the rationale so a future editor understands the
+intent.
+
+## Unreleased
+
+### Changed
+- **Step 2 now hands the policy work off to the new `policy-compliance-assessment` skill**,
+  keeping only what triage needs to route, and the routing table gains rows for that skill and
+  for `policy-representation`. _Why:_ two-layers house rule — Step 2's four-item list was a
+  framework summary standing in for a method the repo did not yet have. Now that a skill owns
+  identifying the adopted plan and scoring accordance policy by policy, triage should point at
+  it rather than imply the assessment can be done in passing. The hand-off also carries the
+  reminder that adopted policies are the local authority's own and have primacy over national
+  policy, which is the hierarchy a lay user most often inverts.
+- **Step 4's "so-what" test and the routing table now hand off to the new
+  `planning-balance` companion skill** as the final step of the chain. _Why:_ the test
+  needs the evidenced grounds to run properly; naming the skill makes the chain explicit.
+- **Step 2 (decision framework) now points to the companion `national-planning-policy`
+  skill** for the edition register, verify-before-citing protocol, and the shared s.38(6)/
+  presumption citations — including checking whether the tilted balance is engaged or
+  disapplied. _Why:_ one shared register instead of per-skill NPPF snapshots that drift.
+
+### Added
+- **New Step 2 — "Establish the decision framework (s.38(6))":** adopted development plan →
+  relevant policies → emerging plan and its weight → neighbourhood plan → national policy,
+  before scanning for grounds; findings are anchored to named plan policies. _Why:_ reviewer
+  feedback — determination legally starts with the development plan, and grounds framed as
+  conflict with named plan policies are the strongest an objector can raise; the plan was
+  previously an afterthought.
+- **Planning history in intake:** previous applications, refusals, appeal decisions on the
+  same site, enforcement, extant permissions/conditions, s73s. _Why:_ a previous Inspector's
+  decision on the same site can outweigh any generic policy argument.
+- **Consultee map in `references/material-considerations.md`** (who speaks to what), with an
+  instruction to locate and read the matching response for every engaged consideration.
+  _Why:_ generalises the ecology skill's "the LPA ecologist is the strongest anchor" insight
+  across the system; a consultee's requested conditions are a ready-made ask.
+- **"So-what" test in ranking (A/B/C):** each ground is classified as demonstrated harm (A),
+  insufficient evidence (B), or conditionable (C), with an honest view on whether the grounds
+  together would plausibly justify refusal. _Why:_ a list of technically valid criticisms is
+  not itself a case for refusal; this stops impressive-but-ineffective objections.
+
+### Changed
+- **"What you need first" now says uploaded/pasted/already-downloaded documents work
+  directly, and `planning-document-search` is only needed when the user doesn't have
+  them.** _Why:_ makes explicit that direct document supply is a first-class input, and
+  completes the retrieval skill's fail-fast handover (stop → download manually → feed the
+  files back in here).
+
+## 0.1.0 — 2026-08-14 — Initial release
+
+First version: the **router** for the representation skills. Given an application, it
+identifies the engaged material considerations, ranks them, and routes each to the skill that
+handles it. Structure: `SKILL.md` + `references/material-considerations.md`. Key design
+decisions:
+
+### Added
+- **A router, not a drafter.** _Why:_ the suite had drafting skills but nothing to answer the
+  lay user's real first question — "what should I object about?" Triage fills that gap and ties
+  the skills together; it hands off rather than drafting.
+- **Detection from the document list and site constraints.** _Why:_ the applicant's own
+  submitted reports (and their telling *absence*) plus the site's constraints
+  (`planning.data.gov.uk`, the EA flood map, the local plan) are the fastest, most reliable
+  signal of which considerations are engaged — more reliable than reading every document first.
+- **An explicit non-material list, with reframes.** _Why:_ lay objectors most often lose
+  credibility by raising non-material concerns (loss of view, property values, competition,
+  private disputes). Naming them — and offering a material reframe where one exists — is as
+  valuable as naming the good grounds.
+- **Honest ranking (decision-critical / supporting / weak) and a "no strong ground" output.**
+  _Why:_ consistent with the suite's integrity principle — the point is to spend effort where
+  it counts, and sometimes the honest answer is not to object.
+
+### Notes
+- Routes to `ecological-representation`, `transport-representation`, `heritage-representation`
+  and `flood-representation`; for considerations without a dedicated skill yet (design,
+  amenity, Green Belt, landscape, trees, air quality, …) it gives the framework to argue on
+  the application's own facts. Add routes here as new representation skills are built.

--- a/nppf-2024-12/application-triage/LICENSE
+++ b/nppf-2024-12/application-triage/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ian Howard
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/nppf-2024-12/application-triage/README.md
+++ b/nppf-2024-12/application-triage/README.md
@@ -1,0 +1,38 @@
+# Application Triage
+
+The **router** for the planning representation skills. Given a UK planning application, it
+works out which material planning considerations are actually engaged, ranks them, and routes
+each to the skill that handles it — or says plainly that there is no strong ground to object.
+
+> **Not legal advice. No warranty.** A starting assessment provided "as is"; **a human must
+> review the grounds and evidence before acting.** Anything later submitted to a council is
+> published on its portal in the submitter's name.
+
+## What it does
+
+- Reads the application (via the reference + council, or the documents) and its site
+  constraints.
+- Identifies the engaged material considerations from the proposal, the constraints, and the
+  presence or telling *absence* of technical documents.
+- **Ranks** them (decision-critical / supporting / weak) and **sets aside non-material
+  concerns** (loss of view, property values, competition, private disputes) — with a reframe
+  where one exists.
+- **Routes** each live ground to its representation skill.
+
+## Contents
+
+| File | What it is |
+|---|---|
+| `SKILL.md` | The skill: workflow, the integrity principle, and the routing table. **Start here.** |
+| `references/material-considerations.md` | The map: each consideration's tells, the skill/framework that handles it, and the non-material concerns to exclude. |
+| `CHANGELOG.md` | Design decisions and their rationale, per revision. |
+
+## Pairs with
+
+- **planning-document-search** — fetches the application documents and the constraint signals.
+- **ecological-representation**, **transport-representation**, **heritage-representation**,
+  **flood-representation** — the drafting skills this one routes to.
+
+## License
+
+MIT — see [`LICENSE`](LICENSE). Provided as-is, with no warranty; not legal advice.

--- a/nppf-2024-12/application-triage/SKILL.md
+++ b/nppf-2024-12/application-triage/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: application-triage-nppf-2024-12
+description: >-
+  ARCHIVED - December 2024 NPPF edition (superseded 17 August 2026). Use only when the user explicitly asks to work under the pre-August-2026 framework and has confirmed they want the archived skills; outputs must state they cite a superseded framework. 
+  Given a UK planning application, work out which material planning
+  considerations are actually engaged and which representation skill(s) to run
+  (ecology, transport, heritage, flood risk, …), in what priority order — or
+  advise that there is no strong ground to object. The router for the planning
+  representation skills. England-focused. Not legal advice; human review required.
+license: MIT
+---
+
+# Planning application triage
+
+Help a member of the public who has an application in front of them but doesn't know **which
+grounds are worth pursuing**. This skill reads the application, identifies the material
+considerations that are genuinely engaged, ranks them, and routes each to the representation
+skill that handles it — or says plainly that there is no strong objection.
+
+It is the **router** for the representation skills, not a drafting skill itself. It answers
+"what should I object about, and how strong is each ground?", then hands off.
+
+## When to use
+
+The user has a planning application (a reference + council, or the documents) and asks
+something like: "should I object to this?", "what are the grounds?", "what's wrong with this
+application?", "which of these is worth raising?" Use it first, before the topic-specific
+skills, whenever the grounds aren't already decided.
+
+## What you need first
+
+- The **application reference and council**, or the **documents themselves** — uploaded,
+  pasted, or already-downloaded files work directly; the companion
+  **planning-document-search** skill is only needed when you don't have them (it
+  retrieves them from the reference + council).
+- The **proposal description and application type** (full / outline / reserved matters / s73
+  / listed building consent / householder …) — this frames everything.
+- The **site's planning constraints** — is it in a conservation area, near a listed building,
+  in a flood zone, Green Belt, an AONB/National Landscape, greenfield? Public constraint data
+  (e.g. `planning.data.gov.uk` for conservation areas, listed buildings, Article 4 directions;
+  the Environment Agency "Flood map for planning" for flood zones) tells you this without the
+  application documents.
+- The **document list itself** — it is the single best signal. The presence of an *Ecological
+  Impact Assessment*, *Transport Assessment*, *Heritage Statement* or *Flood Risk Assessment*
+  tells you which considerations the applicant themselves thought were engaged.
+- The **development plan** for the area — the adopted local plan (and any made neighbourhood
+  plan), from the council website. Determination starts here (see Step 2), so the relevant
+  policies are needed before grounds can be ranked; the companion
+  **policy-compliance-assessment** skill identifies and verifies the adopted plan and assesses
+  the proposal against it.
+- The **site's planning history** — previous applications and refusals, **appeal decisions on
+  the same site**, enforcement history where relevant, extant permissions and their
+  conditions, and any s73 variations. Portals list related applications on the detail page; a
+  previous Inspector's decision on the same site can be worth more than any generic policy
+  argument, and a recent refusal tells you what the LPA already considers unacceptable.
+
+## The integrity principle
+
+**Only flag a ground that is genuinely engaged and arguable.** Triage is not a licence to
+manufacture objections — if the application is sound, or a consideration is not actually in
+play, say so. Two disciplines in particular:
+
+- **Distinguish material from non-material.** Objections must rest on *material planning
+  considerations*. Common **non-material** concerns to set aside (or reframe): loss of a
+  private view; impact on property values; competition with an existing business; boundary or
+  covenant disputes; the identity or motives of the applicant; construction disturbance in
+  itself (as opposed to a permanent effect); and moral objections. Tell the user honestly when
+  their concern isn't material — and whether it can be reframed as one that is (e.g. "it will
+  ruin my view" is not material, but "it is overbearing and harms the character of the street"
+  may be).
+- **Rank honestly.** Not every engaged ground is a *strong* ground. Say which are decision-
+  critical, which are supporting, and which are weak — so the user spends effort where it
+  counts.
+
+## Workflow
+
+### Step 1 — Intake
+Get the application (reference + council, or documents), the proposal and its **type/stage**,
+the **site constraints** (conservation area, listed buildings, flood zone, Green Belt,
+AONB, greenfield/brownfield, protected trees), and the **site's planning history** (previous
+applications, refusals, appeal decisions, enforcement, extant permissions and conditions,
+s73s — see "What you need first"). Retrieve the **document list**.
+
+### Step 2 — Establish the decision framework (s.38(6))
+Section 38(6) of the Planning and Compulsory Purchase Act 2004 requires applications to be
+determined **in accordance with the development plan unless material considerations indicate
+otherwise** — so the development plan is the starting point, not an afterthought. Before
+scanning for grounds, establish:
+
+1. the **adopted development plan** — the local plan (and any joint/minerals/waste plans) and
+   any made **neighbourhood plan**;
+2. the **relevant policies** for this proposal and site (settlement boundaries, housing,
+   design, amenity, and the topic policies for each consideration);
+3. any **emerging plan** and the weight it can carry (stage of preparation, unresolved
+   objections, consistency with national policy);
+4. **national policy** (NPPF/PPG) as a material consideration alongside the plan.
+
+Grounds framed as **conflict with named development-plan policies** are the strongest kind an
+objector can raise — anchor each finding in Step 3 to a plan policy wherever one exists.
+
+Triage needs only enough of this to route. The companion **policy-compliance-assessment** skill
+does the work in full — identifying and verifying the **adopted** plan (adoption dates,
+superseded and saved policies, the policies map), assessing the proposal policy by policy, and
+scoring accordance from -2 to +2. Hand off to it for the policy foundation; don't attempt the
+full assessment here. Remember that the adopted policies are the **local authority's own** and
+carry primacy: national policy sits alongside the plan as a material consideration, not above it.
+
+The companion **national-planning-policy** skill holds the current NPPF/PPG edition
+register, the verify-before-citing protocol, and the shared decision-making citations
+(s.38(6) and plan primacy, the para 11 presumption/"tilted balance" and its footnotes,
+emerging-plan weight) — use it for this step, including checking whether the tilted balance
+is engaged or disapplied for this site.
+
+### Step 3 — Scan for engaged considerations
+Work through [`references/material-considerations.md`](references/material-considerations.md).
+For each consideration, check the *tells* — the application type, the proposal, the site
+constraints, and the presence (or telling *absence*) of the relevant technical document. Note
+the evidence for each ground you flag. For each engaged consideration, **locate and read the
+matching consultee response** (the consultee map in the reference file says who speaks to
+what) — read them before ranking, and note where a consultee objects, seeks conditions, or is
+silent.
+
+### Step 4 — Rank
+Grade each engaged ground: **decision-critical / supporting / weak**, on the strength of (a)
+how clearly the development plan or national policy is engaged, (b) whether the applicant's
+evidence looks thin or is missing, and (c) how much weight the consideration typically
+carries. Set aside non-material concerns (with a reframe where possible).
+
+Then apply the **"so-what" test**: a list of technically valid criticisms is not itself a
+case for refusal. Note for each ground whether it points to **(A)** a demonstrated
+unacceptable impact (a refusal reason), **(B)** insufficient evidence for the Council to
+reach the necessary conclusion (a "do not determine yet" ask), or **(C)** something a
+condition or obligation could secure (a mitigation ask) — and say honestly whether the
+grounds, taken together, would plausibly justify refusal under the applicable tests, or
+whether the credible representation is one that seeks information and conditions. The
+companion **planning-balance** skill runs this test in full once the representation skills
+have evidenced the grounds — recommend it as the final step of the chain.
+
+### Step 5 — Route
+For each ground worth pursuing, name the representation skill that handles it and hand off:
+
+| Consideration | Skill |
+|---|---|
+| Ecology / biodiversity / protected species / BNG | **ecological-representation** |
+| Transport / highways / access / parking / active travel | **transport-representation** |
+| Heritage / listed buildings / conservation areas / archaeology | **heritage-representation** |
+| Flood risk / drainage / SuDS | **flood-representation** |
+| Other material considerations (design, amenity, Green Belt, landscape, …) | *no dedicated skill yet — see the map for the framework and argue on the documents' own facts* |
+| Compliance with the adopted development plan, policy by policy | **policy-compliance-assessment** (the policy foundation — run early; it underpins every ground) |
+| Drafting the policy case, in support **or** objection | **policy-representation** (after the policy assessment) |
+| Final check — does the assembled case justify the ask? | **planning-balance** (run last, after the representation skills) |
+
+Recommend an order (lead with the decision-critical grounds). Note where two skills should
+both run (a scheme often engages several).
+
+### Step 6 — Hand off / summarise
+Tell the user: the grounds worth objecting on (ranked, each anchored to the development-plan
+policies it engages and classified A/B/C), which skill will draft each, the non-material
+concerns to drop, and — if that's the honest answer — that there is no strong ground and an
+objection would not be sustainable.
+
+## Reference files
+
+- [`references/material-considerations.md`](references/material-considerations.md) — the
+  catalogue of material considerations: what each is, the tells that it's engaged, the skill
+  or framework that handles it, and the common non-material concerns to exclude.
+
+## Scope and limitations
+
+- **Not legal advice; no warranty; output requires human review.** Triage is a starting
+  assessment, provided "as is"; a person must confirm the grounds and the evidence before
+  acting.
+- **England-focused.** Material considerations are broadly similar across the UK but the
+  policy framework differs in the devolved nations — flag when the application is outside
+  England.
+- **A UK planning representation is public and in the submitter's name** — carry that warning
+  through to whichever representation skill drafts the objection.
+- **"No strong ground" is a valid, valuable output.** Say it when it's true.

--- a/nppf-2024-12/application-triage/references/material-considerations.md
+++ b/nppf-2024-12/application-triage/references/material-considerations.md
@@ -1,0 +1,159 @@
+# Material considerations — a triage map
+
+For each consideration: **what it is**, the **tells** that it's engaged (from the application
+type, the proposal, the site constraints, and the presence or *absence* of a technical
+document), the **skill or framework** that handles it, and a note on how much weight it
+typically carries. Then a list of **non-material** concerns to set aside.
+
+Use this to decide what to object about. Cite the specific framework, and route to the named
+skill. Where there is no dedicated skill yet, the framework line tells you what to argue on
+the application's own facts.
+
+> **Read the document list first.** The applicant's own submission usually names the engaged
+> considerations: an *Ecological Impact Assessment*, *Transport Assessment*, *Heritage
+> Statement / Statement of Significance*, *Flood Risk Assessment*, *Arboricultural Report*,
+> *Daylight/Sunlight Assessment*, *Landscape and Visual Impact Assessment*, *Air Quality
+> Assessment*, *Noise Assessment*. A telling **absence** (e.g. no FRA for a site partly in a
+> flood zone, no Heritage Statement next to a listed building) is itself a ground.
+
+---
+
+## Considerations with a dedicated skill
+
+### Ecology / biodiversity → **ecological-representation**
+- *What:* protected species (bats, great crested newts, reptiles, dormice, badgers, birds),
+  priority habitats, Biodiversity Net Gain, lighting, protected sites.
+- *Tells:* an Ecological Impact Assessment / Preliminary Ecological Appraisal, BNG metric,
+  protected-species surveys; a greenfield or vegetated site, watercourses, hedgerows, mature
+  trees, ponds; a designated site (SSSI/SAC/SPA) nearby; or the telling absence of ecological
+  survey where habitat is obviously present.
+- *Weight:* high where a European Protected Species or a designated site is engaged (Habitats
+  Regulations); statutory 10% BNG applies to most major development.
+
+### Transport / highways → **transport-representation**
+- *What:* access and safety, walking/cycling/public-transport provision, trip generation and
+  capacity, parking, inclusive design, delivery of secured mitigation.
+- *Tells:* a Transport Assessment/Statement, Travel Plan, parking schedules, access/visibility
+  drawings; a site with poor public-transport access, on a fast road, or reliant on active-
+  travel connections; the highway authority's consultation response.
+- *Weight:* refusal on *capacity/safety* needs a "severe"/"unacceptable" impact (high bar);
+  the winnable grounds are sustainable-transport, active-travel and inclusive-design
+  compliance, and evidence adequacy.
+
+### Heritage / historic environment → **heritage-representation**
+- *What:* harm to a listed building (or its setting), a conservation area, scheduled monument,
+  registered park/garden, or a non-designated heritage asset; archaeology.
+- *Tells:* a Heritage Statement / Statement of Significance, an archaeological desk-based
+  assessment; the site is in or adjoins a **conservation area**, is a **listed building** or
+  within its **setting**, or near a scheduled monument (check `planning.data.gov.uk` /
+  Historic England); a listed-building-consent or conservation-area application; or the
+  absence of a proportionate significance assessment.
+- *Weight:* high — the statutory duties (LB & CA Act 1990 ss.66/72) require *considerable
+  importance and weight*, and designated-asset harm attracts *great weight*.
+
+### Flood risk / drainage → **flood-representation**
+- *What:* flood risk to and from the development (all sources), the Sequential/Exception
+  Tests, safe access, sustainable drainage (SuDS), and surface-/foul-water capacity.
+- *Tells:* a Flood Risk Assessment, Drainage Strategy/SuDS report; the site is in **Flood Zone
+  2 or 3**, is >1 ha, or is in a critical drainage area (check the EA "Flood map for
+  planning"); a Lead Local Flood Authority or Environment Agency consultation; or the absence
+  of an FRA where one is required.
+- *Weight:* high where the Sequential/Exception Tests are engaged or an FRA is missing/
+  inadequate; the EA and LLFA are statutory consultees.
+
+---
+
+## Considerations without a dedicated skill yet (argue on the framework)
+
+Flag these when engaged and argue them on the application's own facts, citing the framework.
+
+- **Design and character** — NPPF Chapter 12 (well-designed places; refusal for poor design),
+  the National Design Guide and National Model Design Code, and local design policy. *Tells:*
+  a Design and Access Statement; an out-of-character bulk/height/density; local design codes.
+- **Residential amenity** — the neighbour classics: **daylight/sunlight** (BRE guidance),
+  **overlooking/loss of privacy**, **overbearing/overshadowing**, **noise and disturbance**.
+  *Tells:* a Daylight/Sunlight Assessment or Noise Assessment; close boundaries; windows
+  facing habitable rooms; a use that generates noise. Weight is real but fact-sensitive.
+- **Green Belt** — a *heavyweight* ground where it applies: development in the Green Belt is
+  *inappropriate* unless it falls within the exceptions, and inappropriate development is
+  harmful and should not be approved except in *very special circumstances* (NPPF Ch13).
+  *Tells:* the site is washed over by Green Belt (local plan / `planning.data.gov.uk`).
+- **Landscape and visual impact / AONB (National Landscape)** — NPPF Ch15; GLVIA3
+  methodology; great weight to conserving/enhancing National Landscapes. *Tells:* an LVIA;
+  a prominent or elevated site; an AONB/National Landscape or valued landscape.
+- **Trees** — TPOs, BS 5837, hedgerows (overlaps ecology). *Tells:* an Arboricultural Report;
+  protected trees; tree loss.
+- **Air quality** — NPPF; IAQM/EPUK guidance; Air Quality Management Areas. *Tells:* an Air
+  Quality Assessment; an AQMA; a trip-generating use.
+- **Agricultural land** — best and most versatile (BMV) land (NPPF). *Tells:* greenfield
+  agricultural land, an Agricultural Land Classification.
+- **Nutrient / water neutrality** — catchment-specific but decisive where it bites (Habitats
+  Regulations); overlaps ecology. *Tells:* the catchment is subject to a Natural England
+  advice position (e.g. certain river catchments).
+- **Housing land supply / the "tilted balance"** — whether the council can demonstrate a
+  five-year housing land supply engages the NPPF para 11 presumption; a strategic argument
+  rather than a site issue.
+- **Contamination, ground conditions, land stability; foul drainage capacity; light
+  pollution; ecology-adjacent public rights of way.**
+
+---
+
+## Not material — set these aside (or reframe)
+
+Objections must be *material planning considerations*. These commonly-raised concerns are
+**not** material, and an objection resting on them will carry no weight:
+
+- **Loss of a private view** (no right to a view) — *reframe:* impact on the character of the
+  area, or an overbearing effect, may be material.
+- **Impact on property values.**
+- **Competition** with, or loss of trade to, an existing business.
+- **Private disputes** — boundaries, covenants, rights of way as private-law matters, the
+  developer's motives or identity.
+- **Construction-period disturbance in itself** (noise/dust during works) — usually a matter
+  for a Construction Management Plan condition, not a reason for refusal; *reframe* to any
+  *permanent* effect.
+- **Moral objections**, or the fact that the land could be "better used" for something else.
+- **Matters controlled by other regimes** (e.g. building regulations, licensing) except where
+  they are also a planning consideration.
+
+Tell the user honestly when their concern is not material — and whether it can be reframed as
+one that is. Credibility with the case officer depends on it.
+
+## Who speaks to what — the consultee map
+
+For every engaged consideration, deliberately **locate and read the matching consultee
+response** on the portal — don't treat them as incidental. A consultee's objection or holding
+position is often the strongest anchor a representation has; their requested conditions are a
+ready-made ask; and their *silence* on an engaged issue is itself worth noting. Compare each
+response against your own findings before ranking.
+
+| Consideration | Consultee response(s) to find |
+|---|---|
+| Ecology / biodiversity | LPA or county **ecologist**; **Natural England** (designated sites, EPS, nutrient/water neutrality) |
+| Transport / highways | **Highway authority** (county/unitary); **Active Travel England** (major schemes); National Highways (trunk roads) |
+| Flood risk / drainage | **Environment Agency** (river/sea flooding); **Lead Local Flood Authority** (surface water, major development); the water/sewerage company |
+| Heritage / archaeology | **Conservation officer**; **Historic England** (listed Grade I/II*, scheduled monuments, registered parks); county **archaeologist** |
+| Trees / landscape | **Tree officer** / arboricultural officer; landscape officer |
+| Amenity, noise, air quality, contamination | **Environmental health** |
+| Design | Design officer / **design review panel** where one operates |
+| Rights of way | The highway authority's PROW team |
+
+Caution: a consultee's "no objection" settles only their own remit — e.g. the highway
+authority's silence on capacity/safety is not an assessment of sustainable-transport policy
+compliance (see the transport skill), and the LPA must still strike its own balance.
+
+## Quick triage from the document list + constraints
+
+1. **List the documents** (planning-document-search). Each technical report ⇒ its
+   consideration is in play; a missing report where the constraint is present ⇒ a ground.
+2. **Check constraints** — conservation area / listed buildings / Article 4
+   (`planning.data.gov.uk`), flood zones (EA flood map), Green Belt / AONB (local plan). Each
+   hit ⇒ the corresponding consideration.
+3. **Read the proposal and stage** — outline vs reserved matters vs s73 vs full vs LBC changes
+   what is open.
+4. **Read the consultee responses for every engaged consideration** (the consultee map above
+   says who speaks to what). Their concerns are strong signals (and their *withdrawal* on
+   safety/capacity is not an assessment of sustainability — see the transport skill's
+   "spine").
+5. **Rank and route** — lead with decision-critical grounds; drop the non-material; hand each
+   live ground to its skill.

--- a/nppf-2024-12/ecological-representation/CHANGELOG.md
+++ b/nppf-2024-12/ecological-representation/CHANGELOG.md
@@ -1,0 +1,91 @@
+# Changelog — ecological-representation
+
+Design decisions per revision, newest first. See `../CLAUDE.md` for the format and the
+house rules. The **_Why_** lines record the rationale so a future editor understands the
+intent.
+
+## Unreleased
+
+### Changed
+- **`national-guidance.md` now defers to the companion `national-planning-policy` skill**
+  for the NPPF/PPG edition register, the verify-before-citing protocol, and the shared
+  decision-making core; this file keeps only the topic layer. _Why:_ reviewer feedback —
+  per-skill NPPF snapshots drift out of sync as editions change; one register, checked
+  first, keeps the citations consistent (two-layers house rule).
+
+### Added
+- **A/B/C outcome discipline:** every point must be classified as **(A)** demonstrated
+  unacceptable impact (refusal reason), **(B)** insufficient evidence to reach the necessary
+  conclusion (do-not-determine-yet ask), or **(C)** controllable by condition/obligation
+  (mitigation ask) — plus a pre-send checklist item that no point asks for refusal where a
+  condition would lawfully and satisfactorily do. _Why:_ reviewer feedback — an inadequate
+  assessment does not necessarily mean the development is unacceptable, only that the LPA
+  cannot presently be satisfied that it is; conflating the two (or over-asking for refusal
+  on conditionable points) is the classic credibility mistake in lay objections.
+
+### Changed
+- **Renamed the skill folder and `name` from `ecological-objection` to
+  `ecological-representation`.** _Why:_ parity with `transport-representation`, and a
+  "representation" is the accurate umbrella term — the skill can conclude *not* to object, or
+  support conditions, not only object. The drafting content (objections) is unchanged.
+- **"What you need first" now says uploaded/pasted/already-downloaded documents work
+  directly, and `planning-document-search` is only needed when the user doesn't have
+  them.** _Why:_ the old wording ("get them from the council's planning portal") read as
+  an instruction to fetch, risking a retrieval detour when the user has already supplied
+  the files; it also completes the retrieval skill's fail-fast handover (stop → download
+  manually → feed the files back in here).
+
+## 0.1.0 — 2026-08-14 — Initial release
+
+First public-ready version: a skill that (1) evaluates the ecological evidence submitted
+with a UK planning application, (2) maps each deficiency to the national law/policy/
+guidance it engages, and (3) drafts a concise objection — or advises that none is
+warranted. Structure: `SKILL.md` + `references/` (`deficiency-catalogue.md`,
+`national-guidance.md`, `house-style.md`, `objection-template.md`). Key design decisions:
+
+### Added
+- **The integrity principle as the skill's spine.** Only object where the evidence is
+  genuinely inadequate; treat "don't object" as a valid, valuable output; an objection
+  built on presentational faults when the method is sound is vexatious. _Why:_ credibility
+  with case officers is the asset — manufacturing weak objections burns it, and the source
+  material included a deliberate "no objection" example precisely to make this point.
+- **Deficiency catalogue as the evaluation engine.** Recurring, defensible grounds
+  (evidence currency, survey method/effort/coverage, deferral, internal inconsistency, BNG
+  metric integrity, mitigation & hierarchy, lighting & Habitats Regs, irreplaceable
+  habitats, management plans), each with *the tell / why it matters / what it breaches /
+  the ask*. _Why:_ turns a fuzzy "critique this" into a repeatable checklist tied to
+  citable authority.
+- **A verified national-guidance catalogue.** Statute, NPPF (Dec 2024 paragraph numbers),
+  PPG, case law, and current professional-guidance editions — **web-verified**, with a
+  superseded-edition table and ⏳ flags on time-sensitive items. _Why:_ citing the wrong
+  NPPF paragraph or a superseded survey-guidance edition undermines the objection; and
+  citing a *superseded* edition is itself a common, valid objection ground, so the current
+  editions must be right.
+- **House style + annotated template** distilled from a human-edited exemplar: measured
+  expert voice, material-considerations-only, quote-the-applicant-against-themselves, the
+  "resolve by evidence, not condition" spine, and a numbered summary of requests. _Why:_
+  a concise, officer-liftable representation is more effective than a long emotive one.
+
+### Changed
+- **Scoped to ecology, England-focused, explicitly not legal advice.** _Why:_ honest
+  bounds; transport/heritage/flooding are separate matters, devolved policy differs, and
+  the tool must not be mistaken for a solicitor.
+- **Habitats Regulations citation precision:** the derogation *duty* is reg 9(3); the
+  three derogation *tests* are reg 55. _Why:_ legal accuracy — the two are often conflated,
+  and this is a law-facing skill.
+- **User-protection disclaimers made explicit:** not legal advice; **no warranty** (output
+  "as is"); **human review required before submitting**; and a flag that a UK planning
+  representation is normally **published on the council's portal in the submitter's name**
+  and kept on the record. _Why:_ the skill drafts something a user may submit to a public
+  body — they must review it, expect no guarantee, and understand their name becomes public,
+  choosing their personal details accordingly.
+
+### Removed
+- **All case- and campaign-specific fingerprints removed from the skill.** Genericized the
+  worked example's provenance, the named consultant, the specific Local Plan policy numbers
+  (→ generic "Local Plan biodiversity/watercourse/hedgerow policies"), site specifics
+  ("plot H4" → "a plot"; "99 dwellings" → "the proposed number of dwellings"), and the
+  "cite a named inquiry against the same applicant" framing (kept only as generic *guidance
+  to exclude* such framing). _Why:_ the skill must be a reusable, neutral tool that carries
+  no trace of the particular objection campaign it was distilled from, and must not
+  identify any real dispute, applicant, or consultant.

--- a/nppf-2024-12/ecological-representation/LICENSE
+++ b/nppf-2024-12/ecological-representation/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ian Howard
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/nppf-2024-12/ecological-representation/README.md
+++ b/nppf-2024-12/ecological-representation/README.md
@@ -1,0 +1,55 @@
+# Ecological Objection
+
+A skill for producing a rigorous, credible representation on the **ecological** merits of a
+UK planning application — or advising that no sustainable objection exists. England-focused.
+
+> **Not legal advice. No warranty.** Output is a draft aid provided "as is". **A human must
+> review and check it before submitting.** Note that a UK planning representation is
+> normally **published on the council's portal in the submitter's name** and kept on the
+> record — include only personal details you're content to make public.
+
+It does three things:
+
+1. **Evaluate** the applicant's ecological submission (EcIA/PEA, protected-species surveys,
+   BNG metric and Biodiversity Gain Plan, lighting strategy, LEMP/CEMP/HMMP) against current
+   good-practice guidance and identify the material deficiencies.
+2. **Map** each deficiency to the specific national law, policy and guidance it engages.
+3. **Draft** the objection in clear, precise, concise language — to the house style of a
+   human-edited target letter.
+
+## Contents
+
+| File | What it is |
+|---|---|
+| `SKILL.md` | The skill: workflow, the integrity principle, and pointers to the references. **Start here.** |
+| `references/deficiency-catalogue.md` | Function 1 — the evaluation checklist: recurring, defensible grounds, each with the tell, why it matters, what it breaches, and the ask. |
+| `references/national-guidance.md` | Function 2 — the verified law/policy/guidance catalogue with citations and superseded-edition traps. |
+| `references/house-style.md` | Function 3 — how a strong objection reads. |
+| `references/objection-template.md` | Skeleton + annotated worked example. |
+| `CHANGELOG.md` | Design decisions and their rationale, per revision. |
+
+## Two principles that define this skill
+
+- **Only object where it is warranted.** If the method complies with current guidance, the
+  data is current, the surveyor is competent, and the LPA ecologist is content, there is no
+  sustainable objection — say so. Manufacturing one from presentational faults is vexatious
+  and burns credibility.
+- **Every point is evidenced.** Objections stand or fall on the submitted documents and the
+  cited guidance. Quote the applicant against themselves; never invent survey results or
+  assert a species is present without a basis. A missing survey is itself the point.
+
+## Pairs with
+
+The **planning-document-search** skill retrieves the application documents (from a reference
++ council) that this skill then critiques.
+
+## Freshness
+
+The guidance catalogue was web-verified **August 2026**. Ecology guidance editions, the NPPF
+and the statutory BNG rules change; items flagged ⏳ in `national-guidance.md` are
+time-sensitive — **re-verify current NPPF paragraph numbers and current guidance editions at
+the point of drafting.**
+
+## License
+
+MIT — see [`LICENSE`](LICENSE). Provided as-is, with no warranty; not legal advice.

--- a/nppf-2024-12/ecological-representation/SKILL.md
+++ b/nppf-2024-12/ecological-representation/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: ecological-representation-nppf-2024-12
+description: >-
+  ARCHIVED - December 2024 NPPF edition (superseded 17 August 2026). Use only when the user explicitly asks to work under the pre-August-2026 framework and has confirmed they want the archived skills; outputs must state they cite a superseded framework. 
+  Evaluate the ecological evidence submitted with a UK planning application
+  (Ecological Impact Assessment, protected-species surveys, BNG metric,
+  LEMP/CEMP, lighting strategy), identify the national law/policy/guidance it
+  engages, and draft a concise, well-founded objection (or advise that no
+  sustainable objection exists). England-focused. Not legal advice.
+license: MIT
+---
+
+# Ecological objection to a planning application
+
+Help a member of the public produce a rigorous, credible representation on the
+**ecological** merits of a planning application — the kind a case officer can act on and
+lift into the officer report. The skill does three things:
+
+1. **Evaluate** the quality and adequacy of the applicant's ecological submission against
+   current good-practice guidance and identify the material deficiencies.
+2. **Map** each deficiency to the specific national (and local) law, policy and guidance
+   it engages.
+3. **Draft** the objection in clear, precise, concise language — or advise that the
+   submission is sound and no sustainable objection exists.
+
+## When to use
+
+The user has a planning application and wants to object (or find out whether they *can*
+object) on ecological/biodiversity grounds — bats, great crested newts, reptiles,
+dormice, badgers, water voles, breeding birds, hedgerows, ancient woodland, Biodiversity
+Net Gain, lighting impacts, protected sites. Trigger phrases: "object to this planning
+application on ecology grounds", "is this ecology report any good", "critique this EcIA /
+BNG metric", "the developer's bat survey looks thin."
+
+Not this skill: transport/highways, heritage, flooding, general amenity — those are
+separate matters. This skill is ecology only.
+
+## What you need first
+
+- The **application reference and council** (and, ideally, the documents).
+- The **ecological documents themselves** — you cannot critique what you have not read.
+  Uploaded, pasted, or already-downloaded files work directly; the companion
+  **planning-document-search** skill is only needed when you don't have them (it
+  retrieves them from the reference + council). Prioritise: the Ecological Impact
+  Assessment / Preliminary Ecological Appraisal, any protected-species survey reports, the
+  BNG metric / Biodiversity Gain Plan and BNG report, the lighting strategy / Lighting
+  Impact Assessment, the LEMP/CEMP/HMMP, and the **LPA ecologist's consultation response**
+  (often the strongest anchor — align with it).
+- The **local plan's** biodiversity/green-infrastructure policies (portal or council
+  website) — cite these alongside national policy.
+
+## The integrity principle (read before drafting anything)
+
+**Only object where the evidence is genuinely inadequate or the impact genuinely
+unacceptable.** If the survey method complies with current guidance, the data is current,
+the surveyor is competent and licensed, and the LPA's own ecologist is content, then there
+is **no sustainable objection** — say so plainly, and stop. An objection manufactured from
+presentational faults (a wrong site name in a heading, template-reuse typos) when the
+method is sound is *vexatious, not substantive*; it wastes the officer's time and burns
+the credibility you need on the applications that matter. Sometimes the right output is a
+note explaining why not to object, or a short representation asking only that the LPA
+ecologist's recommended conditions be imposed in full.
+
+**Classify every point's ask — (A) refuse, (B) don't determine yet, or (C) condition it.**
+An evidential deficiency is not itself a reason for refusal. For each confirmed point, be
+explicit about which outcome it supports: **(A)** the evidence *demonstrates* an unacceptable
+impact → a refusal reason; **(B)** the evidence is *insufficient* for the Council to reach the
+necessary conclusion (e.g. it cannot lawfully conclude on an EPS or a European site) → the
+application should **not be determined** until the information is provided; **(C)** the issue
+can be adequately controlled → ask for the *specific* condition or obligation (LEMP, lighting
+scheme, BNG verification). Most deficiency findings are (B), not (A) — claiming (A) on (B)
+evidence is the classic credibility mistake. And test every point against (C): if a condition
+would lawfully and satisfactorily resolve it, ask for that rather than refusal — over-asking
+weakens the whole representation.
+
+## Workflow
+
+### Step 1 — Intake and read
+Gather the documents (above). Identify: the proposal and its stage (outline / reserved
+matters / full / condition discharge — this changes what "before determination" means and
+what is still open); the receptors present or likely (from the reports and the site's
+context); whether any **European site (SAC/SPA/Ramsar)** or **qualifying species** is
+engaged (this raises the bar — Habitats Regulations); and whether **statutory BNG**
+applies. Read the LPA ecologist's response first if there is one.
+
+### Step 2 — Evaluate against the deficiency catalogue (function 1)
+Work through [`references/deficiency-catalogue.md`](references/deficiency-catalogue.md)
+against the documents. For each candidate deficiency, confirm it is **actually present**
+and **material**, and capture the *specific* evidence: the document, author, date, and the
+paragraph/table/figure that shows it. Quote the applicant's own words. Grade each finding
+(decision-critical vs minor) — lead with the decision-critical ones. Apply the integrity
+principle: drop anything you cannot evidence.
+
+Key cross-cutting tests: Is the data **current** at the decision date? Is the method the
+**current guidance edition**? Does the survey **effort/coverage** match the site's own
+graded importance? Has the **decision-critical assessment been deferred** beyond the
+decision? Does the **BNG metric** stand up (baseline, distinctiveness/condition, double-
+counting, verification)? Are **buffers and mitigation** real and deliverable? Does
+**lighting** protect commuting routes? Is a **European site / EPS** engaged, and can the
+Council conclude on it *now*?
+
+### Step 3 — Map to law, policy and guidance (function 2)
+For every confirmed deficiency, attach the precise instrument it engages from
+[`references/national-guidance.md`](references/national-guidance.md) — statute (Environment
+Act 2021 BNG, NERC s.40, Habitats Regs reg 9(3)/63, WCA 1981, Badgers Act), national
+policy (NPPF paragraphs, PPG), and professional guidance (CIEEM, BCT/Collins, Froglife,
+ILP/BCT lighting, AWI Handbook). Add the **local plan** biodiversity policies. Cite
+specifically — a named paragraph or guidance clause, never "best practice" in the
+abstract. If a point needs current guidance you are unsure of, verify it rather than
+guess.
+
+### Step 4 — Draft (function 3)
+Draft to the [`references/house-style.md`](references/house-style.md) and
+[`references/objection-template.md`](references/objection-template.md): header → RE line →
+opening (consultation status; material considerations; place on file) → framework list →
+numbered points (each a bold conclusion heading, the quoted evidence, why it matters, the
+ask and its timing) → numbered **Summary of requests** (mostly "before determination") →
+objection sentence → sign-off. Keep it concise — density over length. Lead with the
+decision-critical points and align with the LPA ecologist.
+
+### Step 5 — Check before sending
+- Every point is evidenced from the documents or cited guidance; nothing asserted.
+- Quotes are accurate and referenced (§/Table/Figure).
+- It reads as material considerations, not objection-to-development-in-principle.
+- Consultant-/campaign-specific framing excluded unless the user asked for it and it is
+  defensible on this application's own facts (see the template note).
+- The requests are concrete and correctly timed to the application's stage.
+- Every point is classified **(A) demonstrated harm / (B) insufficient evidence / (C)
+  conditionable** — and no point asks for refusal where a condition would lawfully and
+  satisfactorily do.
+- Deadline: note if consultation has closed; representations are usually still accepted
+  and are material while the application is undecided — say so in the opening.
+- **Hand back to a human, with the two warnings:** the draft must be read and checked by a
+  person before submission, and submitting it will put a **public document in the user's
+  name** on the council's portal — so confirm they're content with the content and with
+  the personal details included.
+
+## Reference files
+
+- [`references/deficiency-catalogue.md`](references/deficiency-catalogue.md) — the
+  evaluation checklist: recurring, defensible grounds, each with the tell, why it matters,
+  what it breaches, and the ask.
+- [`references/national-guidance.md`](references/national-guidance.md) — the law/policy/
+  guidance catalogue, with citations, to map deficiencies to instruments.
+- [`references/house-style.md`](references/house-style.md) — how a strong objection reads.
+- [`references/objection-template.md`](references/objection-template.md) — skeleton +
+  annotated worked example.
+
+## Scope and limitations
+
+- **Not legal advice, and no warranty.** This helps a lay objector marshal evidence and
+  cite policy; it is not a substitute for a solicitor or professional ecologist, guarantees
+  no outcome, and is provided "as is" with no warranty of accuracy or fitness for purpose.
+- **Human review is necessary before submitting.** A person must read the draft, check
+  every quote and citation against the actual documents, and confirm the points are correct
+  and fair for this application. Do not submit skill output unread.
+- **A UK planning representation is a public document in your name.** Comments and
+  objections submitted to a local planning authority are normally published on the
+  council's public planning portal, typically including the submitter's name (and sometimes
+  address), and are retained on the record. Tell the user this before they submit, and let
+  them decide what personal details to include; many councils publish name but redact
+  signatures/contact details — check the council's statement.
+- **England-focused.** The statutory BNG regime, NPPF and PPG are England; the species
+  legislation (Habitats Regs, WCA, NERC, Badgers Act) is broadly GB-wide but devolved
+  policy differs in Wales/Scotland/NI — flag when the application is outside England and
+  adjust the policy citations.
+- **Evidence-bound.** Every objection stands or falls on the submitted documents and the
+  cited guidance. Do not invent survey results, fabricate quotes, or assert a species is
+  present without a basis. Where information is missing, that *absence* is itself the point
+  ("the survey was not done"), argued as such — not filled with speculation.
+- **The honest answer is sometimes "don't object."** Treat that as a valid, valuable
+  output, not a failure.

--- a/nppf-2024-12/ecological-representation/references/deficiency-catalogue.md
+++ b/nppf-2024-12/ecological-representation/references/deficiency-catalogue.md
@@ -1,0 +1,286 @@
+# Ecological submission — deficiency catalogue
+
+The recurring, defensible grounds on which a planning application's **ecological
+evidence** (Preliminary Ecological Appraisal, Ecological Impact Assessment, protected-
+species survey reports, BNG metric and Biodiversity Gain Plan, LEMP/CEMP/HMMP, lighting
+strategy) can be challenged. Each entry is a *pattern to look for*, not a template
+sentence — find the specific instance in the documents in front of you, quote it, and
+attach the request.
+
+Use this as the evaluation checklist (skill function 1). Every entry cross-references the
+guidance it breaches in [`national-guidance.md`](national-guidance.md); cite the specific
+guidance, not "best practice" in the abstract.
+
+> **Integrity rule (read first).** Only raise a deficiency that is actually present and
+> material. If the survey method complies with current guidance, the data is current, the
+> surveyor is competent/licensed, and the LPA's own ecologist is content, **there is no
+> sustainable objection** — say so. An objection built on presentational faults (wrong
+> site name in a heading, template-reuse typos) when the method is sound is *vexatious,
+> not substantive*, and damages credibility on the applications that matter. Distinguish
+> "the evidence is wrong/inadequate" from "I don't like the development."
+
+---
+
+## A. Evidence currency and provenance
+
+**A1 — Survey data is out of date at the point of decision.**
+- *Tell:* the survey schedule (there is almost always a dated table) shows species data
+  more than ~2–3 years old at the anticipated determination date; validity is asserted on
+  the strength of a single later habitat *walkover*.
+- *Why it matters:* a walkover cannot detect changes in bat activity, breeding-bird
+  assemblages, reptile populations or riparian-mammal occupation. The decision must rest
+  on current information; reserved matters / condition discharge is the *last* chance to
+  get it right.
+- *Breaches:* CIEEM *Lifespan of Ecological Reports & Surveys* (>~3 yrs unlikely to remain
+  valid without update); BS 42020:2013; PPG Natural Environment (information current at
+  decision).
+- *Ask:* updated season surveys for the affected taxa **before determination**, or an
+  express reasoned officer-report justification for relying on the old baseline.
+
+**A2 — Partial updates that update the convenient taxa only.**
+- *Tell:* the applicant updated the taxa with little constraint effect (a pond HSI, a
+  reptile refresh) but left un-updated exactly the taxa that most constrain the layout
+  (bats, dormouse, water vole).
+- *Why it matters:* it shows updating was *practicable*, undercutting any "not
+  reasonably possible" defence, and the omissions are not random.
+- *Ask:* update the constraint-critical taxa to the same currency.
+
+**A3 — Results recorded as "TBC"/"to follow" in the final issue.**
+- *Tell:* a summary table carries "TBC" for a survey result (e.g. eDNA) in the *final*
+  document.
+- *Ask:* confirm the actual result is before the Council before determination.
+
+---
+
+## B. Survey method, effort and coverage
+
+**B1 — Superseded guidance edition.**
+- *Tell:* bat surveys cited to Collins **2016** (3rd ed.) when the current standard is
+  Collins **2023** (4th ed.); GCN/EPS work to a withdrawn edition.
+- *Why it matters:* the application "falls to be determined" under current guidance; the
+  editions differ on effort/timing.
+- *Ask:* re-survey to the current edition, or a reasoned justification.
+
+**B2 — Survey effort/season below the guidance for the site's own graded importance.**
+- *Tell:* static detectors deployed April–July when the report itself says the guidance
+  is April–October "for this site"; number of visits below the roost-suitability category;
+  weather/seasonal-spread constraints not met.
+- *Why it matters:* the evidential standard must match the importance the report *itself*
+  assigns (e.g. a site graded of Regional/International importance for commuting bats).
+- *Ask:* full-season / full-effort survey to guideline standard.
+
+**B3 — A survey designed not to find the species (coverage bias).**
+- *Tell:* reptile refugia placed only on margins / "suitable habitat" with the site centre
+  unsurveyed, contrary to Froglife Advice Sheet 10 (which requires refugia *across* the
+  survey area precisely because reptiles turn up in unexpected places); figures captioned
+  "not entirely accurate / illustrative only" so effort can't be audited.
+- *Ask:* repeat presence/absence survey with refugia distributed across the whole site.
+
+**B4 — Only a fraction of collected data analysed.**
+- *Tell:* static-detector table shows only e.g. 10% of non-identifiable (NoID)/noise
+  files analysed.
+- *Why it matters:* rare, quiet-calling species (Barbastelle, *Myotis*, long-eared bats)
+  are exactly what hides in NoID files; presence would change valuation and lighting
+  constraints.
+- *Ask:* analyse the full dataset.
+
+**B5 — Ground-level assessment used where inspection/emergence survey is required.**
+- *Tell:* trees with Potential Roost Features (PRF) cleared for felling on a single
+  ground-level tree assessment (GLTA); no climbed inspection or dusk-emergence/dawn-re-
+  entry survey.
+- *Breaches:* Bat Mitigation Guidelines / BCT good practice.
+- *Ask:* climbed inspection or emergence surveys for all removal trees not fully
+  inspectable from ground level, before felling is approved.
+
+**B6 — Species scoped out on desk study alone.**
+- *Tell:* dormouse (or another EPS) dismissed on absence of records + a habitat judgment,
+  with no nest-tube/footprint survey, where suitable habitat (species-rich hedgerow,
+  woodland strip) is present. "Absence of records is not evidence of absence where no one
+  has looked." A precautionary "fingertip search during clearance" is not a lawful
+  substitute.
+- *Ask:* the appropriate presence/absence survey in season, before layout is fixed.
+
+**B7 — Screening tool substituted for a presence/absence method.**
+- *Tell:* GCN dealt with by HSI screening only (a *suitability* tool), with no eDNA /
+  population survey and no District Level Licensing route; ponds within 500 m left
+  unsurveyed.
+- *Ask:* eDNA (or DLL) resolved before determination.
+
+**B8 — Wrong method for the taxon.**
+- *Tell:* "breeding bird survey" run as point counts stationed on the *bat transect route*
+  rather than territory mapping; still finds red-listed/ground-nesting species (skylark)
+  — so a proper survey would find more.
+- *Ask:* survey to a recognised territory-mapping standard; compensation for confirmed
+  species.
+
+---
+
+## C. Deferral of the decision-critical assessment
+
+**C1 — The most sensitive impact is postponed to after the decision.**
+- *Tell:* explicit wording such as "*it is not known whether any trees identified as
+  supporting bat roost potential will be removed… full details will be added once they
+  have been identified*." The assessment of the most sensitive ecological impact is
+  thereby deferred beyond determination.
+- *Why it matters:* if a maternity roost is present the Habitats Regulations are engaged —
+  the Council must have regard to the derogation requirements (reg 9(3)) and be satisfied
+  the three derogation tests (reg 55) are capable of being met — and it must judge that
+  *now*, not on a promise.
+- *Ask:* the outstanding survey and confirmation of affected features **before
+  determination**, not by condition.
+
+**C2 — Pre-determination matters mislabelled as condition matters.**
+- *Tell:* serious evidence gaps (baseline errors, missing buffers, unresolved licensing
+  triggers) waved through as "to be secured by condition" or "reserved for later."
+- *The framing:* these "go beyond arithmetic." Until they are resolved the Council cannot
+  know whether the proposed quantum *physically fits* the site's constraints; granting
+  outline permission first bakes in a density the constraints may not accommodate.
+- *Ask:* resolve by *evidence, not condition*, before determination. (This is the
+  load-bearing meta-argument — see house-style.)
+
+---
+
+## D. Internal inconsistency (the document contradicts itself)
+
+**D1 — Contradictory survey dates.**
+- *Tell:* the transect table, one caption and another caption give three different sets of
+  survey dates; the Council cannot tell when surveys happened or whether the seasonal
+  spread was achieved.
+
+**D2 — Contradictory results.**
+- *Tell:* "no reptiles were recorded" in one section vs "a single common lizard was the
+  only reptile recorded" in another.
+
+**D3 — Metric vs layout contradiction.**
+- *Tell:* the BNG metric shows hedgerows as buffered while the layout plan backs a plot
+  directly onto them; lighting text promises lux levels its own Lighting Impact
+  Assessment does not support.
+- *Ask:* reconcile the documents; an internally contradictory evidence base cannot be
+  relied on.
+
+---
+
+## E. Biodiversity Net Gain metric integrity
+
+**E1 — Baseline features omitted.** On-site watercourse omitted from the baseline (no
+watercourse metric) → the whole gain calculation, and the statutory Biodiversity Gain
+Plan the condition will later approve, is corrupted from the start.
+
+**E2 — Distinctiveness/condition inflated.** Future garden habitats given higher
+distinctiveness than the "vegetated garden" classification allows; "moderate condition"
+grassland claimed with no evidence it is achievable — especially where the same land
+doubles as public open space.
+
+**E3 — Double-counting / irreconcilable management.** The same parcel counted for BNG
+habitat units *and* as species mitigation (e.g. reptile habitat) or recreational open
+space, when the two functions demand incompatible management regimes (tussocky infrequent
+cutting for reptiles vs frequent active-season cutting for meadow condition). Either one
+regime must be shown to deliver both, or the double-count comes out.
+
+**E4 — No implementation strategy / no independent verification.** The BNG assessment
+lacks the implementation/management/monitoring strategy needed to discharge the BNG
+condition; the metric has not been independently verified by the county/LPA ecologist.
+
+**E5 — No reconciliation with the outline-stage claim.** Where great weight was given at
+outline to a headline gain (e.g. "+58.67% habitat units"), the reserved-matters metric
+must be reconciled against it; any shortfall is a material departure, not a detail.
+
+*Ask (E1–E5):* a corrected, independently verified metric (watercourse baseline, honest
+garden classifications, realistic condition targets, layout-consistent hedgerows,
+double-counting removed), reconciled to the outline claim, **now** — because statutory
+10% BNG (Environment Act 2021, Schedule 7A) means baseline errors propagate into the
+statutory Gain Plan.
+
+---
+
+## F. Mitigation adequacy and the mitigation hierarchy
+
+**F1 — Mitigation by displacement.** Reptiles/other species "encouraged to passively
+disperse" into retained boundaries with no receptor site and no translocation.
+Displacement into already-occupied habitat is not mitigation; if the population is larger
+than a flawed survey suggests, killing/injury during works engages WCA 1981 s.9(1).
+- *Ask:* a properly sized, managed receptor strategy per Natural England standing advice.
+
+**F2 — Missing buffers.** Hedgerow buffers (commonly 5–10 m, unlit), watercourse buffers
+(commonly 10 m), ancient-woodland buffer (min 15 m), badger-sett buffer — absent from the
+layout, or asserted but breached by the applicant's own SuDS/infrastructure.
+- *Ask:* a plan demonstrating the required buffers *alongside the proposed quantum* — or a
+  reduced quantum.
+
+**F3 — No compensation for confirmed losses.** Confirmed skylark territories / barn-owl
+foraging removed with no compensation proposed anywhere in the submission.
+
+**F4 — Mitigation hierarchy not applied.** Harm not first avoided, then mitigated, then
+(last) compensated; NPPF requires refusal where significant harm cannot be avoided,
+adequately mitigated or, as a last resort, compensated.
+
+---
+
+## G. Lighting and the Habitats Regulations
+
+**G1 — No lighting strategy / no lux-contour modelling against dark corridors.** The
+layout fixes the lighting environment of retained hedgerows, stream corridors and tree
+lines used by commuting bats, yet no lux-contour plan (per ILP/BCT GN08) demonstrates
+dark corridors.
+
+**G2 — Non-compliant lux levels / wrong fixtures.** Committed lux exceeds the standard
+for the species/zone; tall columns proposed adjacent to dark zones where low-level
+bollards are required; hop-over crossings over-lit.
+
+**G3 — European site / qualifying species engaged.** Where an SAC/SPA-qualifying species
+(e.g. barbastelle for certain SACs) commutes across the site, or an EPS roost is confirmed
+in a tree to be worked, the competent authority must be able to conclude (appropriate
+assessment where required; reg 63) that approved details will not adversely affect site
+integrity, and that the EPS derogation tests (reg 55, to which reg 9(3) requires it to have
+regard) are *capable of being met* — **before** approving the details, not after. It cannot do so while its own advisers say
+the lighting scheme fails.
+- *Ask:* amended, wildlife-sensitive lighting scheme submitted, assessed and secured
+  before approval, with the appropriate assessment updated.
+
+---
+
+## H. Irreplaceable and priority habitats
+
+**H1 — Possible unrecorded ancient woodland dismissed without assessment.** A shaw / old
+tree-belt / boundary feature mapped merely as "lowland mixed deciduous woodland" and
+dismissed by listing Ancient Woodland Inventory sites within 2 km — when the AWI is known
+to under-record small/narrow woods. No holistic assessment (historic/tithe cartography,
+landscape context, ancient-woodland indicator plants) per Natural England's *Handbook for
+Updating the Ancient Woodland Inventory*.
+- *Why it matters:* if it is ancient woodland it is *irreplaceable*; NPPF requires refusal
+  of development causing its loss/deterioration save in wholly exceptional circumstances,
+  with a min 15 m buffer.
+- *Ask:* a proportionate historical-ecological (Handbook) assessment before layout is
+  fixed; failing that, apply the precautionary principle and treat it as ancient woodland
+  with a compliant buffer.
+
+**H2 — Priority habitats / hedgerows undervalued.** Species-rich native hedgerow, lowland
+meadow and similar s.41 priority habitats not given their proper weight or buffer.
+
+---
+
+## I. Management, monitoring and delivery plans
+
+**I1 — LEMP/HMMP lacks the mandatory elements.** The Landscape & Ecological Management
+Plan (or Habitat Management & Monitoring Plan) omits required elements: a long-horizon
+(commonly 30-year) rolling schedule, prescriptions by compartment, a **named** responsible
+body (not "to be confirmed"), a **costed, legally secured funding mechanism**, measurable
+success criteria and remedial triggers. A LEMP "based on" inadequate survey work inherits
+that inadequacy.
+
+**I2 — CEMP defers protected-species safeguards.** The Construction Environmental
+Management Plan fails to map ecological features, time works to avoid harm (clearance
+outside nesting season; riparian-mammal timing; badger buffer), or name responsible
+persons; matters that must be *resolved* in the CEMP are deferred.
+- *Ask:* do not discharge the condition until each required element is present, specific
+  and enforceable.
+
+---
+
+## J. Standard-of-evidence mismatch (a cross-cutting test)
+
+**J1 — The evidence does not match the site's own graded importance.** Where the report
+itself grades the site of County/Regional/International importance for a receptor, hold
+the survey effort, currency and method to that standard — and show, point by point, where
+it falls short. This is often the most persuasive framing: you are holding the applicant
+to *their own* stated valuation.

--- a/nppf-2024-12/ecological-representation/references/house-style.md
+++ b/nppf-2024-12/ecological-representation/references/house-style.md
@@ -1,0 +1,90 @@
+# House style — how a strong objection reads
+
+Distilled from a human-edited exemplar objection. The goal is a
+representation a busy case officer can act on: **concise, specific, evidenced, and easy to
+lift into the officer report.** These are the writing rules the skill applies at the
+drafting stage (function 3).
+
+## Voice and stance
+
+- **Measured and expert, never emotive.** No outrage, no adjectives doing an argument's
+  work. The force comes from specificity, not volume. You are helping the Council do its
+  job correctly, not fighting it.
+- **Material considerations only.** Everything must be a planning material consideration:
+  the adequacy of the evidence, compliance with law/policy/guidance, deliverability of
+  mitigation. Not "I don't want houses here." Loss of a view, house prices, and general
+  dislike of development are not ecological grounds — leave them out.
+- **Concede what is sound.** Credibility is the asset. Acknowledge the LPA ecologist's
+  holding objection and align with it; if part of the submission is fine, don't attack it.
+  If the whole submission is sound, advise *not* objecting (see the integrity rule).
+- **No personal criticism.** Critique methods and documents, not individuals ("I make no
+  criticism of any individual").
+
+## Structure
+
+1. **Header block** — your name/address/email, the Council's address, date, the case
+   officer by name if known.
+2. **RE line** — application reference + site + a one-line description of the proposal.
+3. **Opening** — one short paragraph: note if the consultation period has closed but the
+   application remains undecided, so the matters are *material considerations the Council
+   must take into account*; ask that the representation be placed on the file.
+4. **Roadmap sentence** — "This representation is in three parts…" so the reader knows the
+   shape.
+5. **Framework list** — a short bulleted list of the relevant legislation/policy/guidance
+   engaged (see `national-guidance.md`). This signals rigour and anchors every later point.
+6. **Numbered sections** — one deficiency per numbered sub-section (A1, A2…), each with a
+   **bold one-line heading that states the point as a conclusion** ("Bat impact assessment
+   is deferred beyond the decision"), then 1–3 tight paragraphs.
+7. **Summary of requests** — a single numbered list of concrete asks, grouped, most ending
+   "before determination." This is what the officer copies into the recommendation.
+8. **Objection sentence** — "Unless these matters are resolved, I object to the grant of
+   [outline] planning permission." Then sign-off.
+
+## Each point: the anatomy
+
+A good sub-section does four things, fast:
+
+1. **Names the defect** in the heading as a conclusion.
+2. **Quotes the document** — the applicant's own words, with the paragraph/table/figure
+   reference (`§3.24`, `Table 1`, `Figure 23`). *Quoting the applicant against themselves
+   is the single most powerful move.* Never paraphrase where you can quote.
+3. **Says why it matters** in planning terms — the consequence for the decision (e.g.
+   "the Council cannot know whether the proposed number of dwellings physically fits"), and the specific
+   guidance/law breached, cited precisely.
+4. **States the ask** — the specific thing to do, and *when* ("before determination",
+   "at reserved matters", "in the CEMP").
+
+## Load-bearing arguments (use where they fit)
+
+- **"Resolve by evidence, not condition."** The recurring spine: serious evidence gaps are
+  *pre-determination* matters, because they go to whether the development is acceptable in
+  principle / physically fits — not details to be conditioned. Granting first "bakes in" a
+  quantum the constraints may not allow.
+- **"Hold them to their own valuation."** Where the report grades the site of
+  Regional/International importance, demand evidence to match that grade.
+- **"The competent authority must be able to conclude now."** For Habitats-Regulations /
+  European-site / EPS points: the Council must be *able to conclude* on integrity /
+  derogation-test feasibility before it approves, not on a promise details will follow.
+- **"Highways/ecologist 'no objection' is not an assessment of X."** A consultee's
+  narrow sign-off is not a substitute for the LPA's own assessment of the matter you raise.
+
+## Length and formatting
+
+- **Shorter is stronger.** The target letter makes ~11 distinct points in a few pages.
+  Cut throat-clearing. One point per paragraph. If a sentence doesn't add a fact or a
+  consequence, delete it.
+- Bold the sub-section headings and the key phrase in a dense bullet; italicise quoted
+  document text. Keep bullets parallel and short.
+- Use British spelling and legal register ("the Council", "determination", "material
+  consideration"). Spell out an acronym once (EcIA, BNG, PRF, LEMP, CEMP, EPS).
+- Reference documents precisely by author and date the first time (e.g. "the Ecological
+  Impact Assessment ([consultant name], [month year])") so the file is unambiguous.
+
+## What to leave out
+
+- Anything you cannot evidence from the submitted documents or from cited guidance.
+- Consultant-specific or campaign-specific material (e.g. cross-referencing other live
+  applications, or a named inquiry) unless the user explicitly wants it and it is
+  defensible on this application's own facts. **Default to omitting it** — each
+  application is determined on its own evidence.
+- Padding, repetition, and any point already conceded by the applicant or already secured.

--- a/nppf-2024-12/ecological-representation/references/national-guidance.md
+++ b/nppf-2024-12/ecological-representation/references/national-guidance.md
@@ -1,0 +1,334 @@
+# National law, policy and guidance — ecology in planning (England)
+
+The framework to cite when mapping a deficiency (skill function 2). **Cite the specific
+instrument and clause, never "best practice" in the abstract.** Each deficiency in
+[`deficiency-catalogue.md`](deficiency-catalogue.md) points here.
+
+The **current NPPF/PPG edition register, the verify-before-citing protocol, and the shared
+decision-making core** (s.38(6) and plan primacy, the para 11 presumption and its footnotes,
+emerging-plan weight, the conditions and obligations tests) live in the companion
+**national-planning-policy** skill — check it first when citing the NPPF/PPG. This file owns
+only the topic-specific layer.
+
+> **Compiled and web-verified 14 August 2026 (England).** Several items are time-sensitive
+> — NPPF is under review, statutory BNG rules changed through 2026, and professional
+> guidance editions turn over. **Re-verify anything marked ⏳ before relying on it**, and
+> confirm the current NPPF paragraph numbers at the date you draft. This is not legal
+> advice.
+>
+> **Scope:** the statutory *species* protections (Habitats Regs, WCA, NERC, Badgers Act)
+> are broadly GB-wide, but statutory BNG, the NPPF and PPG are **England**. For Wales /
+> Scotland / NI, substitute the devolved policy (e.g. Planning Policy Wales, NPF4) and
+> flag it.
+
+---
+
+## Part 1 — Primary legislation
+
+### 1.1 Biodiversity Net Gain — Environment Act 2021
+- **Statutory 10% BNG:** TCPA 1990 **Schedule 7A, para 2** (inserted by Environment Act
+  2021 s.98 & Sch 14). Post-development biodiversity value must exceed the pre-development
+  on-site baseline by **at least 10%**, measured with the statutory metric.
+- **Biodiversity gain condition + Biodiversity Gain Plan:** deemed pre-commencement
+  condition — development may not begin until the LPA approves a **Biodiversity Gain Plan**
+  (Sch 7A paras 13–14). *Objection relevance:* baseline errors in the metric corrupt the
+  Gain Plan the condition will later approve — so a wrong baseline is a *present* problem,
+  not a later-condition problem.
+- **30-year maintenance:** secured habitat maintained ≥30 years (condition / s.106 /
+  conservation covenant).
+- **Commencement:** major development — applications from **12 Feb 2024**; small (non-major)
+  sites — from **2 April 2024**. ⏳ Further BNG changes reported to take effect **6 Aug
+  2026** (new small-area/temporary-development exemptions; self/custom-build exemption
+  expiry) and **NSIP** commencement **2 Nov 2026** — verify the amending SIs before relying.
+- **Exemptions:** Biodiversity Gain Requirements (Exemptions) Regulations 2024 (SI 2024/47)
+  — householder applications; de minimis (below **25 m²** habitat / **5 m** linear); self/
+  custom-build; development on a registered gain site; and others. ⏳ Check current list.
+- *Sources:* legislation.gov.uk/ukpga/2021/30/section/98 ; /schedule/14/enacted ;
+  gov.uk/guidance/biodiversity-net-gain
+
+### 1.2 Biodiversity duty — NERC Act 2006 ss.40–41 (as amended)
+- **s.40 (strengthened duty):** amended by EA2021 s.102 — public authorities including LPAs
+  must further the **"general biodiversity objective"** (conserve *and enhance*
+  biodiversity), consider what action to take and take it, and **have regard to relevant
+  Local Nature Recovery Strategies**. (s.40A, inserted by EA2021 s.103, adds periodic
+  biodiversity reporting.)
+- **s.41 (species/habitats of principal importance — the "s.41 list"):** priority habitats
+  and species a decision-maker must have regard to under the s.40 duty when a development
+  affects them.
+- *Sources:* legislation.gov.uk/ukpga/2006/16/section/40 ; /section/41
+
+### 1.3 Conservation of Habitats and Species Regulations 2017 (SI 2017/1012, as amended)
+- **Reg 9(3) — general duty:** a competent authority must **have regard to** the Directives'
+  requirements in exercising its functions — i.e. the LPA must take the conservation
+  requirements into account when determining. *(This is the provision applied in* Morge*;
+  it was reg 9(5) in the 2010 Regs.)*
+- **Reg 63 — appropriate assessment (HRA):** before consenting a plan/project likely to
+  have a significant effect on a European site (alone or in combination) and not connected
+  with its management, the authority must make an appropriate assessment and may consent
+  only after ascertaining **no adverse effect on site integrity**; must consult Natural
+  England. See Part 4.
+- **Reg 43 — the EPS offence:** deliberately capturing/injuring/killing/disturbing a
+  European Protected Species, or damaging/destroying a breeding site or resting place.
+  *(Note: reg 43 in the 2017 consolidation — not "reg 41".)*
+- **Reg 42 + Schedule 2 — EPS animals:** all **bats**, **great crested newt**, **hazel
+  dormouse**, **otter**, sand lizard, smooth snake, natterjack toad, large blue, etc.
+- **Reg 55 — derogation licence, the THREE tests (all required):** (i) a **licensable
+  purpose** — for development, IROPI ("imperative reasons of overriding public interest",
+  reg 55(2)(e)); (ii) **no satisfactory alternative** (reg 55(9)(a)); (iii) the action
+  **will not be detrimental to maintaining the species at favourable conservation status**
+  (reg 55(9)(b)). *(reg 55 in the 2017 Regs — reg 53 in the old 2010 Regs.)*
+- *Objection relevance:* where an EPS is (or may be) present, the LPA must be able to judge
+  that these tests are **capable of being met before it grants permission** (see *Woolley*,
+  Part 4) — not defer the question to a later licence.
+- *Sources:* legislation.gov.uk/uksi/2017/1012/regulation/9 ; /63 ; /43 ; /55 ; /schedule/2
+
+### 1.4 Wildlife and Countryside Act 1981 (as amended)
+- **s.1 — wild birds:** offence to kill/injure/take a wild bird or take/damage/destroy a
+  nest in use or being built, or take/destroy eggs; **s.1(5)** — disturb a **Schedule 1**
+  bird at the nest. Active nests are protected **whenever** they occur (the "March–August"
+  season is convention, not a statutory window).
+- **s.9 + Schedule 5 — protected animals:** offence to kill/injure/take (s.9(1)) or to
+  damage/destroy/obstruct a place of shelter or disturb the animal in it (s.9(4)).
+  Schedule 5 includes **water vole**, adder, grass snake, common lizard, slow-worm (GCN is
+  additionally an EPS). *Objection relevance:* "mitigation by displacement" into occupied
+  habitat can lead to killing/injury contrary to s.9(1).
+- **s.13 + Schedule 8 — wild plants.**
+- *Sources:* legislation.gov.uk/ukpga/1981/69/section/1 ; /9 ; /13
+
+### 1.5 Protection of Badgers Act 1992
+- **s.1** kill/injure/take; **s.3** damage/destroy a sett, obstruct access, or disturb a
+  badger occupying it (intentionally or recklessly); **s.10** Natural England licence for
+  sett interference for development (class licence CL35; works window 1 Jul–30 Nov).
+- *Sources:* legislation.gov.uk/ukpga/1992/51/section/1 ; /3
+
+### 1.6 Hedgerows Regulations 1997 (SI 1997/1160)
+- **Reg 5:** no removal of a qualifying hedgerow without a removal notice; removal only if
+  the LPA approves or does not serve a retention notice within **42 days**.
+- **"Important" hedgerow (reg 4 + Sch 1):** ≥**30 years old** *and* meeting ≥1 Schedule 1
+  criterion (archaeological/historical, or wildlife/landscape — e.g. 7+ woody species, or
+  6+ with an associated bank/wall/ditch). Removal normally refused.
+- *Sources:* legislation.gov.uk/uksi/1997/1160/regulation/5 ; /4 ; /schedule/1
+
+### 1.7 Local Nature Recovery Strategies — EA2021 ss.104–108
+- Mapped, locally agreed nature-recovery priorities. No stand-alone "planning must
+  implement" clause; they bite through the **NERC s.40** duty to *have regard*, and as a
+  material consideration reinforced by national policy.
+
+---
+
+## Part 2 — National planning policy
+
+### 2.1 NPPF — **December 2024 edition** (amended 7 Feb 2025; the amendment did **not**
+touch the biodiversity chapter). ⏳ A Dec 2025 consultation draft exists (a revised NPPF
+was expected ~Summer 2026) — **confirm the live edition and paragraph numbers when you
+draft**; the numbers below are the Dec 2024 edition. Biodiversity sits in **Chapter 15,
+"Conserving and enhancing the natural environment" → "Habitats and biodiversity."**
+
+- **Para 193(a) — decision principle + mitigation hierarchy** *(was 180 in 2021, 186 in
+  2023)*: "if significant harm to biodiversity resulting from a development cannot be
+  avoided (through locating on an alternative site with less harmful impacts), adequately
+  mitigated, or, as a last resort, compensated for, then planning permission should be
+  refused." **The primary hook for a biodiversity objection.**
+- **Para 193(b) — SSSIs:** development likely to have an adverse effect on an SSSI "should
+  not normally be permitted," save where benefits clearly outweigh impacts.
+- **Para 193(c) + footnote 70 — irreplaceable habitats:** development resulting in the loss
+  or deterioration of irreplaceable habitats (ancient woodland, ancient/veteran trees)
+  "should be refused, unless there are wholly exceptional reasons and a suitable
+  compensation strategy exists." Footnote 70 confines "wholly exceptional" essentially to
+  major public-benefit infrastructure — an ordinary scheme will rarely qualify.
+- **Para 193(d) / 192(b) — net gains:** integrate opportunities to improve biodiversity,
+  "especially where this can secure measurable net gains." (Policy — *separate from and
+  additional to* statutory 10% BNG.)
+- **Paras 194–195 + footnote 7 — habitats sites:** pSPAs/cSACs, listed/proposed Ramsar
+  sites and compensatory sites get habitats-site protection; the **presumption in favour of
+  sustainable development does not apply** where a plan/project is likely to have a
+  significant effect on a habitats site unless appropriate assessment concludes no adverse
+  effect on integrity.
+- *Source PDF:* assets.publishing.service.gov.uk/media/67aafe8f3b41f783cca46251/NPPF_December_2024.pdf
+
+### 2.2 Planning Practice Guidance — "Natural environment" (gov.uk/guidance/natural-environment)
+- **Information must inform every stage (Ref ID 8-019-20240214):** biodiversity impacts/
+  opportunities must inform site selection, design and the application itself — not be left
+  until after permission. A survey is required **before** the application where a significant
+  impact is possible and existing information is inadequate; assessments must be proportionate.
+- **Conditions vs refusal (8-020-20240214):** conditions/obligations are to *secure*
+  identified mitigation/monitoring/management — **not a substitute** for the up-front
+  assessment; where the mitigation hierarchy cannot be satisfied, permission should be
+  refused. *(PPG still cross-refers to the old "para 186" — read as current para 193.)*
+- **BNG:** statutory BNG is a separate regime with its own biodiversity gain hierarchy —
+  gov.uk/guidance/biodiversity-net-gain.
+
+---
+
+## Part 3 — "Information must be adequate and current at the decision"
+
+- **R (Woolley) v Cheshire East BC [2009] EWHC 1227 (Admin):** permission quashed where the
+  LPA failed to have regard to the Habitats Directive / derogation tests and merely imposed
+  a survey-and-licence condition. **Leading authority that an LPA needs sufficient EPS
+  information and a realistic view on the derogation tests *before* granting permission, and
+  cannot defer protected-species survey work to conditions.**
+- **R (Morge) v Hampshire CC [2011] UKSC 2:** the planning-stage duty is to "have regard
+  to" the Directive; refuse only where the LPA concludes both that an offence is likely
+  *and* a derogation licence is unlikely; it may rely on Natural England withdrawing an
+  objection. *Read with Woolley — engage with Natural England's position and the tests.*
+- **Waddenzee (C-127/02), CJEU:** consent for a European site only where **"no reasonable
+  scientific doubt"** remains as to the absence of adverse effects on integrity
+  (precautionary principle).
+- **BS 42020:2013 — Biodiversity: Code of practice for planning and development** (BSI,
+  current; revision under way): submitted ecological information must be **sufficient,
+  transparent, of adequate scope/timing/currency, follow recognised methods, and be produced
+  by competent persons** (qualified/experienced, licensed where needed). The standard route
+  to challenge inadequate/out-of-date reports or non-competent authors. *Attribute specific
+  survey shelf-life figures to CIEEM (below), not to a BS 42020 clause.*
+
+---
+
+## Part 4 — Habitats Regulations Assessment / appropriate assessment
+- **Trigger:** likely significant effect on a European site (SAC/SPA), alone or in
+  combination, not connected with the site's management → HRA required (reg 63).
+- **Standard for consent:** the competent authority may grant only after ascertaining, via
+  appropriate assessment, **no adverse effect on site integrity** — the *Waddenzee* "no
+  reasonable scientific doubt" standard.
+- **People Over Wind (C-323/17), CJEU:** avoidance/reduction **mitigation must be ignored at
+  the screening stage**; if a likely significant effect can't be excluded without it, a full
+  appropriate assessment is required. Grounds an objection where an LPA "screens out" HRA by
+  relying on mitigation.
+- **Qualifying-species example — barbastelle bat** (*Barbastella barbastellus*, Annex II): a
+  qualifying feature of several English SACs. Where development may affect such a population,
+  HRA obligations are engaged **in addition to** EPS protection.
+- ⏳ **Ramsar statutory footing is in flux** (Planning & Infrastructure Act 2025 / *CG Fry*
+  Supreme Court 2025 / a reported 2026 extension of reg 63 to English Ramsar sites). Rely on
+  the **NPPF para 194 policy** protection as the safe proposition; re-check the statute.
+
+---
+
+## Part 5 — Professional survey & assessment guidance (what "competent" work follows)
+
+Deviation from the **current** edition — especially citing a **superseded** one — is a core
+objection ground. The superseded-edition traps are consolidated in Part 6.
+
+### Cross-taxa
+- **CIEEM, Guidelines for Ecological Impact Assessment (EcIA) — v1.3, Sept 2024** (supersedes
+  v1.2 2022 / v1.1 2018 / v1.0 2016; 2006 version obsolete). Proportionate baseline surveys
+  of appropriate season/effort, current data, reasoned significance conclusions.
+- **CIEEM, Advice Note on the Lifespan of Ecological Reports & Surveys — April 2019.**
+  Graduated bands: **<12 months** likely valid; **12–18 months** usually valid with caveats;
+  **18 months–3 years** requires a professional to revisit, update the desk study and issue a
+  justified validity statement; **>3 years** "unlikely to still be valid" and surveys likely
+  need updating. It is a graduated presumption subject to judgement — **the 18-month fresh-
+  site-visit trigger and the >3-year presumption are the actionable thresholds**; a habitat
+  walkover is *not* a species-survey update.
+- **CIEEM, Guidelines for Preliminary Ecological Appraisal (PEA) — 2nd ed., Dec 2017.**
+- **CIEEM Competency Framework 2024 (V7)** + **BS 42020** "competent person": authors should
+  be suitably qualified/experienced (MCIEEM, CEcol/CEnv), with the relevant Natural England
+  survey/mitigation licence for protected-species work.
+
+### Bats
+- **Bat Conservation Trust, Bat Surveys for Professional Ecologists: Good Practice Guidelines
+  — 4th ed., Sept 2023 ("Collins 2023").** ⚠ **Superseded: 3rd ed. 2016** — roost-suitability
+  categories are **not transferable** across editions. Effort scales to roost-suitability
+  category (defaults ~Low 1 / Moderate 2 / High 3 nocturnal visits, **≥3 weeks apart**, active
+  season), static detectors carry remaining effort, suitable weather required. *(Verify exact
+  per-category visit counts in the source before quoting a number.)*
+- **UK Bat Mitigation Guidelines — Reason & Wray, CIEEM, v1.2 Aug 2025.** ⚠ Replaces the
+  long-cited **Mitchell-Jones (2004)**. PRFs cannot be cleared on ground-level assessment
+  alone — **moderate/high-suitability PRF trees need nocturnal emergence/re-entry or a
+  climbed/endoscope inspection by a licensed surveyor before felling.**
+- **Bats and artificial lighting — ILP/BCT Guidance Note GN08/23, Aug 2023.** ⚠ Superseded:
+  **GN08/18**. Dark corridors/roost accesses/commuting routes kept **below ~0.5 lux**; warm
+  spectrum (≤2700K), full cut-off/shielded luminaires, lowest viable lux/height, part-night
+  dimming, maintained dark buffers. *(Confirm exact lux ceilings in the source.)*
+- **Natural England bat licensing:** EPS mitigation licence (three derogation tests, Part
+  1.3); ⏳ the Bat Mitigation Class Licence (CL21) is reportedly transitioning toward "Bat
+  Earned Recognition" — confirm the live position.
+- **Standing advice:** gov.uk/guidance/bats-advice-for-making-planning-decisions
+
+### Other protected / priority species *(Natural England standing-advice pages, mostly
+updated Apr 2025)*
+- **Great crested newt:** **HSI is a habitat-*screening* tool — never presence/absence**
+  (Oldham et al. 2000; ARG UK Advice Note 5, 2010). Presence/likely-absence by **eDNA** (Biggs
+  et al. 2014; single visit **15 Apr–30 Jun**) or traditional surveys (English Nature 2001
+  Mitigation Guidelines; ≥4 visits presence/absence, 6 for population class). **District Level
+  Licensing** is an accepted strategic route. Standing advice: data ≤4 survey seasons old.
+- **Reptiles:** **Froglife Advice Sheet 10 (1999)** — ≥7 visits in suitable weather; refugia
+  ~5–10/ha **distributed across ALL suitable habitat, not just margins** (the core objection
+  where a survey is "designed not to find them"). *(Don't confuse with the 2013 volunteer
+  booklet or the 2018 peatland Advice Note 10.)* Also Herpetofauna Workers' Manual (2003
+  reprint); HGBI (1998) translocation standard.
+- **Hazel dormouse (EPS):** ⚠ **current = Hazel Dormouse Conservation Handbook 3rd ed. 2025
+  + Mitigation Handbook 2025** (Mammal Society; the 2006 English Nature handbook is
+  superseded). Nest tubes (~50 at ~20 m, monthly across the active season; Survey Effort Score
+  ≥20 before inferring absence) or autumn nut searches. **Cannot be scoped out on desk study
+  alone where suitable habitat is present** — "absence of a record does not mean there are no
+  dormice."
+- **Water vole (WCA Sch 5, fully protected incl. habitat):** Water Vole Conservation Handbook
+  3rd ed. 2011 + Mitigation Handbook 2016; two bankside visits in a season (Apr–Jun, Jul–Sept);
+  currency ~2 years by convention.
+- **Badger:** Harris, Cresswell & Jefferies (1989) *Surveying Badgers* + CIEEM (2013)
+  competencies; sett classification, activity monitoring, **bait-marking** (spring) to
+  establish sett status/territory before design.
+- **Breeding birds:** **territory mapping** (BTO Common Birds Census method; ~8–10 visits
+  Mar/Apr–Jun/Jul) — point counts on a bat-transect route are the wrong method. All active
+  nests protected (WCA s.1); **Schedule 1** species specially protected (barn owl — Shawyer
+  2011/rev. 2012 methodology, pub. Wildlife Conservation Partnership/IEEM). **Birds of
+  Conservation Concern: current = BoCC5 (2021)** (⚠ supersedes BoCC4 2015). Skylark is
+  red-listed and ground-nesting but *not* Schedule 1.
+- **Otter (EPS):** standard search unit **600 m of one bank** (Chanin 2003) — relevant for
+  riparian/near-water development.
+
+### Habitats & BNG technical
+- **UK Habitat Classification (UKHab) — v2.0 (July 2023)** operative. ⏳ v2.1 is
+  consultation-stage only — do not cite as operative.
+- **The Statutory Biodiversity Metric** (Natural England/Defra; Small Sites Metric for
+  qualifying small sites). ⚠ **Superseded naming: "Biodiversity Metric 3.0/3.1/4.0"** are no
+  longer valid for statutory BNG. Requires full baseline completeness incl. the separate
+  **watercourse** and **hedgerow** modules; **distinctiveness + condition** scoring against
+  published criteria; **trading rules** (high/very-high distinctiveness cannot be traded
+  down); strategic-significance and spatial-risk multipliers. Scrutinise: inflated condition,
+  **omitted baseline features** (unsurveyed watercourse/hedgerow), mis-classification to lower
+  baseline distinctiveness, the **"vegetated garden" classification**, and **double-counting
+  one parcel for two functions.** gov.uk/guidance/calculate-biodiversity-value-with-the-statutory-biodiversity-metric
+- **Ancient woodland:** Ancient Woodland Inventory (woodland since ≥1600 AD); updating method
+  = NE Commissioned Report **NECR248 (2018)** — holistic assessment using historic/tithe maps
+  and ancient-woodland indicator plants (the basis for challenging a small/narrow feature, e.g.
+  a shaw, "dismissed" merely by listing AWI sites within 2 km). **Standing advice** (NE &
+  Forestry Commission, updated Jan 2022): **ancient woodland buffer ≥15 m** (semi-natural, no
+  SuDS/services); **ancient/veteran trees — 15× stem diameter or 5 m beyond the canopy,
+  whichever is greater.** As irreplaceable habitat it sits **outside** metric trading (NPPF
+  193(c)).
+- **Hedgerows:** ecological function = corridors/foraging/nesting; assessed via the metric's
+  hedgerow module; important hedgerows protected (Hedgerows Regs 1997, Part 1.6). **No single
+  statutory national buffer distance** — verify the number against the local plan and current
+  metric hedgerow-condition guidance. Survey: Hedgerow Survey Handbook (2nd ed., 2007).
+
+---
+
+## Part 6 — Superseded-edition quick reference (citing the old one is an objection ground)
+
+| Topic | Current | Superseded (⚠ if cited as current) |
+|---|---|---|
+| Bat surveys | **Collins 4th ed., 2023** | 3rd ed. 2016 (categories not transferable) |
+| Bat mitigation | **Reason & Wray, CIEEM v1.2, 2025** | Mitchell-Jones 2004 |
+| Bats & lighting | **ILP/BCT GN08/23, 2023** | GN08/18, 2018 |
+| EcIA | **CIEEM v1.3, Sept 2024** | v1.2 2022 / v1.1 2018 / v1.0 2016 / 2006 |
+| PEA | **CIEEM 2nd ed., 2017** | 1st ed. 2012/13 |
+| Dormouse | **Mammal Society 3rd ed. + Mitigation Handbook, 2025** | English Nature 2nd ed., 2006 |
+| Water vole | **Conservation Handbook 3rd ed. 2011 + Mitigation 2016** | 1998 / 2006 |
+| Birds of Conservation Concern | **BoCC5, 2021** | BoCC4, 2015 |
+| Biodiversity metric | **The Statutory Biodiversity Metric** | Metric 3.0 / 3.1 / 4.0 |
+| Herpetofauna Workers' Manual | **2003 reprint** | 1998 |
+| CIEEM competency | **2024 (V7)** | pre-2024 framework |
+
+## Part 7 — ⏳ Verify-before-relying (time-sensitive as of Aug 2026)
+
+- **NPPF paragraph numbers** — Dec 2024 edition used here; a revised NPPF was expected
+  ~Summer 2026 and will likely renumber. Confirm before citing.
+- **BNG 2026 changes** — the 6 Aug 2026 exemptions/thresholds and 2 Nov 2026 NSIP
+  commencement (verify the amending SIs); current exemption list.
+- **Ramsar statutory footing** — Planning & Infrastructure Act 2025 / *CG Fry* / reported
+  reg 63 extension. Safe proposition remains NPPF para 194 policy.
+- **UKHab v2.1** and the **bat class-licence → "Bat Earned Recognition"** transition — in
+  progress; confirm the live position.
+- **Exact figures** (per-category bat visit counts; GN08/23 lux ceilings; NECR248 internal
+  method) — corroborated from multiple sources but confirm in the primary document before
+  quoting a precise number.

--- a/nppf-2024-12/ecological-representation/references/objection-template.md
+++ b/nppf-2024-12/ecological-representation/references/objection-template.md
@@ -1,0 +1,169 @@
+# Objection template + annotated worked example
+
+Two things: a **skeleton** to fill, and a **worked example** (adapted from the
+human-edited exemplar objection) showing the house style in practice. Match the
+example's density and tone, not its exact wording — every point must come from the
+documents actually in front of you.
+
+---
+
+## Skeleton
+
+```
+[Your name]
+[Your address]
+[Email]
+
+[Date]
+
+[Planning department / Council name / address]
+[For the attention of [Case Officer], if known]
+
+RE: Application [ref] — [site]
+[One-line description of the proposal]
+
+Dear [Sir or Madam / Mr/Ms Name],
+
+REPRESENTATION ON ECOLOGICAL GROUNDS — OBJECTION UNLESS MATTERS RESOLVED
+
+[Opening: note consultation status; application undecided; matters are material
+considerations the Council must take into account; ask that this be placed on the file.]
+
+[Roadmap sentence if more than one theme. State which documents you are addressing —
+e.g. the Ecological Impact Assessment (author, date) and the BNG metric — and that you
+support and ask the Council to enforce its own ecologist's objection, if there is one.]
+
+The relevant framework includes: [short bulleted list from national-guidance.md — only
+the instruments actually engaged by this application].
+
+## 1. [Point stated as a conclusion]
+[Quote the document (§/Table/Figure). Say why it matters for the decision and which
+guidance/law it breaches. State the ask and its timing.]
+
+## 2. [Next point]
+…
+
+## Summary of requests
+[Numbered, concrete, grouped, mostly "before determination".]
+
+Unless and until these matters are resolved, I object to [the grant of outline permission
+/ approval of the reserved matters / discharge of condition N].
+
+Yours [sincerely/faithfully],
+[Name]
+```
+
+---
+
+## Worked example (ecology, condensed — annotations in ⟨…⟩)
+
+> ⟨Header block, RE line and opening omitted here for brevity — see the skeleton. The
+> opening notes the consultation has closed, the application is undecided, and the matters
+> are material considerations; it aligns the representation with the Council ecologists'
+> holding objection of [date].⟩
+
+**The relevant framework documents in relation to this representation are:**
+⟨Framework list — signals rigour, anchors every later point. Keep to what is engaged.⟩
+
+- the statutory biodiversity net gain condition under section 98 and Schedule 7A of the
+  Environment Act 2021;
+- sections 40–41 NERC Act 2006;
+- the Conservation of Habitats and Species Regulations 2017 (including regulation 9(3));
+- the Wildlife and Countryside Act 1981;
+- the NPPF's habitats and biodiversity provisions;
+- the Local Plan's biodiversity, watercourse / river-corridor, and trees-hedgerows-
+  woodlands policies **[insert the specific policy references for the authority]**.
+
+### A1. The holding objection raises pre-determination matters, not condition matters
+⟨Heading = conclusion. Lead with the LPA ecologist's own findings, as a bullet list of
+specific defects, each naming the guidance/policy breached.⟩
+
+The Council's ecologists identified serious gaps in the BNG and habitat evidence,
+including: the on-site stream **omitted entirely from the BNG baseline** (no watercourse
+metric); future garden habitats given higher distinctiveness than the 'vegetated garden'
+classification guidance allows, inflating the claimed units; no evidence that 'moderate
+condition' grassland is achievable in areas doubling as public open space; metric and
+layout plans that contradict each other (a plot backs directly onto hedgerows the metric
+shows as buffered); and missing hedgerow buffers (the Local Plan hedgerow-buffer standard,
+commonly 5–10 m, unlit) and the watercourse buffer (the Local Plan watercourse policy).
+
+⟨Then the load-bearing argument: why these are pre-determination, not condition, matters.⟩
+These go beyond arithmetic. Until the buffers are drawn correctly the Council cannot know
+whether **the proposed number of dwellings physically fits on the site**; granting outline permission
+first would bake in a density the constraints may not accommodate. Because the application
+is subject to statutory 10% BNG (Environment Act 2021, Schedule 7A), the baseline errors
+also corrupt the Biodiversity Gain Plan the statutory condition will later approve. The
+corrected, independently verified metric is needed **now**, before determination.
+
+### A2. Bat impact assessment is deferred beyond the decision
+⟨Quote the applicant against themselves — the strongest single move.⟩
+
+The EcIA identifies several trees with potential maternity roost features (PRF-M), then
+states: "*it is not known whether any trees identified as supporting bat roost potential
+will be removed… full details… will be added… once they have been identified.*" The
+assessment of the most sensitive ecological impact is thereby postponed until after the
+decision. The Council's ecologists have specified three PRF inspection surveys between May
+and September; those surveys, and confirmation of which PRF trees are affected, must come
+**before determination** — if a maternity roost is present the Habitats Regulations
+derogation tests are engaged (regulation 9(3)).
+
+### A3. Further deficiencies not yet covered by the holding objection
+⟨Lettered sub-points where several smaller, independent defects sit together. Each: bold
+one-line claim, then the quoted evidence and the ask.⟩
+
+**(a) 90% of unidentified bat recordings were never analysed.** Table 1 shows only 10% of
+the non-identifiable (NoID)/noise files were analysed. Rare, quiet-calling species —
+Barbastelle, *Myotis*, long-eared bats — are exactly what sits unrecognised in NoID files,
+and their presence would change the site's valuation and lighting constraints. The full
+dataset should be analysed.
+
+**(b) The bat survey dates contradict themselves three ways.** The transect table says
+15/04/25, 11/07/25 and 08/10/25; one caption says "April, July & September"; another says
+"June, August & October". The Council cannot tell when the surveys happened or whether the
+seasonal spread in the BCT guidelines (Collins, 2023) was achieved.
+
+**(c) No great crested newt eDNA survey was done.** Of seven ponds within 500 m, three
+were never surveyed and four received only HSI screening — a suitability tool, not a
+presence/absence method. eDNA (or district licensing) should be resolved before
+determination.
+
+### Summary of requests
+⟨Concrete, numbered, grouped, timed. This is what the officer lifts into the report.⟩
+
+Ecology — before determination:
+1. Maintain the holding objection until every matter is resolved by evidence, not
+   condition;
+2. PRF inspection surveys and confirmation of which PRF trees are affected;
+3. Full analysis of the NoID/noise bat datasets and corrected survey dates;
+4. GCN eDNA (or district licensing) for the ponds within 500 m;
+5. A corrected, independently verified BNG metric (watercourse baseline, garden
+   classifications, realistic condition targets, layout-consistent hedgerows);
+6. A plan demonstrating the required watercourse and hedgerow buffers alongside the
+   proposed quantum — or a reduced quantum;
+7. A reconciled, wildlife-sensitive lighting strategy.
+
+Unless these matters are resolved, I object to the grant of outline planning permission.
+
+Yours sincerely,
+[Name]
+
+---
+
+### Notes on adapting the example
+
+- This skill is scoped to **ecology**. A representation may of course also raise transport,
+  heritage, flooding or amenity, but those are separate matters for a different skill; the
+  worked example above shows the ecology part only.
+- **Consultant- or campaign-specific framing is deliberately excluded by default** — for
+  example, cross-referencing other live applications, or citing a named public inquiry to
+  attack a particular applicant or consultancy. The underlying *technical* points (reptile
+  refugia placement, felling roost-potential trees without emergence surveys, BNG
+  double-counting, metric errors) are free-standing grounds already in
+  `deficiency-catalogue.md` — raise them on the application's own facts, not by reference to
+  another case, unless the user specifically asks and it is genuinely relevant and
+  defensible here.
+- **Before submitting:** a person must read and check the draft — every quote and citation
+  against the actual documents — and be aware that the representation is normally
+  **published on the council's planning portal in the submitter's name** and kept on the
+  record, so include only personal details the user is content to make public. This is a
+  draft aid provided with no warranty; it is not legal advice.

--- a/nppf-2024-12/flood-representation/CHANGELOG.md
+++ b/nppf-2024-12/flood-representation/CHANGELOG.md
@@ -1,0 +1,65 @@
+# Changelog — flood-representation
+
+Design decisions per revision, newest first. See `../CLAUDE.md` for the format and the
+house rules. The **_Why_** lines record the rationale so a future editor understands the
+intent.
+
+## Unreleased
+
+### Changed
+- **`national-guidance.md` now defers to the companion `national-planning-policy` skill**
+  for the NPPF/PPG edition register, the verify-before-citing protocol, and the shared
+  decision-making core; this file keeps only the topic layer. _Why:_ reviewer feedback —
+  per-skill NPPF snapshots drift out of sync as editions change; one register, checked
+  first, keeps the citations consistent (two-layers house rule).
+
+### Added
+- **A/B/C outcome discipline:** every point must be classified as **(A)** demonstrated
+  unacceptable impact (refusal reason), **(B)** insufficient evidence to reach the necessary
+  conclusion (do-not-determine-yet ask), or **(C)** controllable by condition/obligation
+  (mitigation ask) — plus a pre-send checklist item that no point asks for refusal where a
+  condition would lawfully and satisfactorily do. _Why:_ reviewer feedback — an inadequate
+  assessment does not necessarily mean the development is unacceptable, only that the LPA
+  cannot presently be satisfied that it is; conflating the two (or over-asking for refusal
+  on conditionable points) is the classic credibility mistake in lay objections.
+
+### Changed
+- **"What you need first" now says uploaded/pasted/already-downloaded documents work
+  directly, and `planning-document-search` is only needed when the user doesn't have
+  them.** _Why:_ makes explicit that direct document supply is a first-class input, and
+  completes the retrieval skill's fail-fast handover (stop → download manually → feed the
+  files back in here).
+
+## 0.1.0 — 2026-08-14 — Initial release
+
+First version, built to the same pattern as the other representation skills: (1) evaluate the
+flood-risk and drainage evidence, (2) map deficiencies to national policy/guidance and the
+tests, and (3) draft a concise representation — or advise that none is warranted. Structure:
+`SKILL.md` + `references/` (`deficiency-catalogue.md`, `national-guidance.md`, `house-style.md`,
+`objection-template.md`). Key design decisions:
+
+### Added
+- **Two anchors as the spine:** *the statutory consultees (Environment Agency, Lead Local Flood
+  Authority) are your allies* — read their responses first and build on any objection; and *the
+  two hard requirements* — safe for the development's lifetime, and no increase in flood risk
+  elsewhere. _Why:_ flood objections succeed when they align with the consultees and press the
+  two requirements that policy makes non-negotiable, rather than asserting "it will flood."
+- **Lead with the Sequential Test.** _Why:_ it is the first hurdle and can defeat an application
+  on its own (reasonably available lower-risk sites), before any site-specific FRA detail.
+- **A web-verified guidance catalogue** — the NPPF flood policies and the Sequential/Exception
+  Tests, the PPG flood zones and vulnerability classes, the EA/LLFA roles and standing advice,
+  climate-change allowances, and the SuDS standards — with time-sensitive items flagged ⏳ (NPPF
+  numbering; the Schedule 3 mandatory-SuDS status; climate allowances).
+- **Deficiency catalogue** covering the Sequential/Exception Tests, FRA adequacy (all sources,
+  current data, climate change, safe access, residual risk), not increasing risk elsewhere
+  (floodplain storage, runoff), SuDS and the drainage hierarchy, foul capacity, and consultee
+  engagement.
+- **House style + annotated template** with the bullet / lettered-sub-point discipline built in
+  from the start, so drafts are scannable.
+
+### Changed / Security
+- **Scoped to flood risk, England-focused, explicitly not legal advice; no warranty; human
+  review required; public-document-in-your-name flag.** _Why:_ the same user-protection
+  disclaimers as the other skills.
+- **Built generic and public-safe** — no case/campaign/consultant/place fingerprints; local
+  policy references left as `[insert …]`. _Why:_ repo house rules.

--- a/nppf-2024-12/flood-representation/LICENSE
+++ b/nppf-2024-12/flood-representation/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ian Howard
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/nppf-2024-12/flood-representation/README.md
+++ b/nppf-2024-12/flood-representation/README.md
@@ -1,0 +1,53 @@
+# Flood Representation
+
+A skill for producing a rigorous, credible representation on the **flood-risk and drainage**
+merits of a UK planning application — or advising that no sustainable objection exists.
+England-focused.
+
+> **Not legal advice. No warranty.** Output is a draft aid provided "as is". **A human must
+> review and check it before submitting.** A UK planning representation is normally **published
+> on the council's portal in the submitter's name** — include only personal details you're
+> content to make public.
+
+It does three things:
+
+1. **Evaluate** the applicant's flood-risk and drainage evidence (Flood Risk Assessment,
+   Drainage Strategy / SuDS report, Sequential/Exception Test) against current policy and
+   guidance, and identify the material deficiencies.
+2. **Map** each deficiency to the specific policy, test and guidance it engages.
+3. **Draft** the representation in clear, precise, concise language.
+
+## Contents
+
+| File | What it is |
+|---|---|
+| `SKILL.md` | The skill: workflow, integrity principle, and the two flood anchors. **Start here.** |
+| `references/deficiency-catalogue.md` | Function 1 — the evaluation checklist. |
+| `references/national-guidance.md` | Function 2 — the policy/guidance catalogue with citations. |
+| `references/house-style.md` | Function 3 — how a strong representation reads. |
+| `references/objection-template.md` | Skeleton + annotated worked example. |
+| `CHANGELOG.md` | Design decisions and their rationale, per revision. |
+
+## Two things that define this skill
+
+- **The statutory consultees are your allies.** The Environment Agency and the Lead Local Flood
+  Authority carry weight — read their responses first and build on any objection or holding
+  position.
+- **Two hard requirements.** Whatever the benefits, the development must be *safe for its
+  lifetime* and must *not increase flood risk elsewhere*. Lead with the Sequential Test, which
+  can defeat an application on its own.
+
+## Pairs with
+
+The **planning-document-search** skill retrieves the documents; **application-triage** decides
+whether flood risk is a live ground.
+
+## Freshness
+
+The guidance catalogue was web-verified **August 2026**. Policy and standards change (NPPF
+paragraph numbers; the status of mandatory SuDS under Schedule 3; climate-change allowances) —
+items flagged ⏳ in `national-guidance.md` are time-sensitive; re-verify at the point of drafting.
+
+## License
+
+MIT — see [`LICENSE`](LICENSE). Provided as-is, with no warranty; not legal advice.

--- a/nppf-2024-12/flood-representation/SKILL.md
+++ b/nppf-2024-12/flood-representation/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: flood-representation-nppf-2024-12
+description: >-
+  ARCHIVED - December 2024 NPPF edition (superseded 17 August 2026). Use only when the user explicitly asks to work under the pre-August-2026 framework and has confirmed they want the archived skills; outputs must state they cite a superseded framework. 
+  Evaluate the flood-risk and drainage evidence submitted with a UK planning
+  application (Flood Risk Assessment, Drainage Strategy / SuDS report, and the
+  Sequential/Exception Test justification), identify the national policy and
+  guidance it engages, and draft a concise, well-founded objection — or advise
+  that no sustainable objection exists. England-focused. Not legal advice; no
+  warranty; output requires human review.
+license: MIT
+---
+
+# Flood-risk representation on a planning application
+
+Help a member of the public produce a rigorous, credible representation on the **flood-risk
+and drainage** merits of a planning application. The skill does three things:
+
+1. **Evaluate** the applicant's flood-risk and drainage evidence against current national
+   policy and guidance, and identify the material deficiencies.
+2. **Map** each deficiency to the specific policy, test and guidance it engages.
+3. **Draft** the representation in clear, precise, concise language — or advise that the
+   evidence is sound and no sustainable objection exists.
+
+## When to use
+
+The user has a planning application and wants to object, or find out whether they can, on
+flood-risk or drainage grounds — the Sequential/Exception Tests, an inadequate or missing Flood
+Risk Assessment, increased flood risk elsewhere, surface-water/foul drainage, or sustainable
+drainage (SuDS). Trigger phrases: "object on flood grounds", "is this Flood Risk Assessment
+adequate", "this will flood my property / make flooding worse", "they haven't done a sequential
+test", "the drainage isn't sustainable."
+
+Not this skill: ecology, transport, heritage, general amenity — separate matters.
+
+## What you need first
+
+- The **application reference and council**, or the **documents themselves** — uploaded,
+  pasted, or already-downloaded files work directly; the companion **planning-document-search**
+  skill is only needed when you don't have them (it retrieves them from the reference + council).
+- The **flood/drainage documents** — the Flood Risk Assessment, the Drainage Strategy / SuDS
+  report, and any Sequential/Exception Test statement. Also the **Environment Agency and Lead
+  Local Flood Authority consultation responses** (often decisive — read them first).
+- The **flood context** — which **Flood Zone** the site is in (Environment Agency "Flood map for
+  planning"), its size, and any other flood sources (surface water, groundwater, sewers) or
+  critical drainage area; whether the site is greenfield.
+- The **local plan's** flood-risk and drainage policies, and any Strategic Flood Risk Assessment.
+
+## The integrity principle and two anchors (read before drafting)
+
+**Only object where the evidence is genuinely inadequate or the risk genuinely unacceptable.**
+If the site is in Flood Zone 1 with no other source, an FRA may not even be required; if the FRA
+is adequate, the tests are satisfied, and the EA and LLFA are content, there is **no sustainable
+objection** — say so. Treat "don't object" as a valid output.
+
+Two anchors:
+- **The statutory consultees are your allies.** The **Environment Agency** (river/sea risk) and
+  the **Lead Local Flood Authority** (surface-water drainage on major development) are statutory
+  consultees. Read their responses first; align with any objection/holding position and press
+  for it to be resolved *before* determination.
+- **The two hard requirements.** Whatever the benefits: the development must be **safe for its
+  lifetime** and must **not increase flood risk elsewhere** (ideally reduce it). Test both.
+
+**Classify every point's ask — (A) refuse, (B) don't determine yet, or (C) condition it.**
+An evidential deficiency is not itself a reason for refusal. For each confirmed point, be
+explicit about which outcome it supports: **(A)** the evidence *demonstrates* an unacceptable
+impact (a failed Sequential/Exception Test; demonstrated risk elsewhere) → a refusal reason;
+**(B)** the evidence is *insufficient* for the Council to reach the necessary conclusion (no
+FRA where one is required; no climate-change allowances; an unresolved EA/LLFA holding
+objection) → the application should **not be determined** until the information is provided;
+**(C)** the issue can be adequately controlled → ask for the *specific* condition or
+obligation (a detailed drainage scheme, runoff limits, a SuDS maintenance plan). Most
+deficiency findings are (B), not (A) — claiming (A) on (B) evidence is the classic
+credibility mistake. And test every point against (C): if a condition would lawfully and
+satisfactorily resolve it, ask for that rather than refusal — over-asking weakens the whole
+representation.
+
+## Workflow
+
+### Step 1 — Intake and read
+Identify the **flood zone(s)** and sources of risk, the site size, whether it is greenfield, and
+the application type. Read the **EA and LLFA responses first**. Get the FRA, Drainage Strategy
+and any Sequential/Exception Test statement.
+
+### Step 2 — Evaluate against the deficiency catalogue (function 1)
+Work through [`references/deficiency-catalogue.md`](references/deficiency-catalogue.md). Confirm
+each candidate deficiency is **present** and **material**, and capture the specific evidence —
+the document, author, date, and the paragraph/figure/plan. Quote the FRA's own words, or the
+consultee response. Grade findings and lead with the decision-critical.
+
+Key tests: Is the **Sequential Test** passed (reasonably available lower-risk sites)? Is the
+**Exception Test** (both limbs) met where required? Is a **site-specific FRA** provided where
+required, assessing **all sources** with current data and **climate-change allowances**? Are
+**safe access/egress and floor levels** shown, and **residual risk** assessed? Does the scheme
+**increase flood risk elsewhere** (floodplain storage, runoff)? Does the **drainage** follow the
+hierarchy, restrict runoff, and secure maintenance? Are the **EA/LLFA** satisfied?
+
+### Step 3 — Map to policy and guidance (function 2)
+Attach the precise instrument from
+[`references/national-guidance.md`](references/national-guidance.md) — the NPPF flood paragraphs
+and the Sequential/Exception Tests, the PPG (flood zones, when an FRA is required, vulnerability
+classes), the EA/LLFA roles and standing advice, the climate-change allowances, and the SuDS
+standards — plus the **local plan** flood policies and the Strategic Flood Risk Assessment. Cite
+specifically.
+
+### Step 4 — Draft (function 3)
+Draft to [`references/house-style.md`](references/house-style.md) and
+[`references/objection-template.md`](references/objection-template.md): header → RE line (note
+the flood zone) → opening → bulleted framework list → numbered conclusion-headed points (lead
+with the Sequential Test; quoted evidence; the ask) → numbered **Summary of requests** →
+objection sentence → sign-off. Keep it concise; use bullets for lists and `(a)/(b)` for
+multi-limb points (e.g. the Exception Test).
+
+### Step 5 — Check before sending
+- Every point is evidenced from the documents/consultees or cited policy; nothing asserted.
+- Figures and flood-zone references are accurate.
+- It aligns with, and builds on, the EA/LLFA positions.
+- Consultant-/campaign-specific framing excluded unless the user asked and it is defensible.
+- Requests are concrete and correctly timed.
+- Every point is classified **(A) demonstrated harm / (B) insufficient evidence / (C)
+  conditionable** — and no point asks for refusal where a condition would lawfully and
+  satisfactorily do.
+- **Hand back to a human, with the two warnings:** the draft must be read and checked, and
+  submitting it puts a **public document in the user's name** on the council's portal.
+
+## Reference files
+
+- [`references/deficiency-catalogue.md`](references/deficiency-catalogue.md) — the evaluation
+  checklist.
+- [`references/national-guidance.md`](references/national-guidance.md) — the policy/guidance
+  catalogue with citations.
+- [`references/house-style.md`](references/house-style.md) — how a strong representation reads.
+- [`references/objection-template.md`](references/objection-template.md) — skeleton + annotated
+  worked example.
+
+## Scope and limitations
+
+- **Not legal advice, and no warranty.** Not a substitute for a solicitor or a flood-risk
+  engineer; guarantees no outcome; provided "as is".
+- **Human review is necessary before submitting.** A person must check every figure and citation
+  against the actual documents.
+- **A UK planning representation is a public document in the submitter's name** — normally
+  published on the council's portal; include only personal details the user is content to make
+  public.
+- **England-focused.** The NPPF/PPG and EA/LLFA framework are England; devolved policy differs —
+  flag when outside England.
+- **Evidence-bound.** Don't invent flood levels, flows or modelling; where information is
+  missing, that *absence* is itself the point ("no FRA / no sequential test"), argued as such.
+- **The honest answer is sometimes "don't object."**

--- a/nppf-2024-12/flood-representation/references/deficiency-catalogue.md
+++ b/nppf-2024-12/flood-representation/references/deficiency-catalogue.md
@@ -1,0 +1,142 @@
+# Flood-risk & drainage submission — deficiency catalogue
+
+The recurring, defensible grounds on which a planning application's **flood-risk and drainage
+evidence** (a Flood Risk Assessment, a Drainage Strategy / SuDS report, and the Sequential/
+Exception Test justification) can be challenged. Each entry is a *pattern to look for*, not a
+template sentence: find the specific instance, quote it, and attach the request. Cross-
+references point to [`national-guidance.md`](national-guidance.md).
+
+> **Integrity rule (read first).** Only raise a deficiency that is actually present and
+> material. If the site is in Flood Zone 1 with no other flood source, an FRA may not even be
+> required; if the FRA is adequate, the Sequential/Exception Tests are satisfied, and the EA
+> and Lead Local Flood Authority are content, there is **no sustainable objection** — say so.
+>
+> **Two anchors for flood objections:**
+> - **The statutory consultees are your allies.** The **Environment Agency** (river/sea flood
+>   risk) and the **Lead Local Flood Authority** (surface-water drainage, major development) are
+>   statutory consultees. Read their responses first; align with any objection or "holding"
+>   position, and press for it to be resolved *before* determination.
+> - **The two hard requirements.** Whatever the benefits, the development must be **safe for its
+>   lifetime** and must **not increase flood risk elsewhere** (ideally reduce it). Those are the
+>   points to test.
+
+---
+
+## A. The Sequential and Exception Tests
+
+**A1 — Sequential Test not applied, or not passed.** Development that should be steered to
+areas at **lower** flood risk, without evidence that there are no **reasonably available sites**
+at lower risk within the area of search.
+- *Why it matters:* the Sequential Test is the first hurdle — if there are lower-risk
+  alternatives, the test fails and permission should be refused, whatever the site's own FRA
+  says.
+- *Ask:* a Sequential Test with a defined area of search and evidence that no reasonably
+  available lower-risk sites exist — before determination.
+
+**A2 — Exception Test not applied, or only half-done.** Where the Exception Test is required
+(a more-vulnerable use in a higher flood zone), it has **two** limbs and **both** must be met:
+- **(a)** the development provides wider sustainability benefits to the community that
+  **outweigh** the flood risk; and
+- **(b)** it will be **safe for its lifetime**, **without increasing flood risk elsewhere**,
+  and where possible will **reduce** flood risk overall.
+- *Tell:* the benefits limb asserted but the safety/no-worsening limb not demonstrated (or
+  vice versa).
+- *Ask:* both limbs of the Exception Test demonstrated on the evidence.
+
+**A3 — Sequential approach within the site not applied.** The most vulnerable uses (housing,
+ground-floor sleeping accommodation) placed in the higher-risk parts of the site when lower-
+risk parts exist.
+- *Ask:* the layout re-worked to put the most vulnerable uses in the lowest-risk areas.
+
+**A4 — Wrong vulnerability / flood-zone compatibility.** A "more vulnerable" (e.g. residential)
+or "highly vulnerable" use proposed in a flood zone where it is incompatible or requires the
+Exception Test, without that being addressed.
+- *Ask:* the vulnerability classification and flood-zone compatibility correctly applied.
+
+---
+
+## B. Flood Risk Assessment adequacy
+
+**B1 — No site-specific FRA where one is required.** No FRA for a site in **Flood Zone 2 or
+3**, over **1 hectare** in Zone 1, or in an area with other flood sources / a critical drainage
+problem.
+- *Ask:* a site-specific FRA to the required standard before determination.
+
+**B2 — Not all sources of flooding assessed.** The FRA addresses only rivers/sea and ignores
+**surface water, groundwater, sewers, and reservoirs**, where these are a risk at the site.
+- *Ask:* an assessment of all relevant sources of flood risk.
+
+**B3 — Out of date or wrong baseline.** The FRA uses superseded flood-zone/modelling data, the
+wrong flood zone, or ignores more recent EA mapping or a local surface-water study.
+- *Ask:* the FRA re-based on the current Environment Agency data and any local study.
+
+**B4 — Climate change allowances not applied, or the wrong ones.** Peak river-flow / peak
+rainfall allowances for the development's **lifetime** not applied, or an out-of-date/too-low
+allowance used.
+- *Ask:* the current climate-change allowances applied over the development's lifetime.
+
+**B5 — Safe access/egress and finished levels not demonstrated.** No safe access and egress in
+a flood event; finished floor levels not set above the design flood level (with freeboard);
+residual risk (e.g. a breach, or an event exceeding the design standard) not assessed; no flood
+warning/evacuation consideration where relevant.
+- *Ask:* safe access/egress, appropriate floor levels and freeboard, and a residual-risk
+  assessment.
+
+---
+
+## C. Not increasing flood risk elsewhere
+
+**C1 — Loss of floodplain storage not compensated.** Building in the floodplain displaces flood
+water without **compensatory storage** (level-for-level, volume-for-volume), increasing risk to
+others.
+- *Ask:* compensatory flood storage demonstrated, or the footprint kept out of the floodplain.
+
+**C2 — Development on functional floodplain (Zone 3b).** Built development (other than the water-
+compatible/essential exceptions) proposed on land that floods in the design event and is needed
+to store or convey flood water.
+- *Ask:* the functional floodplain kept free of inappropriate development.
+
+**C3 — Increased surface-water runoff.** Runoff not restricted to the **greenfield rate** (or a
+betterment on a brownfield site); attenuation undersized for the design storm (including the
+climate-change allowance).
+- *Ask:* runoff restricted to greenfield/agreed rates with adequately-sized attenuation.
+
+---
+
+## D. Drainage and SuDS
+
+**D1 — No sustainable drainage for major development.** Sustainable drainage systems (SuDS) not
+provided where expected for major development; a piped/attenuation-tank-only solution presented
+without justifying why SuDS features (swales, basins, permeable surfaces) are not used.
+- *Ask:* a SuDS-led drainage strategy for the major development.
+
+**D2 — Drainage hierarchy not followed.** The strategy discharges to sewer as a first resort
+without demonstrating that **discharge to ground (infiltration)** and then to a **watercourse**
+are not feasible; no infiltration (percolation) testing where ground discharge is dismissed.
+- *Ask:* the drainage hierarchy evidenced — infiltration tested first, watercourse next, sewer
+  only as a last resort.
+
+**D3 — SuDS deferred without deliverability or securing.** SuDS/drainage "to be secured by
+condition" with no demonstration that there is **space** in the layout for it, and no
+**maintenance/adoption/funding** mechanism for the lifetime of the development.
+- *Ask:* the drainage designed into the layout now, with a secured long-term maintenance and
+  adoption mechanism.
+
+**D4 — Foul drainage / sewer capacity not confirmed.** No confirmation from the sewerage
+undertaker that the **foul** network (and any surface-water connection) has capacity, risking
+sewer flooding or pollution.
+- *Ask:* confirmation of foul and surface-water capacity from the undertaker.
+
+---
+
+## E. Statutory-consultee engagement
+
+**E1 — Environment Agency objection or holding position not resolved.** An EA objection (often
+pending an adequate FRA) treated as if it can be conditioned away, or not resolved before
+determination.
+- *Ask:* the EA's objection resolved by evidence, and re-consultation on any revised FRA, before
+  determination.
+
+**E2 — Lead Local Flood Authority concerns not resolved.** The LLFA's surface-water/SuDS
+comments unanswered or the scheme inconsistent with them.
+- *Ask:* the LLFA's requirements met and secured before determination.

--- a/nppf-2024-12/flood-representation/references/house-style.md
+++ b/nppf-2024-12/flood-representation/references/house-style.md
@@ -1,0 +1,70 @@
+# House style — how a strong flood-risk representation reads
+
+The goal is a representation a busy case officer can act on: **concise, specific, evidenced,
+and easy to lift into the officer report.** These are the writing rules the skill applies at
+the drafting stage (function 3); they match the other representation skills, with the flood-
+specific moves flagged.
+
+## Voice and stance
+
+- **Measured and technical, never alarmist.** The force comes from the tests and the evidence —
+  the Sequential Test, the Exception Test, the FRA's own gaps — not from "it will flood." Quote
+  the FRA and the statutory consultees against the proposal.
+- **Material considerations only.** The adequacy of the flood-risk and drainage evidence and
+  compliance with national policy; not a general worry about weather.
+- **Align with the statutory consultees.** The Environment Agency and the Lead Local Flood
+  Authority carry weight; read their responses first and build on any objection or holding
+  position rather than duplicating it.
+- **Concede what is sound; don't manufacture.** If the FRA is adequate and the consultees are
+  content, say so. If the whole thing is sound, advise *not* objecting.
+
+## The flood-specific spine
+
+- **Sequential Test first.** If the development could reasonably go somewhere at lower flood
+  risk, it fails the first test — argue this before the site-specific detail, because it can be
+  decisive on its own.
+- **Both limbs of the Exception Test.** Wider benefits **and** safe-for-lifetime-without-
+  worsening-elsewhere. Applicants often prove the first and assert the second.
+- **The two hard requirements.** Whatever the benefits: **safe for its lifetime**, and **no
+  increase in flood risk elsewhere** (ideally a reduction). Test both.
+- **All sources, and the drainage hierarchy.** Surface water, groundwater and sewers matter as
+  much as rivers; SuDS and infiltration come before discharge to sewer.
+
+## Structure
+
+1. **Header block**; **RE line** (note the flood zone and application type); **opening**
+   (consultation status; material considerations; place on file; name the flood zone / sources).
+2. **Framework list** — a short **bulleted** list of the policy/guidance engaged (see
+   `national-guidance.md`) and the EA/LLFA positions.
+3. **Numbered sections** — one point per numbered sub-section, each a **bold conclusion
+   heading** then 1–3 tight paragraphs.
+4. **Summary of requests** — numbered, mostly "before determination".
+5. **Objection sentence** + sign-off.
+
+## Each point: the anatomy
+
+1. **Name the defect** in the heading as a conclusion.
+2. **Quote the document** — the FRA/Drainage Strategy's own words with the reference; or quote
+   the EA/LLFA response.
+3. **Say why it matters** — the consequence and the specific policy/test breached, cited.
+4. **State the ask** — the specific thing to do, and *when* ("before determination").
+
+## Formatting discipline (keep it scannable)
+
+- **Shorter is stronger.** One point per paragraph; prefer short sentences to long ones chained
+  with semicolons.
+- **Break dense material out — don't run it into prose.**
+  - list several things (the un-assessed flood sources, the drainage-hierarchy steps skipped,
+    the missing FRA elements) as a **bulleted list**;
+  - use **bold lettered sub-points** `(a)/(b)` for multi-limb points (e.g. the two limbs of the
+    Exception Test);
+  - present the framework list as bullets.
+- Bold each heading as a conclusion; italicise quoted text; end each point with a **Request:**
+  line.
+- British spelling and legal register. Spell out an acronym once (FRA, SuDS, EA, LLFA).
+
+## What to leave out
+
+- Anything you cannot evidence; generalised "it always floods here" without a source.
+- Non-material concerns (property values, insurance costs in the abstract).
+- Consultant-/campaign-specific framing — argue each point on this application's own facts.

--- a/nppf-2024-12/flood-representation/references/national-guidance.md
+++ b/nppf-2024-12/flood-representation/references/national-guidance.md
@@ -1,0 +1,183 @@
+# Flood-risk & drainage policy and guidance (England)
+
+The framework to cite when mapping a deficiency (skill function 2). **Cite the specific
+instrument and clause, never "best practice" in the abstract.** Each deficiency in
+[`deficiency-catalogue.md`](deficiency-catalogue.md) points here.
+
+The **current NPPF/PPG edition register, the verify-before-citing protocol, and the shared
+decision-making core** (s.38(6) and plan primacy, the para 11 presumption and its footnotes,
+emerging-plan weight, the conditions and obligations tests) live in the companion
+**national-planning-policy** skill — check it first when citing the NPPF/PPG. This file owns
+only the topic-specific layer.
+
+> **Compiled and web-verified 14 August 2026 (England).** ⏳ Several items are time-sensitive —
+> the NPPF is under revision (its flood paragraphs will renumber if republished), the national
+> SuDS standards were replaced in 2025, and climate-change allowance *figures* now live in
+> refreshed datasets rather than the guidance page. **Re-verify anything marked ⏳ before
+> relying on it.** This is not legal advice.
+>
+> **Scope:** England. The NPPF/PPG, the EA/LLFA framework and the SuDS standards are England-
+> specific; Wales/Scotland/NI differ (notably, mandatory SuDS via Schedule 3 *is* in force in
+> Wales — see Part 5).
+
+---
+
+## Part 1 — NPPF (Chapter 14, "Planning and flood risk")
+
+**December 2024 edition** (current; amended 7 Feb 2025, flood policy unchanged). ⏳ The flood
+paragraphs are **170–182**; they renumbered from the Dec 2023 edition (which used 165–175), and
+a further revision is expected — confirm the numbers when you draft.
+gov.uk/guidance/national-planning-policy-framework/14-meeting-the-challenge-of-climate-change-flooding-and-coastal-change
+
+- **Para 170 — avoid inappropriate development / safe for lifetime:** steer development away from
+  the highest-risk areas; where development must be there, it "should be made **safe for its
+  lifetime without increasing flood risk elsewhere**."
+- **Para 173 — a sequential, risk-based approach applies to *individual applications*** in areas
+  at risk now or in future **from any form of flooding** (surface water is explicitly in scope
+  in the Dec 2024 edition).
+- **Para 174 — the Sequential Test:** "steer new development to areas with the lowest risk of
+  flooding from any source. Development should not be allocated or **permitted if there are
+  reasonably available sites appropriate for the proposed development in areas with a lower risk
+  of flooding**." (The first hurdle — can be decisive on its own.)
+- **Para 175 — the carve-out:** the Sequential Test is not needed only where a site-specific FRA
+  shows no built development, access/escape, land-raising or vulnerable elements would sit in an
+  at-risk area, now or in future.
+- **Paras 177–179 — the Exception Test (both parts required):** where development can't be
+  located at lower risk, it may proceed only if **(a)** it "would provide **wider sustainability
+  benefits to the community that outweigh the flood risk**", **and (b)** it "will be **safe for
+  its lifetime… without increasing flood risk elsewhere, and, where possible, will reduce flood
+  risk overall**." Para 179: **both** elements must be satisfied.
+- **Para 181 — the site-specific requirements (and FRA trigger):** flood risk must **not be
+  increased elsewhere**, and development in a risk area is only allowed where the FRA shows
+  **(a)** the most vulnerable development is in the site's **lowest-risk areas** (within-site
+  sequential approach); **(b)** it is flood **resistant/resilient**; **(c)** it incorporates
+  **SuDS** unless clearly inappropriate; **(d)** **residual risk** can be safely managed; and
+  **(e)** **safe access/escape** routes are included as part of an agreed emergency plan.
+  **Footnote 63** sets the **FRA trigger:** required for *all* development in **Flood Zones 2
+  and 3**; and in Zone 1 for sites **≥1 ha**, land with EA-notified critical drainage problems,
+  land an SFRA identifies as at increased future risk, or land subject to other flood sources
+  where a more vulnerable use is introduced.
+- **Para 182 — SuDS:** "Applications which could affect drainage on or around the site should
+  incorporate **sustainable drainage systems** to control flow rates and reduce volumes of
+  runoff." For **major development** SuDS must **(a)** take account of LLFA advice, **(b)** meet
+  appropriate minimum operational standards, and **(c)** have maintenance arrangements for the
+  development's lifetime.
+- **NPPF Annex 3 — Flood Risk Vulnerability Classification:** the five categories — *essential
+  infrastructure, highly vulnerable, more vulnerable, less vulnerable, water-compatible*.
+
+*Do not mis-cite the NPPF:* it does **not** itemise the six flood sources, does not use the term
+"climate change allowances" (only "current and future impacts of climate change"), and does not
+set out the drainage hierarchy or the national SuDS standards — those are PPG / technical-
+standards material (Parts 2, 4).
+
+---
+
+## Part 2 — Planning Practice Guidance ("Flood risk and coastal change")
+gov.uk/guidance/flood-risk-and-coastal-change (paragraph Ref IDs `7-…`)
+
+- **Flood Zones (Table 1, `7-078`):** **Zone 1 (Low)** <0.1% annual probability; **Zone 2
+  (Medium)** 0.1–1% river / 0.1–0.5% sea; **Zone 3a (High)** ≥1% river / ≥0.5% sea; **Zone 3b
+  (Functional Floodplain)** land that must flood or store water (normally ≥3.3% annual, or
+  designed to flood), defined by the LPA's Strategic Flood Risk Assessment with the EA. The
+  Flood Map ignores defences and **does not account for climate change** — consult the SFRA too.
+- **When a site-specific FRA is required (`7-020`):** defers to the NPPF footnote (see para 181/
+  footnote 63). Assessments must be **proportionate to the degree of flood risk (`7-021`)**.
+  *(Note: the PPG page still calls it "footnote 55"; the live Dec 2024 NPPF renumbers it to 63 —
+  same content.)*
+- **Sequential Test (`7-023`–`7-029`, `7-035`):** aim is to steer to the lowest risk; **existing
+  flood defences are initially ignored** (uncertain long-term funding, `7-024`); applies to
+  **major and non-major** development; the **applicant demonstrates, the LPA decides**; a
+  defined **area of search (`7-027a`)**; a "**reasonably available**" site is one that is
+  suitable, meets the same need, and has a reasonable prospect of coming forward at the same
+  time (need not be owned by the applicant, `7-028`); the **absence of a 5-year housing land
+  supply is not relevant** to the Sequential Test.
+- **Exception Test (`7-031`, `7-035`):** the two parts (above); "**not a tool to justify
+  development when the Sequential Test has already shown there are reasonably available,
+  lower-risk sites**" — the Sequential Test comes first.
+- **Vulnerability × flood-zone compatibility matrix (Table 2, `7-079`):** *more vulnerable*
+  (most housing) needs the **Exception Test in Zone 3a** and is **not permitted in Zone 3b**;
+  *highly vulnerable* is **not permitted in Zone 3a/3b**; use the **highest** vulnerability where
+  a scheme mixes uses. Cite this where a vulnerable use is proposed in the wrong zone.
+
+---
+
+## Part 3 — Environment Agency
+- **Statutory consultee** (Town and Country Planning (DMPO) (England) Order 2015, SI 2015/595,
+  Sch 4): the LPA must consult the EA before permitting development within 20 m of a main river,
+  non-minor development in Flood Zones 2/3, vulnerable uses in flood zones, and Zone 1 sites in
+  EA-notified critical drainage areas. Read the EA's response first and build on any objection.
+- **Flood map for planning** (flood-map-for-planning.service.gov.uk) — the **authoritative**
+  flood zones for planning (ignores defences; no climate change). Do **not** cite the public
+  "Check your long term flood risk" service for planning zones.
+- **Flood risk assessment: standing advice** (LPA- and applicant-facing; updated 2026) — the
+  benchmark for when an FRA is required and its content; the yardstick for a deficient/missing
+  FRA. gov.uk/guidance/flood-risk-assessment-standing-advice
+- **Climate-change allowances** — peak river-flow / peak-rainfall / sea-level allowances by
+  catchment and epoch. ⏳ The guidance *page* is unchanged since 2022, but the **allowance
+  datasets were refreshed (Sep 2025)** — take specific figures from the live datasets, not the
+  page. gov.uk/guidance/flood-risk-assessments-climate-change-allowances
+
+---
+
+## Part 4 — Lead Local Flood Authority (LLFA) and SuDS
+- **LLFA — statutory consultee** on surface-water drainage for **major development** since **15
+  April 2015** (WMS HCWS161; SI 2015/595). "Major" = 10+ dwellings, or residential on ≥0.5 ha
+  where the number is unknown, or ≥1,000 m² floorspace, or a site ≥1 ha.
+- **National standards for sustainable drainage systems (SuDS)** — ⚠ **Defra, June 2025 (updated
+  July 2025), which REPLACED the March 2015 non-statutory technical standards** at the same URL.
+  Still non-statutory (delivered through planning policy); cover the runoff-destination
+  hierarchy, interception, peak-flow control, water quality, amenity and biodiversity, and
+  maintenance. gov.uk/government/publications/sustainable-drainage-systems-non-statutory-technical-standards
+- **CIRIA "The SuDS Manual" (C753, 2015)** — the principal UK technical benchmark (no successor
+  as of 2026). Key concepts to test a drainage strategy against:
+  - the **SuDS management train** — prevention → source control → site control → regional
+    control (manage runoff in stages, most local first);
+  - the **drainage hierarchy** — (1) to ground / infiltration / soakaway; (2) to a watercourse;
+    (3) to a surface-water sewer; (4) to a combined sewer (last resort);
+  - **greenfield runoff rates** — restrict post-development rate *and* volume toward the
+    pre-development (greenfield) rate so downstream risk is not increased.
+
+---
+
+## Part 5 — Statutory duties, foul drainage, watercourses, reservoirs
+- ⏳ **Schedule 3 to the Flood and Water Management Act 2010 (mandatory SuDS / SuDS Approving
+  Body) is NOT commenced in England** as of Aug 2026 — the Government's stated preference is the
+  planning-policy route. **Rely on the NPPF/PPG SuDS policy and the 2025 National Standards, not
+  on any statutory SAB duty in England.** (It *is* in force in Wales.)
+- **Flood and Water Management Act 2010:** s.6 defines the LLFA; s.9 (local flood-risk
+  management strategy); s.19 (duty to investigate flooding); s.21 (register of flood-risk
+  structures). The EA leads the national FCERM strategy (s.7).
+- **Ordinary watercourse consent — Land Drainage Act 1991 s.23** (not "FWMA s.23"): no
+  culvert/weir/obstruction to an ordinary watercourse without written LLFA/IDB consent — relevant
+  where culverting is proposed.
+- **Foul drainage:** PPG "Water supply, wastewater and water quality" — the **first presumption
+  is connection to the public foul sewer** (package plants/septic tanks only where a connection
+  is impractical); support early engagement with the sewerage undertaker and phasing/refusal
+  where capacity works don't fit the timescale. The right to connect (Water Industry Act 1991
+  s.106) is **qualified** (the undertaker may refuse where prejudicial) and does **not** guarantee
+  downstream capacity — use this to rebut "there's an automatic right to connect, so capacity is
+  irrelevant." **Building Regulations Approved Document H** ranks surface-water discharge
+  (soakaway → watercourse → sewer) in **H3** (H1 is foul).
+- **Reservoir flood risk** (Reservoirs Act 1975; EA reservoir flood maps) — treat as a
+  **residual risk** relevant to emergency planning and safe access/egress, not an absolute bar.
+
+---
+
+## Part 6 — Superseded / currency (citing the old one is an objection or an error)
+
+| Topic | Current | Superseded / status |
+|---|---|---|
+| National SuDS standards | **Defra National Standards for SuDS (2025)** | ⚠ 2015 non-statutory technical standards — replaced |
+| Mandatory SuDS (England) | **not in force — planning-policy route** | Schedule 3 FWMA 2010 uncommenced in England (in force in Wales) |
+| Climate-change allowance figures | **live EA datasets (refreshed 2025)** | the 2022 guidance-page figures |
+| NPPF flood paragraphs | **Dec 2024, paras 170–182** | Dec 2023 (165–175) |
+| SuDS technical manual | **CIRIA C753 (2015)** | C697 (2007) |
+
+## Part 7 — ⏳ Verify-before-relying (time-sensitive as of Aug 2026)
+- **NPPF edition & flood paragraph numbers** — a revision is expected; confirm the live numbers.
+- **Climate-change allowance figures** — take from the live EA datasets, not the 2022 page.
+- **Schedule 3 status** — confirm it is still uncommenced in England before relying on the
+  policy-route framing.
+- **2025 National SuDS Standards detail** — confirm the specific standard/clause before quoting.
+- **The PPG vs NPPF footnote-number mismatch** (55 vs 63) for the FRA trigger — cite the content,
+  note the source.

--- a/nppf-2024-12/flood-representation/references/objection-template.md
+++ b/nppf-2024-12/flood-representation/references/objection-template.md
@@ -1,0 +1,150 @@
+# Objection template + annotated worked example
+
+A **skeleton** to fill, and a **worked example** showing the house style in practice. Match the
+example's density, tone and layout — every point must come from the documents in front of you.
+
+---
+
+## Skeleton
+
+```
+[Your name]
+[Your address]
+[Email]
+
+[Date]
+
+[Planning department / Council name / address]
+[For the attention of [Case Officer], if known]
+
+RE: Application [ref] — [site]
+[One-line description — note the flood zone(s) and whether an FRA is provided]
+
+Dear [Sir or Madam / Mr/Ms Name],
+
+REPRESENTATION ON FLOOD RISK AND DRAINAGE GROUNDS — OBJECTION UNLESS MATTERS RESOLVED
+
+[Opening: consultation status; matters are material considerations while undecided; ask
+that this be placed on the file. Name the flood zone(s) and the sources of flood risk.]
+
+[State which documents you address — the Flood Risk Assessment (author, date), the Drainage
+Strategy / SuDS report — and align with the Environment Agency and Lead Local Flood Authority
+where they have objected or asked for more.]
+
+The relevant framework includes: [short bulleted list from national-guidance.md — the NPPF
+flood policies and tests, the PPG flood zones, the EA/LLFA roles, the SuDS standards].
+
+## 1. [Point stated as a conclusion]
+[Quote the document / consultee. Why it matters + the test/policy breached. The ask.]
+
+## 2. [Next point]
+…
+
+## Summary of requests
+[Numbered, concrete, mostly "before determination".]
+
+Unless and until these matters are resolved, I object to the grant of planning permission.
+
+Yours [sincerely/faithfully],
+[Name]
+```
+
+---
+
+## Worked example (condensed — annotations in ⟨…⟩)
+
+> ⟨Header, RE line and opening omitted for brevity — see the skeleton. The opening names the
+> flood zone(s) and sources, and aligns with the Environment Agency's holding objection.⟩
+
+**The relevant framework includes:** ⟨a bulleted list, not a semicolon-run⟩
+
+- the NPPF's flood-risk policies — the Sequential Test, the Exception Test, the requirement to
+  be safe for the development's lifetime and not increase flood risk elsewhere, and sustainable
+  drainage;
+- the Planning Practice Guidance on flood risk (flood zones; when a site-specific FRA is
+  required);
+- the Environment Agency's role and flood-risk standing advice, and the Lead Local Flood
+  Authority's role on surface-water drainage;
+- the non-statutory technical standards for SuDS and the CIRIA SuDS Manual;
+- **[the Local Plan's flood-risk and drainage policies — insert the specific references]**.
+
+### 1. The Sequential Test has not been passed
+⟨Lead with the first hurdle — it can be decisive on its own.⟩
+
+The application provides no Sequential Test. The site lies in **Flood Zone [2/3]**, so the
+development should be steered to areas at lower risk unless there are no reasonably available
+sites at lower risk within the area of search. That exercise has not been carried out, so the
+Council cannot conclude the test is passed. **Request:** a Sequential Test with a defined area
+of search and evidence that no reasonably available lower-risk sites exist, before determination.
+
+### 2. The Exception Test is only half-made
+⟨Two limbs — use lettered sub-points.⟩
+
+Where the Exception Test is required it has two limbs, and both must be met:
+
+**(a)** *Wider sustainability benefits.* The FRA asserts the scheme's benefits but does not
+weigh them against the flood risk.
+
+**(b)** *Safe for its lifetime, without increasing flood risk elsewhere.* This is not
+demonstrated — [there is no compensatory storage for the floodplain lost / finished floor
+levels and safe access are not shown / climate-change allowances are not applied].
+
+**Request:** both limbs of the Exception Test demonstrated on the evidence, before determination.
+
+### 3. The FRA does not assess all sources of flood risk
+⟨Bullet the omissions.⟩
+
+The FRA addresses only fluvial risk. It does not assess:
+
+- **surface-water** flood risk, despite the site's mapped surface-water hazard;
+- **groundwater** risk;
+- **sewer** flooding and the capacity of the receiving network.
+
+**Request:** an assessment of all relevant sources of flood risk.
+
+### 4. The drainage strategy does not follow the hierarchy or restrict runoff
+⟨Technical but concrete.⟩
+
+The Drainage Strategy discharges surface water to the public sewer as a first resort, without
+demonstrating that discharge to ground (infiltration) or to a watercourse is not feasible — no
+infiltration testing is provided. Runoff is not restricted to the greenfield rate, and the
+attenuation is not sized for the design storm including the climate-change allowance.
+**Request:** a SuDS-led strategy following the drainage hierarchy (infiltration first), with
+runoff restricted to greenfield rates and attenuation sized for the climate-change design storm,
+and a secured maintenance mechanism.
+
+### Summary of requests
+
+Before determination:
+1. A Sequential Test with a defined area of search and evidence on reasonably available lower-
+   risk sites;
+2. Both limbs of the Exception Test demonstrated (benefits, and safe-for-lifetime without
+   increasing risk elsewhere);
+3. A site-specific FRA assessing all sources of flood risk, using current EA data and the
+   current climate-change allowances, with safe access/egress and a residual-risk assessment;
+4. A SuDS-led drainage strategy following the hierarchy, restricting runoff to greenfield rates,
+   with a secured long-term maintenance and adoption mechanism, and confirmation of foul/surface-
+   water capacity from the undertaker;
+5. The Environment Agency's and Lead Local Flood Authority's requirements resolved by evidence,
+   with re-consultation on any revised FRA.
+
+Unless and until these matters are resolved, I object to the grant of planning permission.
+
+Yours faithfully,
+[Name]
+
+---
+
+### Notes on adapting the example
+
+- **Lead with the Sequential Test** where the site is in Zone 2/3 — it can defeat the
+  application on its own, before the site-specific detail.
+- **Read the EA and LLFA responses first** and build on any objection or holding position rather
+  than duplicating it; a consultee objection pending an adequate FRA is a strong anchor.
+- **Consultant- or campaign-specific framing is excluded by default** — argue each point on this
+  application's own facts.
+- **Before submitting:** a person must read and check the draft — every quote and figure against
+  the actual documents — and be aware the representation is normally **published on the council's
+  portal in the submitter's name** and kept on the record, so include only personal details the
+  user is content to make public. This is a draft aid provided with no warranty; it is not legal
+  advice.

--- a/nppf-2024-12/heritage-representation/CHANGELOG.md
+++ b/nppf-2024-12/heritage-representation/CHANGELOG.md
@@ -1,0 +1,65 @@
+# Changelog — heritage-representation
+
+Design decisions per revision, newest first. See `../CLAUDE.md` for the format and the
+house rules. The **_Why_** lines record the rationale so a future editor understands the
+intent.
+
+## Unreleased
+
+### Changed
+- **`national-guidance.md` now defers to the companion `national-planning-policy` skill**
+  for the NPPF/PPG edition register, the verify-before-citing protocol, and the shared
+  decision-making core; this file keeps only the topic layer. _Why:_ reviewer feedback —
+  per-skill NPPF snapshots drift out of sync as editions change; one register, checked
+  first, keeps the citations consistent (two-layers house rule).
+
+### Added
+- **A/B/C outcome discipline:** every point must be classified as **(A)** demonstrated
+  unacceptable impact (refusal reason), **(B)** insufficient evidence to reach the necessary
+  conclusion (do-not-determine-yet ask), or **(C)** controllable by condition/obligation
+  (mitigation ask) — plus a pre-send checklist item that no point asks for refusal where a
+  condition would lawfully and satisfactorily do. _Why:_ reviewer feedback — an inadequate
+  assessment does not necessarily mean the development is unacceptable, only that the LPA
+  cannot presently be satisfied that it is; conflating the two (or over-asking for refusal
+  on conditionable points) is the classic credibility mistake in lay objections.
+
+### Changed
+- **"What you need first" now says uploaded/pasted/already-downloaded documents work
+  directly, and `planning-document-search` is only needed when the user doesn't have
+  them.** _Why:_ makes explicit that direct document supply is a first-class input, and
+  completes the retrieval skill's fail-fast handover (stop → download manually → feed the
+  files back in here).
+
+## 0.1.0 — 2026-08-14 — Initial release
+
+First version, built to the same pattern as the ecological- and transport-representation
+skills: (1) evaluate the heritage evidence, (2) map deficiencies to the statutory duties and
+national policy/guidance, and (3) draft a concise representation — or advise that none is
+warranted. Structure: `SKILL.md` + `references/` (`deficiency-catalogue.md`,
+`national-guidance.md`, `house-style.md`, `objection-template.md`). Key design decisions:
+
+### Added
+- **The two heritage framing points as the spine:** *the level of harm drives the test*
+  (substantial vs less-than-substantial), and *"less than substantial" is not "neutral"* (the
+  statutory duties require considerable importance and weight; the NPPF requires great weight).
+  _Why:_ these are the two things applicants and officer reports most often get wrong, and
+  where a well-pitched representation has the most leverage.
+- **A web-verified guidance catalogue** — the LB & CA Act 1990 duties (ss.66/72 verbatim), the
+  NPPF Chapter 16 harm tests **with the Dec 2024 +13 renumbering flagged**, the PPG, Historic
+  England GPA/HEAN guidance (with the setting method), and the case law (*Barnwell Manor*,
+  *Mordue*, *Palmer*, *Bramshill*, *South Lakeland*). _Why:_ heritage turns on the precise
+  statutory duty and the correct harm test; citing the wrong paragraph or missing the "great
+  weight" duty loses the point. Time-sensitive items (NPPF under revision; two case citations
+  to confirm) are flagged ⏳.
+- **Deficiency catalogue** covering significance (assessed, and proportionately, incl.
+  setting/group value), harm characterisation, the statutory-weight and public-benefit balance,
+  conservation-area preserve-or-enhance, archaeology, and consultee engagement.
+- **House style + annotated template** with the bullet / lettered-sub-point discipline built in
+  from the start (learned from the transport skill), so drafts are scannable.
+
+### Changed / Security
+- **Scoped to heritage, England-focused, explicitly not legal advice; no warranty; human
+  review required; public-document-in-your-name flag.** _Why:_ the same user-protection
+  disclaimers as the other skills.
+- **Built generic and public-safe** — no case/campaign/consultant/place fingerprints; local
+  policy references left as `[insert …]`. _Why:_ repo house rules.

--- a/nppf-2024-12/heritage-representation/LICENSE
+++ b/nppf-2024-12/heritage-representation/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ian Howard
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/nppf-2024-12/heritage-representation/README.md
+++ b/nppf-2024-12/heritage-representation/README.md
@@ -1,0 +1,53 @@
+# Heritage Representation
+
+A skill for producing a rigorous, credible representation on the **heritage / historic-
+environment** merits of a UK planning application — or advising that no sustainable objection
+exists. Covers listed buildings and their settings, conservation areas, scheduled monuments,
+registered parks/gardens, non-designated heritage assets, and archaeology. England-focused.
+
+> **Not legal advice. No warranty.** Output is a draft aid provided "as is". **A human must
+> review and check it before submitting.** A UK planning representation is normally **published
+> on the council's portal in the submitter's name** — include only personal details you're
+> content to make public.
+
+It does three things:
+
+1. **Evaluate** the applicant's heritage evidence (Heritage Statement / Statement of
+   Significance, setting and archaeological assessments) against the statutory duties and
+   current policy and guidance, and identify the material deficiencies.
+2. **Map** each deficiency to the specific legislation, national policy and guidance it engages.
+3. **Draft** the representation in clear, precise, concise language.
+
+## Contents
+
+| File | What it is |
+|---|---|
+| `SKILL.md` | The skill: workflow, integrity principle, and the two heritage framing points. **Start here.** |
+| `references/deficiency-catalogue.md` | Function 1 — the evaluation checklist. |
+| `references/national-guidance.md` | Function 2 — the law/policy/guidance catalogue with citations. |
+| `references/house-style.md` | Function 3 — how a strong representation reads. |
+| `references/objection-template.md` | Skeleton + annotated worked example. |
+| `CHANGELOG.md` | Design decisions and their rationale, per revision. |
+
+## Two things that define this skill
+
+- **The level of harm drives the test.** *Substantial harm* engages a very demanding test;
+  *less than substantial harm* is weighed against public benefits. Applicants routinely
+  under-state harm — getting the level right is decisive (and don't over-claim it either).
+- **"Less than substantial" is not "neutral".** The Act requires *considerable importance and
+  weight* to preserving the asset and its setting; the NPPF requires *great weight* to
+  conservation of a designated asset.
+
+## Pairs with
+
+The **planning-document-search** skill retrieves the documents; **application-triage** decides
+whether heritage is a live ground.
+
+## Freshness
+
+The guidance catalogue was web-verified **August 2026**. ⏳ The NPPF is under revision and its
+Chapter 16 paragraph numbers will change if republished — re-verify at the point of drafting.
+
+## License
+
+MIT — see [`LICENSE`](LICENSE). Provided as-is, with no warranty; not legal advice.

--- a/nppf-2024-12/heritage-representation/SKILL.md
+++ b/nppf-2024-12/heritage-representation/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: heritage-representation-nppf-2024-12
+description: >-
+  ARCHIVED - December 2024 NPPF edition (superseded 17 August 2026). Use only when the user explicitly asks to work under the pre-August-2026 framework and has confirmed they want the archived skills; outputs must state they cite a superseded framework. 
+  Evaluate the heritage/historic-environment evidence submitted with a UK
+  planning application (Heritage Statement / Statement of Significance, setting
+  and archaeological assessments), identify the statutory duties and national
+  policy it engages, and draft a concise, well-founded objection — or advise
+  that no sustainable objection exists. Covers listed buildings, conservation
+  areas, scheduled monuments, non-designated assets and archaeology.
+  England-focused. Not legal advice; no warranty; output requires human review.
+license: MIT
+---
+
+# Heritage representation on a planning application
+
+Help a member of the public produce a rigorous, credible representation on the **heritage /
+historic-environment** merits of a planning application. The skill does three things:
+
+1. **Evaluate** the applicant's heritage evidence against the statutory duties and current
+   policy and guidance, and identify the material deficiencies.
+2. **Map** each deficiency to the specific legislation, national policy and guidance it
+   engages.
+3. **Draft** the representation in clear, precise, concise language — or advise that the
+   evidence is sound and no sustainable objection exists.
+
+## When to use
+
+The user has a planning application (or a listed-building-consent application) and wants to
+object, or find out whether they can, on heritage grounds — harm to a **listed building** or
+its **setting**, a **conservation area**, a **scheduled monument**, a **registered park/garden
+or battlefield**, a **non-designated heritage asset**, or **archaeology**. Trigger phrases:
+"object on heritage grounds", "is this Heritage Statement adequate", "this harms the
+conservation area / the setting of the listed building", "they haven't assessed the
+archaeology."
+
+Not this skill: ecology, transport, flood risk, general amenity — separate matters.
+
+## What you need first
+
+- The **application reference and council**, or the **documents themselves** — uploaded,
+  pasted, or already-downloaded files work directly; the companion **planning-document-search**
+  skill is only needed when you don't have them (it retrieves them from the reference + council).
+- The **heritage documents** — the Heritage Statement / Statement of Significance, any setting
+  assessment, archaeological desk-based assessment or evaluation, and the heritage section of
+  the Design and Access Statement. Also the **conservation officer's and Historic England's
+  consultation responses** (often the strongest anchor).
+- The **designations and their significance** — what is listed (and its grade), the
+  conservation area and its **appraisal**, scheduled monuments, registered parks/gardens
+  (check `planning.data.gov.uk` and the Historic England list).
+- The **local plan's** historic-environment policies.
+
+## The integrity principle and two framing points (read before drafting)
+
+**Only object where the evidence is genuinely inadequate or the harm genuinely unacceptable.**
+Heritage harm is a matter of planning judgement; if significance is properly assessed and the
+proposal genuinely preserves or enhances, there is **no sustainable objection** — say so.
+Treat "don't object" as a valid output.
+
+Two points specific to heritage:
+- **The level of harm drives the test.** *Substantial harm / total loss* engages a very
+  demanding test; *less than substantial harm* is weighed against public benefits. Applicants
+  routinely under-state harm — getting the level right is decisive. (But don't over-claim
+  "substantial harm" either; credibility depends on the honest level.)
+- **"Less than substantial" is not "neutral".** The Act requires **considerable importance and
+  weight** to preserving the asset, its setting and conservation-area character; the NPPF
+  requires **great weight** to conservation of a designated asset.
+
+**Classify every point's ask — (A) refuse, (B) don't determine yet, or (C) condition it.**
+An evidential deficiency is not itself a reason for refusal. For each confirmed point, be
+explicit about which outcome it supports: **(A)** the evidence *demonstrates* unacceptable
+harm under the applicable test → a refusal reason; **(B)** the evidence is *insufficient* for
+the Council to reach the necessary conclusion (significance not assessed; archaeology not
+established before determination) → the application should **not be determined** until the
+information is provided; **(C)** the issue can be adequately controlled → ask for the
+*specific* condition or obligation (materials, detailed design, a written scheme of
+archaeological investigation). Most deficiency findings are (B), not (A) — claiming (A) on
+(B) evidence is the classic credibility mistake. And test every point against (C): if a
+condition would lawfully and satisfactorily resolve it, ask for that rather than refusal —
+over-asking weakens the whole representation.
+
+## Workflow
+
+### Step 1 — Intake and read
+Identify the asset(s) affected and their designation/grade; whether the effect is on the asset,
+its setting, or a conservation area's character; and the application type (permission vs
+listed-building consent). Read the conservation officer's / Historic England's response first.
+Get the Statement of Significance and any setting/archaeology assessments.
+
+### Step 2 — Evaluate against the deficiency catalogue (function 1)
+Work through [`references/deficiency-catalogue.md`](references/deficiency-catalogue.md). For
+each candidate deficiency, confirm it is **present** and **material**, and capture the specific
+evidence — the document, author, date, paragraph. Quote the Heritage Statement's own words.
+Grade findings and lead with the decision-critical. Apply the integrity principle.
+
+Key tests: Is **significance** assessed, and proportionately (fabric *and* setting, group
+value, historic interest)? Is the **level of harm** correctly characterised? Are the
+**statutory duties and great weight** given effect? Is the **public-benefit balance** genuinely
+carried out? For conservation areas, does the scheme **preserve or enhance**? For archaeology,
+is significance established **before** determination?
+
+### Step 3 — Map to law, policy and guidance (function 2)
+Attach the precise instrument from
+[`references/national-guidance.md`](references/national-guidance.md) — the LB & CA Act 1990
+duties (ss.66/72), the NPPF historic-environment paragraphs and the harm tests, the PPG,
+Historic England guidance, the relevant case law on the statutory duties — plus the **local
+plan** heritage policies and the **conservation area appraisal**. Cite specifically.
+
+### Step 4 — Draft (function 3)
+Draft to [`references/house-style.md`](references/house-style.md) and
+[`references/objection-template.md`](references/objection-template.md): header → RE line
+(name the asset) → opening → bulleted framework list → numbered conclusion-headed points
+(quoted evidence; establish significance / characterise harm / invoke the duty; the ask) →
+numbered **Summary of requests** → objection sentence → sign-off. Keep it concise; use bullets
+for lists and `(a)/(b)` for multi-limb points.
+
+### Step 5 — Check before sending
+- Every point is evidenced from the documents or cited guidance; nothing asserted.
+- The harm level is characterised honestly (not over- or under-claimed).
+- The statutory duties and great weight are correctly invoked.
+- Consultant-/campaign-specific framing excluded unless the user asked and it is defensible.
+- Requests are concrete and correctly timed.
+- Every point is classified **(A) demonstrated harm / (B) insufficient evidence / (C)
+  conditionable** — and no point asks for refusal where a condition would lawfully and
+  satisfactorily do.
+- **Hand back to a human, with the two warnings:** the draft must be read and checked, and
+  submitting it puts a **public document in the user's name** on the council's portal.
+
+## Reference files
+
+- [`references/deficiency-catalogue.md`](references/deficiency-catalogue.md) — the evaluation
+  checklist.
+- [`references/national-guidance.md`](references/national-guidance.md) — the law/policy/guidance
+  catalogue with citations.
+- [`references/house-style.md`](references/house-style.md) — how a strong representation reads.
+- [`references/objection-template.md`](references/objection-template.md) — skeleton + annotated
+  worked example.
+
+## Scope and limitations
+
+- **Not legal advice, and no warranty.** Not a substitute for a solicitor or a heritage
+  professional; guarantees no outcome; provided "as is".
+- **Human review is necessary before submitting.** A person must check every quote and
+  citation against the actual documents.
+- **A UK planning representation is a public document in the submitter's name** — normally
+  published on the council's portal; include only personal details the user is content to make
+  public.
+- **England-focused.** The 1990 Act applies in England and Wales, but national policy (NPPF/
+  PPG) is England; devolved policy differs — flag when outside England.
+- **Evidence-bound; heritage harm is a matter of judgement.** Identify significance and harm on
+  the evidence; don't assert a level of harm you cannot support.
+- **The honest answer is sometimes "don't object."**

--- a/nppf-2024-12/heritage-representation/references/deficiency-catalogue.md
+++ b/nppf-2024-12/heritage-representation/references/deficiency-catalogue.md
@@ -1,0 +1,151 @@
+# Heritage submission — deficiency catalogue
+
+The recurring, defensible grounds on which a planning application's **heritage evidence** (a
+Heritage Statement / Statement of Significance, a setting assessment, an archaeological desk-
+based assessment, a Design and Access Statement's heritage section, and any listed-building or
+conservation-area justification) can be challenged. Each entry is a *pattern to look for*, not
+a template sentence: find the specific instance in the documents, quote it, and attach the
+request. Cross-references point to [`national-guidance.md`](national-guidance.md).
+
+> **Integrity rule (read first).** Only raise a deficiency that is actually present and
+> material. Heritage harm is a matter of planning judgement; your job is to make sure
+> **significance is properly identified, the level of harm is correctly characterised, the
+> statutory duties are given effect, and the right test and balance are applied** — not to
+> assert harm where none exists. If the significance assessment is sound and the proposal
+> genuinely preserves or enhances, say so.
+>
+> **The two framing points that win heritage objections:**
+> - **The level of harm drives the test.** *Substantial harm / total loss* engages a very
+>   demanding test; *less than substantial harm* is weighed against public benefits. Getting
+>   the applicant's harm characterisation right (they routinely under-state it) is decisive.
+> - **"Less than substantial" is not "negligible".** Even less-than-substantial harm must be
+>   given **great weight**, and the statutory duties require **considerable importance and
+>   weight** to preserving a listed building, its setting, and conservation-area character.
+>   The common LPA/applicant error is to treat less-than-substantial harm as if it were
+>   neutral and simply outweighed — press for the correct, weighted balance.
+
+---
+
+## A. Significance — assessed at all, and proportionately
+
+**A1 — No significance assessment, or not proportionate to the asset's importance.**
+- *Tell:* no Statement of Significance, or a thin/generic one, for a proposal affecting a
+  listed building, conservation area, scheduled monument or their settings.
+- *Why it matters:* national policy requires the applicant to describe the significance of any
+  heritage asset affected (including from development within its setting), proportionate to
+  the asset's importance; the LPA cannot weigh harm it has not had described.
+- *Ask:* a proportionate Statement of Significance before determination.
+
+**A2 — Significance drawn too narrowly.** Significance limited to the building's fabric, when
+it also derives from **setting, group value, historic/associative interest, communal value,
+plan-form, or archaeological interest**. Under-drawing significance under-states the harm.
+- *Ask:* a significance assessment covering all the heritage interests, not just fabric.
+
+**A3 — Non-designated heritage assets not identified.** Locally-listed buildings, buildings of
+local interest, or assets meeting the local-list criteria treated as if they had no heritage
+value; the "balanced judgement" for non-designated assets never engaged.
+- *Ask:* identify the non-designated heritage assets affected and apply the balanced judgement.
+
+---
+
+## B. Setting
+
+**B1 — Setting not assessed, or not to the recognised method.** The contribution the setting
+makes to the asset's significance is dismissed in a line, without the staged assessment of
+setting that good practice requires (identify the assets; assess the contribution of setting;
+assess the effect of the proposal; consider mitigation).
+- *Why it matters:* development *within the setting* of a designated asset engages the
+  statutory duty and great weight even if the asset itself is untouched.
+- *Ask:* a setting assessment to the recognised method, covering the key views and the
+  experience of the asset.
+
+**B2 — Selective or unrepresentative visualisations.** Views chosen to minimise the apparent
+effect; key or worst-case viewpoints omitted; verified views not provided where the effect is
+significant.
+- *Ask:* representative/verified views from the viewpoints that matter, including the adverse
+  ones.
+
+---
+
+## C. Harm — correctly identified and characterised
+
+**C1 — Harm understated or mislabelled.** "No harm" asserted where there is harm; or
+*substantial* harm mischaracterised as *less than substantial* to escape the more demanding
+test. The threshold between the two is where the significance is *vitiated or very much
+reduced* — press it where the applicant has drawn it too low.
+- *Ask:* the level of harm correctly characterised, and the correct test applied.
+
+**C2 — The statutory duty not given effect.** The assessment treats harm to a listed building/
+its setting, or to a conservation area, as an ordinary material consideration, without giving
+it the **considerable importance and weight** the Act requires, and the **great weight** the
+NPPF requires to conservation of a designated asset.
+- *Ask:* the officer report to apply the statutory duties and give harm the requisite weight.
+
+**C3 — "Less than substantial" treated as neutral.** Less-than-substantial harm acknowledged
+but then not actually weighed — or weighed as if trivial — against public benefits.
+- *Ask:* the proper public-benefit balance, with great weight given to the harm.
+
+**C4 — Cumulative / incremental harm ignored.** Erosion of a conservation area's character by
+increments ("death by a thousand cuts") dismissed because each change is individually small.
+- *Ask:* assessment of the cumulative effect on the area's character and appearance.
+
+---
+
+## D. Public benefits and the balance
+
+**D1 — Public benefits overstated or not genuinely public.** Private benefits (developer
+profit, a larger dwelling) presented as public benefits; benefits asserted without evidence or
+weight; the balance treated as a formality.
+- *Why it matters:* only genuine, and generally public, benefits count in the balance against
+  heritage harm, and they must be weighed against harm to which great weight attaches.
+- *Ask:* the public benefits evidenced and weighed against the (great-weight) harm.
+
+**D2 — Optimum viable use / enabling development not tested.** A harm-for-benefit or heritage-
+at-risk case advanced without testing it against the optimum viable use or genuine
+alternatives, or without securing the heritage benefit that justifies the harm.
+- *Ask:* the case tested against alternatives/optimum viable use, and the securing mechanism.
+
+---
+
+## E. Conservation areas
+
+**E1 — Fails to preserve or enhance character or appearance.** The proposal's scale, height,
+bulk, materials, plot pattern, roofscape or rhythm does not preserve or enhance the character
+or appearance of the conservation area; the **conservation area appraisal** is not engaged.
+- *Ask:* a design response demonstrably preserving or enhancing the area's character, assessed
+  against the appraisal.
+
+**E2 — Loss of a positive contributor.** Demolition or alteration of an unlisted building that
+*positively contributes* to the conservation area, treated as neutral.
+- *Ask:* assessment of the contribution the building makes, and of the harm from its loss.
+
+---
+
+## F. Archaeology
+
+**F1 — No assessment where there is archaeological potential.** No desk-based assessment or
+field evaluation on a site with known or likely buried remains; the significance of the
+archaeology not established *before* determination.
+- *Why it matters:* the LPA needs sufficient information to judge significance and the
+  appropriate response; assessment cannot simply be deferred to a condition where it should
+  inform the decision.
+- *Ask:* a desk-based assessment and, where potential is identified, field evaluation before
+  determination.
+
+**F2 — "Preserve by record" where in-situ preservation is warranted.** A recording condition
+proposed for remains that may merit preservation in situ, without justifying the choice.
+- *Ask:* justification for the mitigation strategy against the significance of the remains.
+
+---
+
+## G. Evidence quality and consultee engagement
+
+**G1 — Consultee concerns not addressed.** The conservation officer's or Historic England's
+concerns are unanswered, or the assessment is inconsistent with them.
+- *Ask:* the concerns of the heritage consultees resolved before determination.
+
+**G2 — A generic, template Heritage Statement.** Boilerplate not specific to this asset — wrong
+descriptions, mismatched photographs, significance lifted from another site — indicating the
+assessment was not actually carried out for this application.
+- *Ask:* an asset-specific assessment; a generic statement is not an adequate basis for the
+  weighing the Act and the NPPF require.

--- a/nppf-2024-12/heritage-representation/references/house-style.md
+++ b/nppf-2024-12/heritage-representation/references/house-style.md
@@ -1,0 +1,87 @@
+# House style — how a strong heritage representation reads
+
+The goal is a representation a busy case officer can act on: **concise, specific, evidenced,
+and easy to lift into the officer report.** These are the writing rules the skill applies at
+the drafting stage (function 3); they match the other representation skills, with the
+heritage-specific moves flagged.
+
+## Voice and stance
+
+- **Measured and expert, never emotive.** The force comes from specificity — quoting the
+  applicant's own Heritage Statement against itself and identifying the significance and harm
+  precisely — not from adjectives.
+- **Material considerations only.** The adequacy of the significance assessment, the correct
+  characterisation of harm, the statutory duties, and the public-benefit balance. Not "old
+  buildings are nicer."
+- **Concede what is sound; don't manufacture.** Heritage harm is a matter of judgement — if
+  the assessment is sound and the proposal genuinely preserves or enhances, say so. If the
+  whole thing is sound, advise *not* objecting.
+- **No personal criticism.** Critique the document and the method, not individuals.
+
+## The heritage-specific spine
+
+Three moves win heritage representations, and each point should serve one of them:
+
+- **Establish significance.** Identify what makes the asset significant — fabric, setting,
+  group value, historic interest, communal value — because harm can only be measured against
+  significance the applicant has under-drawn.
+- **Characterise the harm correctly.** The level of harm drives the test: *substantial harm /
+  total loss* engages a very demanding test; *less than substantial harm* is weighed against
+  public benefits. Applicants routinely under-state harm — press the correct level.
+- **Insist on the statutory weight.** The Act requires **considerable importance and weight**
+  to preserving a listed building, its setting and conservation-area character; the NPPF
+  requires **great weight** to the conservation of a designated asset. "Less than substantial"
+  is **not** "neutral."
+
+## Structure
+
+1. **Header block** — your name/address/email, the Council's address, date, case officer if
+   known.
+2. **RE line** — application reference + site + a one-line description (note if it is listed-
+   building consent, a conservation-area application, or affects a designated asset/setting).
+3. **Opening** — consultation status; matters are material considerations while undecided; ask
+   that the representation be placed on the file. Name the asset(s) affected and their grade/
+   designation.
+4. **Framework list** — a short **bulleted** list of the legislation/policy/guidance engaged
+   (see `national-guidance.md`) — the statutory duties, the NPPF paragraphs, Historic England
+   guidance, the conservation area appraisal.
+5. **Numbered sections** — one point per numbered sub-section, each with a **bold conclusion
+   heading**, then 1–3 tight paragraphs.
+6. **Summary of requests** — a numbered list, mostly "before determination".
+7. **Objection sentence** + sign-off.
+
+## Each point: the anatomy
+
+1. **Name the defect** in the heading as a conclusion.
+2. **Quote the document** — the Heritage Statement's own words, with the reference. Where its
+   significance assessment omits an interest, or its harm characterisation is too low, say so
+   in its own terms.
+3. **Say why it matters** — the consequence for the decision and the specific duty/policy
+   breached, cited precisely.
+4. **State the ask** — the specific thing to do, and *when* ("before determination").
+
+## Formatting discipline (keep it scannable)
+
+- **Shorter is stronger.** One point per paragraph; cut throat-clearing; prefer short sentences
+  to long ones chained with semicolons.
+- **Break dense material out — don't run it into prose.**
+  - where a point lists several things (the interests that make up significance, the omitted
+    viewpoints, the reasons harm is under-stated), use a **bulleted list**;
+  - where a point has two or more distinct limbs, use **bold lettered sub-points** `(a)/(b)`;
+  - present the framework list as bullets.
+- Bold each sub-section heading as a conclusion; italicise quoted document text; end each point
+  with a **Request:** line.
+- British spelling and legal register. Spell out an acronym once (Heritage Statement, HE for
+  Historic England, CA for conservation area).
+- Reference documents precisely by author and date the first time.
+
+## What to leave out
+
+- Anything you cannot evidence, or generalised dislike of new development near old buildings.
+- Non-material concerns (loss of a private view, property values).
+- Consultant- or campaign-specific framing (cross-referencing other applications, or a named
+  inquiry) — argue each point on this application's own facts, unless the user asks and it is
+  defensible here.
+- "Substantial harm" asserted where the honest characterisation is less-than-substantial —
+  over-claiming the harm level is as damaging to credibility as the applicant under-claiming
+  it. Get the level right and argue it.

--- a/nppf-2024-12/heritage-representation/references/national-guidance.md
+++ b/nppf-2024-12/heritage-representation/references/national-guidance.md
@@ -1,0 +1,175 @@
+# Historic-environment law, policy and guidance (England)
+
+The framework to cite when mapping a deficiency (skill function 2). **Cite the specific
+instrument and clause, never "best practice" in the abstract.** Each deficiency in
+[`deficiency-catalogue.md`](deficiency-catalogue.md) points here.
+
+The **current NPPF/PPG edition register, the verify-before-citing protocol, and the shared
+decision-making core** (s.38(6) and plan primacy, the para 11 presumption and its footnotes,
+emerging-plan weight, the conditions and obligations tests) live in the companion
+**national-planning-policy** skill — check it first when citing the NPPF/PPG. This file owns
+only the topic-specific layer.
+
+> **Compiled and web-verified 14 August 2026 (England).** ⏳ The NPPF is under revision (a
+> restructured draft consulted to March 2026, a new edition expected); its Chapter 16
+> paragraph numbers will change again if it is republished, so **confirm the current numbers
+> when you draft.** This is not legal advice.
+>
+> **Scope:** the 1990 Act applies in England and Wales; the NPPF/PPG and Historic England
+> guidance are **England**. For Wales/Scotland/NI substitute the devolved framework.
+
+---
+
+## Part 1 — Primary legislation (the statutory duties — invoke the right one)
+
+**Planning (Listed Buildings and Conservation Areas) Act 1990.** These are **duties**, not
+policy — and the courts read them as requiring more than neutral weighing.
+
+- **s.66(1) — listed buildings (the key duty for a *planning* application):** in considering
+  whether to grant permission for development which **affects a listed building or its
+  setting**, the authority **"shall have special regard to the desirability of preserving the
+  building or its setting or any features of special architectural or historic interest which
+  it possesses."** Per *Barnwell Manor* (Part 5), "special regard" requires **considerable
+  importance and weight** and a **strong (rebuttable) presumption against** harm.
+- **s.16(2) — listed building consent:** the same "special regard" duty applies to an **LBC**
+  application (works to a listed building).
+- **s.72(1) — conservation areas:** for any planning decision on land in a conservation area,
+  **"special attention shall be paid to the desirability of preserving or enhancing the
+  character or appearance of that area."** "Preserving" means **doing no harm** (*South
+  Lakeland*, Part 5) — a neutral scheme satisfies the duty; a harmful one does not.
+- **s.69 — designation:** LPAs designate (and must review) conservation areas as "areas of
+  special architectural or historic interest the character or appearance of which it is
+  desirable to preserve or enhance."
+- *Invoke the right duty for the consent type:* s.16 for LBC; s.66 for planning permission
+  affecting a listed building/setting; s.72 for conservation areas.
+- *Source:* legislation.gov.uk/ukpga/1990/9 (ss.16, 66, 69, 72).
+
+**Ancient Monuments and Archaeological Areas Act 1979.** Scheduled monuments (s.1 schedule)
+have their **own consent regime** — **scheduled monument consent (s.2)** is required for most
+works and planning permission does **not** authorise them. Scheduled monuments are "assets of
+the highest significance" in NPPF terms. legislation.gov.uk/ukpga/1979/46
+
+**Registered parks & gardens, registered battlefields, World Heritage Sites.** Their weight
+flows from **NPPF policy, not a bespoke consent regime** (registered parks/gardens are
+statutory under the 1953 Act s.8C but add no consent control; battlefields and WHS are
+policy). All four are **"designated heritage assets"** in the NPPF Glossary, so the NPPF harm
+tests apply.
+
+---
+
+## Part 2 — NPPF (Chapter 16, "Conserving and enhancing the historic environment")
+
+**December 2024 edition** (current; amended 7 Feb 2025, Chapter 16 unchanged). ⏳ Chapter 16
+was **renumbered +13 from the Dec 2023 edition** (Dec 2024 = Dec 2023 + 13); a further revision
+is expected, so re-confirm numbers. gov.uk/guidance/national-planning-policy-framework/16-conserving-and-enhancing-the-historic-environment
+
+- **Para 207 [was 194] — describe significance (proportionately):** the applicant must
+  **describe the significance of any heritage assets affected, including any contribution made
+  by their setting**, in detail proportionate to the asset's importance. The hook for "no
+  proportionate significance/setting assessment provided." (For the "proportionate / don't
+  demand more information than needed" point, cite para 207 + the PPG, not a separate NPPF
+  sentence.)
+- **Para 208 [was 195] — LPA to identify and assess significance**, including where development
+  affects the **setting**, to avoid or minimise conflict.
+- **Para 209 [was 196] — deliberate neglect/damage** must not be taken into account in favour
+  of the applicant.
+- **Para 212 [was 199] — GREAT WEIGHT:** "great weight should be given to the asset's
+  conservation … the more important the asset, the greater the weight." Applies **whether the
+  harm is substantial, less than substantial, or none.**
+- **Para 213 [was 200] — substantial harm / total loss threshold:** any harm needs **clear and
+  convincing justification**; substantial harm/total loss to **grade II** should be
+  **exceptional**, and to **assets of the highest significance** (scheduled monuments, grade I
+  and II* listed buildings, grade I/II* registered parks & gardens, registered battlefields,
+  protected wreck sites, World Heritage Sites) **wholly exceptional**.
+- **Para 214 [was 201] — the substantial-harm test:** refuse unless the harm is **necessary to
+  achieve substantial public benefits that outweigh it**, OR **all four** of: (a) the asset's
+  nature prevents all reasonable use of the site; (b) no viable use of the asset itself can be
+  found through appropriate marketing; (c) not-for-profit/charitable/public conservation is
+  demonstrably impossible; and (d) harm is outweighed by bringing the site back into use.
+- **Para 215 [was 202] — LESS THAN SUBSTANTIAL harm:** "weighed against the public benefits of
+  the proposal including, where appropriate, securing its optimum viable use." Remember para
+  212: great weight still applies. Less-than-substantial harm is **not** neutral (*Bramshill*).
+- **Para 216 [was 203] — non-designated heritage assets:** a **"balanced judgement … having
+  regard to the scale of any harm or loss and the significance of the heritage asset."**
+- **Paras 217–218 [~205–206] — archaeology:** where a site has archaeological interest or
+  potential, require an **appropriate desk-based assessment and, where necessary, field
+  evaluation**; where justified loss occurs, require **recording and advancing understanding**
+  proportionate to importance, deposited with the Historic Environment Record — and **the
+  record must not be a substitute for preservation** where preservation is warranted.
+- **Setting** is woven through paras 207–208 (not a single paragraph); the operative method is
+  Historic England GPA3 (Part 4). NPPF Glossary: *setting* = "the surroundings in which a
+  heritage asset is experienced."
+
+---
+
+## Part 3 — Planning Practice Guidance ("Historic environment")
+gov.uk/guidance/conserving-and-enhancing-the-historic-environment (Ref ID 18a; substantive
+detail at 18a-015 to 18a-020)
+- **Proportionate significance assessment** — decisions on a proportionate assessment of the
+  particular significance of any asset affected, including its setting.
+- **Setting** — how setting contributes to significance and how to assess effects (with GPA3).
+- **Optimum viable use** — securing the use that keeps the asset viable while causing least
+  harm to significance; a public benefit to weigh under para 215.
+- **Enabling development** — otherwise-unacceptable development justified because it secures an
+  asset's conservation; tests apply (with Historic England GPA4).
+- **Recording / the Historic Environment Record (HER)** — recording as mitigation, proportionate
+  to importance, publicly deposited.
+
+---
+
+## Part 4 — Historic England guidance (current editions)
+- **GPA1 — The Historic Environment in Local Plans** (2015).
+- **GPA2 — Managing Significance in Decision-Taking in the Historic Environment** (2015) — the
+  core decision-taking note: assess significance, understand impact, minimise harm, use HERs.
+- **GPA3 — The Setting of Heritage Assets** — **2nd ed., Dec 2017** (⚠ supersedes the 2015 1st
+  ed.). The **staged setting method:** Step 1 identify the assets affected; Step 2 assess
+  whether/how setting contributes to significance; Step 3 assess the effect of the proposal;
+  Step 4 maximise enhancement/minimise harm; Step 5 make and document the decision. Cite this
+  when a setting assessment is absent or not to method.
+- **GPA4 — Enabling Development and Heritage Assets** (2020).
+- **HEAN 12 — Statements of Heritage Significance: Analysing Significance in Heritage Assets**
+  (2019) — the benchmark for preparing/critiquing a Statement of Significance.
+- **HEAN 1 (2nd ed., 2019) — Conservation Area Appraisal, Designation and Management** (⚠ this
+  is HEAN 1, not "HEAN 3"). Cite alongside the local conservation-area appraisal.
+- ⏳ **HEAN 4 Tall Buildings (2015)** and **HEAN 10 Listed Buildings and Curtilage (2018)** —
+  relevant to townscape/long views and to curtilage; confirm current editions before citing.
+  **HEAN 2 Making Changes to Heritage Assets** has a Dec 2025 revision — check the edition.
+
+**Significance vocabulary — use the statutory one.** Lead with the NPPF's four **interests** —
+**archaeological, architectural, artistic, historic** (the language of statute, the NPPF and
+HEAN 12). Historic England's *Conservation Principles* (2008) four **values** — **evidential,
+historical, aesthetic, communal** — are a useful analytical overlay but are not the
+statutory/policy vocabulary; don't conflate the two.
+
+---
+
+## Part 5 — Case law on the statutory duties
+- **Barnwell Manor / East Northamptonshire DC v SSCLG [2014] EWCA Civ 137:** the **s.66(1)
+  duty** requires the desirability of preserving a listed building/its setting to be given
+  **"considerable importance and weight"** — a **strong presumption against** harm, not neutral
+  weighing.
+- **Jones v Mordue [2015] EWCA Civ 1243:** an LPA that **works through the NPPF's historic-
+  environment paragraphs** will "generally" have discharged the s.66(1) duty — so insist the
+  officer report actually applies them.
+- **Palmer v Herefordshire [2016] EWCA Civ 1061:** applies *Mordue*; an express reference to the
+  NPPF heritage policies indicates compliance absent contrary evidence.
+- **R (Forge Field) v Sevenoaks DC [2014] EWHC 1895 (Admin):** even where harm is "less than
+  substantial," the desirability of preservation gets **considerable importance and weight**,
+  and benefits must **clearly outweigh** the harm. ⏳ confirm citation before quoting.
+- **South Lakeland DC v SSE [1992] (HL):** **"preserving" = doing no harm** (s.72). ⏳ confirm
+  the [1992] 2 AC 141 parallel citation.
+- **R (Bramshill) v SSHCLG [2021] EWCA Civ 320:** "less than substantial harm" is **not** "less
+  than substantial weight"; the NPPF harm categories operate **alongside** the statutory duties,
+  not in place of them.
+
+---
+
+## Part 6 — ⏳ Verify-before-relying (time-sensitive as of Aug 2026)
+- **NPPF edition & Chapter 16 numbers** — Dec 2024 used here; a restructured revision is
+  expected. Confirm the live edition and paragraph numbers when you draft (a republish will
+  renumber again).
+- **Historic England editions** — GPA3 is the 2017 2nd ed.; confirm HEAN 2/4/10 current editions.
+- **Case citations** — *Forge Field* and the *South Lakeland* AC citation want a quick
+  BAILII/ICLR confirmation before quoting.
+- **The "don't demand more information than reasonably needed" proposition** — cite para 207 +
+  PPG, not a specific NPPF sentence (it isn't expressly in Chapter 16).

--- a/nppf-2024-12/heritage-representation/references/objection-template.md
+++ b/nppf-2024-12/heritage-representation/references/objection-template.md
@@ -1,0 +1,155 @@
+# Objection template + annotated worked example
+
+A **skeleton** to fill, and a **worked example** showing the house style in practice. Match
+the example's density, tone and layout — every point must come from the documents in front of
+you.
+
+---
+
+## Skeleton
+
+```
+[Your name]
+[Your address]
+[Email]
+
+[Date]
+
+[Planning department / Council name / address]
+[For the attention of [Case Officer], if known]
+
+RE: Application [ref] — [site]
+[One-line description — note if listed-building consent / conservation-area / affects a
+designated asset or its setting; name the asset(s) and grade]
+
+Dear [Sir or Madam / Mr/Ms Name],
+
+REPRESENTATION ON HERITAGE GROUNDS — OBJECTION UNLESS MATTERS RESOLVED
+
+[Opening: consultation status; matters are material considerations while undecided; ask
+that this be placed on the file. Name the heritage asset(s) affected and their designation.]
+
+[State which documents you address — the Heritage Statement / Statement of Significance
+(author, date), the setting assessment, any archaeological assessment — and align with the
+conservation officer / Historic England where they have raised concerns.]
+
+The relevant framework includes: [short bulleted list from national-guidance.md — the
+statutory duties, the NPPF paragraphs, Historic England guidance, the conservation area
+appraisal].
+
+## 1. [Point stated as a conclusion]
+[Quote the document. Establish significance / characterise harm / invoke the duty. The ask.]
+
+## 2. [Next point]
+…
+
+## Summary of requests
+[Numbered, concrete, mostly "before determination".]
+
+Unless and until these matters are resolved, I object to the grant of [planning permission /
+listed building consent].
+
+Yours [sincerely/faithfully],
+[Name]
+```
+
+---
+
+## Worked example (condensed — annotations in ⟨…⟩)
+
+> ⟨Header, RE line and opening omitted for brevity — see the skeleton. The opening names the
+> asset (e.g. "the Grade II listed [building], and the [name] Conservation Area within which
+> the site sits") and aligns with the conservation officer's holding concerns.⟩
+
+**The relevant framework includes:** ⟨keep to what is engaged — a bulleted list, not a
+semicolon-run⟩
+
+- sections 66 and 72 of the Planning (Listed Buildings and Conservation Areas) Act 1990 — the
+  duties to have special regard to preserving a listed building and its setting, and special
+  attention to preserving or enhancing the character or appearance of a conservation area;
+- the NPPF's historic-environment policies — describing significance, great weight to the
+  conservation of designated assets, and the harm/public-benefit tests;
+- Historic England's Good Practice Advice (managing significance; the setting of heritage
+  assets);
+- the **[name] Conservation Area Appraisal**;
+- **[the Local Plan's historic-environment policies — insert the specific references]**.
+
+### 1. The significance of the asset has been under-assessed
+⟨Establish significance; bullet the interests the Statement omits.⟩
+
+The Heritage Statement confines the asset's significance to its external fabric. It does not
+assess the significance that derives from:
+
+- its **setting** — the [garden / street / group of buildings] through which the asset is
+  experienced;
+- its **group value** with the adjoining [assets];
+- its **historic interest** — [the association / phase / plan-form];
+- its **contribution to the conservation area's** character.
+
+Harm can only be measured against significance that has been identified. Because the Statement
+draws significance too narrowly, it also under-states the harm.
+
+**Request:** a Statement of Significance covering all the heritage interests — fabric, setting,
+group value and historic interest — before determination.
+
+### 2. The harm is mischaracterised, and the statutory weight is not applied
+⟨Two limbs — use lettered sub-points.⟩
+
+**(a)** The Statement describes the effect as causing "no harm" / "less than substantial
+harm." On a correct assessment the [demolition of the positive contributor / insertion into
+the setting] would [vitiate / very much reduce] the significance, which is **[substantial
+harm / a higher point on the less-than-substantial scale]** and engages the more demanding
+test.
+
+**(b)** Even on the applicant's own "less than substantial" characterisation, the assessment
+treats the harm as if it were neutral and simply outweighed. The Act requires **considerable
+importance and weight** to preserving the asset and its setting, and the NPPF requires **great
+weight** to the conservation of a designated asset. That weighted balance has not been carried
+out.
+
+**Request:** the level of harm correctly characterised, and the correct test and weighted
+public-benefit balance applied — and recorded — in the officer report.
+
+### 3. The public benefits are overstated and not weighed against the harm
+⟨Only genuine, generally public benefits count, weighed against great-weight harm.⟩
+
+The benefits relied on are largely private — [a larger dwelling / the applicant's return].
+The genuinely public benefits are [modest / unquantified], and they are asserted rather than
+weighed against harm to which great weight attaches.
+
+**Request:** the public benefits evidenced and expressly weighed against the (great-weight)
+heritage harm, not treated as a formality.
+
+### Summary of requests
+
+Before determination:
+1. A proportionate Statement of Significance covering all the heritage interests, including
+   setting and group value;
+2. A setting assessment to the recognised method, with representative views;
+3. The level of harm correctly characterised and the correct test applied, with the statutory
+   duties and great weight given effect and recorded in the officer report;
+4. The public benefits evidenced and weighed against the heritage harm;
+5. [Where relevant] an archaeological desk-based assessment and field evaluation before
+   determination.
+
+Unless and until these matters are resolved, I object to the grant of planning permission.
+
+Yours faithfully,
+[Name]
+
+---
+
+### Notes on adapting the example
+
+- **Match the point to the asset.** A listed building engages ss.66 and great weight; a
+  conservation area engages s.72 and "preserve or enhance"; a scheduled monument engages the
+  1979 Act; a non-designated asset engages the "balanced judgement." Name the right test.
+- **Get the harm level right.** Over-claiming "substantial harm" where the honest answer is
+  less-than-substantial damages credibility as much as the applicant under-claiming it.
+- **Consultant- or campaign-specific framing is excluded by default** — argue each point on
+  this application's own facts, not by reference to another case.
+- **Before submitting:** a person must read and check the draft — every quote and citation
+  against the actual documents — and be aware the representation is normally **published on the
+  council's portal in the submitter's name** and kept on the record, so include only personal
+  details the user is content to make public. This is a draft aid provided with no warranty; it
+  is not legal advice.

--- a/nppf-2024-12/national-planning-policy/CHANGELOG.md
+++ b/nppf-2024-12/national-planning-policy/CHANGELOG.md
@@ -1,0 +1,51 @@
+# Changelog — national-planning-policy
+
+Design decisions per revision, newest first. See `../CLAUDE.md` for the format and the
+house rules. The **_Why_** lines record the rationale so a future editor understands the
+intent.
+
+## Unreleased
+
+### Changed
+- **Edition register updated: the NPPF was republished on 17 August 2026**, replacing the
+  December 2024 edition with the anticipated coded-policies restructuring. The register now
+  records the new edition as in force, marks the decision-making core (still keyed to the
+  December 2024 text) as pending re-mapping, and adds the rule that past decisions are read
+  against the edition in force at their determination date. _Why:_ verified first-hand on
+  the gov.uk publication page (18 Aug 2026), after three independent assessment runs each
+  discovered the new edition at run time. Re-mapping the core and every topic catalogue to
+  the new policy codes is a repo-wide job tracked in its own issue; until it is done the
+  register must say loudly that every stored paragraph number is stale — a wrong-but-precise
+  register is exactly the defect the verify-before-citing protocol exists to prevent.
+- **The "two layers" section now names `policy-compliance-assessment` as the owner of the
+  *local* tier**, and states the hierarchy explicitly: adopted local policies are the council's
+  own and have primacy, the Framework is a material consideration alongside the plan rather than
+  above it. _Why:_ with a skill now dedicated to local-plan assessment, this skill needed to say
+  where its own boundary lies — and to guard against the failure mode the split invites, where a
+  reader takes the most detailed catalogue in the repo (this one) for the most important tier.
+- **"When to use" now lists the two new policy skills as callers.** _Why:_ they are the heaviest
+  consumers of the edition register — one for the national and emerging tiers of its policy
+  table, the other for verifying every citation before a draft is sent.
+- **A/B/C paragraph now also points to the `planning-balance` companion skill.** _Why:_
+  the balance skill is where the assembled case is weighed; the cross-reference completes
+  the chain.
+
+## 0.1.0 — 2026-08-16 — Initial release
+
+### Added
+- **The skill itself: a central national-policy layer** with (1) an edition register and a
+  verify-before-citing protocol, and (2) the shared decision-making core (s.38(6)/paras
+  2, 12, 48; the para 10–11 presumption with footnotes 7 and 8; para 49 emerging-plan
+  weight; para 57 conditions tests; para 58 / CIL reg 122(2) obligations tests). _Why:_
+  reviewer feedback — NPPF knowledge distributed across the topic catalogues lets skills
+  drift out of sync as editions change; the December 2025 draft revision (final expected
+  Summer 2026) restructures the Framework into coded policies, so a single re-verification
+  point matters more than ever. Structured as a companion *skill*, not a shared reference
+  file, so each skill folder stays individually copyable (repo convention).
+- **All citations verified against the live gov.uk text on 16 Aug 2026**, not from memory
+  (house rule 3). The verification pass immediately caught a live defect: the transport
+  catalogue cited the conditions tests as "para 56" (a December 2023 number) — fixed in the
+  same change, which is the skill's rationale demonstrated.
+- **Two-layers rule stated in the skill:** this layer owns the shared core + register; the
+  topic catalogues own their chapters and professional instruments. _Why:_ prevents the
+  duplication this skill exists to remove.

--- a/nppf-2024-12/national-planning-policy/LICENSE
+++ b/nppf-2024-12/national-planning-policy/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ian Howard
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/nppf-2024-12/national-planning-policy/README.md
+++ b/nppf-2024-12/national-planning-policy/README.md
@@ -1,0 +1,19 @@
+# national-planning-policy
+
+The shared national-policy layer for the planning skills in this repo. It does two jobs:
+
+1. **Edition discipline.** One register of the current NPPF edition (and the PPG's
+   page-by-page revision model), plus a protocol: never cite an NPPF paragraph from
+   memory — verify it against the live text before a draft leaves any skill. Editions
+   renumber, and a revision that restructures the whole Framework is expected imminently.
+2. **The decision-making core.** The citations every topic skill needs but none owns:
+   s.38(6) and the development plan's primacy, the paragraph-11 presumption ("tilted
+   balance") with its footnote 7/8 machinery, emerging-plan weight, and the tests for
+   planning conditions (para 57) and obligations (para 58 / CIL reg 122(2)).
+
+The topic skills (`ecological-`, `transport-`, `heritage-`, `flood-representation`) keep
+their own topic chapters and professional-guidance catalogues; `application-triage` uses
+this layer in Step 2 when it establishes the development-plan framework.
+
+> **Not legal advice. No warranty. England only.** Output requires human review; see the
+> repo README for the full disclaimer.

--- a/nppf-2024-12/national-planning-policy/SKILL.md
+++ b/nppf-2024-12/national-planning-policy/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: national-planning-policy-nppf-2024-12
+description: >-
+  ARCHIVED - December 2024 NPPF edition (superseded 17 August 2026). Use only when the user explicitly asks to work under the pre-August-2026 framework and has confirmed they want the archived skills; outputs must state they cite a superseded framework. 
+  The shared national-policy layer for the England planning skills: verify the
+  current NPPF/PPG edition before citing anything, and supply the
+  decision-making core — s.38(6) and the development plan's primacy, the
+  paragraph-11 presumption ("tilted balance") and its footnotes, emerging-plan
+  weight, and the tests for planning conditions and obligations. Used by the
+  triage and representation skills; also answers direct "what does the NPPF
+  say / is this paragraph current" questions. England-focused. Not legal
+  advice; no warranty; output requires human review.
+license: MIT
+---
+
+# National planning policy — the shared layer
+
+One place for the two things every companion skill needs from national policy: **which
+edition is current** (and the discipline of checking before citing), and the
+**decision-making core** that no topic catalogue owns — the statutory starting point, the
+presumption, and the tests for conditions and obligations.
+
+## When to use
+
+- **From the companion skills** — `application-triage` (Step 2, establishing the decision
+  framework), `policy-compliance-assessment` (the national and emerging tiers of its policy
+  table, and the plan-status and presumption tests), `policy-representation` (verifying every
+  citation before a draft is sent) and the topic representation skills (when mapping
+  deficiencies to national policy): check the edition register here before citing the NPPF/PPG,
+  and take the shared decision-making citations from here rather than restating them per topic.
+- **Directly** — the user asks "what does the NPPF say about …", "is this paragraph number
+  still right", "does the tilted balance apply here".
+
+## Two layers, no duplication
+
+This skill owns the **shared core and the edition register** — the *national* tier. The
+**local** tier belongs to **policy-compliance-assessment**: identifying and verifying the
+adopted development plan for the authority, and assessing and scoring a proposal against its
+policies. Keep the hierarchy the right way up when citing from here — adopted local policies
+are the council's own and have primacy; the Framework is a material consideration alongside
+the plan, not above it. The topic skills' own `references/national-guidance.md` files own
+their **topic chapters and instruments**
+(ecology's Chapter 15 map, CIEEM and BCT editions; transport's Chapter 9, LTN 1/20 and
+Manual for Streets; heritage's Chapter 16 and the 1990 Act duties; flood's paragraphs
+170–182 and the climate-change allowances). Don't copy either layer into the other.
+
+## The verification protocol — read before citing anything
+
+**Never cite an NPPF paragraph number from memory.** Editions renumber: December 2023 →
+December 2024 shifted several chapters by one, and the pending revision (below) restructures
+the entire document. A representation citing a stale paragraph loses credibility on the
+point it most needs it — and a superseded-edition citation is exactly the kind of defect the
+representation skills criticise applicants for.
+
+Before a draft leaves any companion skill:
+
+1. **Check the edition register below**, then confirm it is still current at
+   [gov.uk/guidance/national-planning-policy-framework](https://www.gov.uk/guidance/national-planning-policy-framework)
+   (the page's "Updates" tab shows the edition history).
+2. **Verify each cited paragraph against the live text** — the gov.uk HTML is the
+   quickest source; quote the paragraph, don't paraphrase from memory.
+3. **If the edition has changed** since the register below was verified: re-verify every
+   NPPF citation in the draft, tell the user the framework has changed, and update this
+   register and any affected topic catalogue (with changelog entries).
+4. **PPG**: cite by the paragraph ID (e.g. "Paragraph: 001 Reference ID: 21a-001-…") *and*
+   the page's "last updated" date — PPG pages revise independently and silently.
+
+## ⏳ Edition register (verified 18 August 2026 — re-verify at run time)
+
+- **NPPF in force: 17 August 2026 edition** (published 17 Aug 2026, replacing the December
+  2024 edition — confirmed on the gov.uk publication page's edition history). This is the
+  anticipated restructuring: the Framework is now organised as **coded policies in themed
+  chapters** rather than sequentially numbered paragraphs, so **every pre-August-2026
+  paragraph-number citation is stale**. Live text:
+  gov.uk/guidance/national-planning-policy-framework.
+- **⚠ Repo-wide re-verification in progress.** The decision-making core below and the topic
+  catalogues in the representation skills were verified against the **December 2024** text
+  and have not yet been re-mapped to the new policy codes — until that is done, treat every
+  NPPF reference in this repo as a pointer to the *concept*, and verify the current code and
+  wording against the live text before citing (protocol above). Applications **determined
+  before 17 August 2026** were decided under the earlier edition; when reviewing a past
+  decision, cite the edition in force at determination.
+- **PPG**: web-based guidance suite, revised page-by-page — no single edition; rely on
+  per-page "last updated" dates.
+
+## The decision-making core (⏳ verified against the December 2024 text — re-map to the August 2026 policy codes before citing)
+
+**The statutory starting point.** Section 38(6) of the Planning and Compulsory Purchase
+Act 2004: applications must be determined **in accordance with the development plan unless
+material considerations indicate otherwise** (see also s.70(2) TCPA 1990). The NPPF
+restates this at **para 2** and **para 48**, and para 2 confirms the Framework itself "is a
+material consideration in planning decisions" — influential, but not above the plan.
+**Para 12**: the presumption in favour of sustainable development "does not change the
+statutory status of the development plan as the starting point for decision-making."
+
+**The presumption / "tilted balance" — paras 10–11.** For decision-taking, para 11(c):
+approve development that accords with an up-to-date plan without delay. Para 11(d) — the
+tilted balance — applies only where there are **no relevant development plan policies, or
+the policies which are most important for determining the application are out-of-date**
+(footnote 8: including where no five-year housing land supply can be demonstrated, or the
+Housing Delivery Test result was below 75%). Even then, permission should be *refused* if
+**footnote 7** assets provide a clear reason to (habitats sites, SSSIs, Green Belt, Local
+Green Space, National Landscapes, National Parks/Broads, Heritage Coast, irreplaceable
+habitats, designated heritage assets, areas at risk of flooding or coastal change) — the
+"footnote 7 disapplication" — or if adverse impacts would **significantly and demonstrably
+outweigh** the benefits. Whether the tilted balance is engaged, and whether footnote 7
+switches it off, is often decisive: check it before framing any objection strategically.
+
+**Emerging plans — para 49.** Weight according to (a) the stage of preparation, (b) the
+extent of unresolved objections, and (c) the degree of consistency with the Framework.
+
+**Planning conditions — para 57.** Conditions should be kept to a minimum and only imposed
+where they are "necessary, relevant to planning and to the development to be permitted,
+enforceable, precise and reasonable in all other respects" — the **six tests** (PPG "Use of
+planning conditions"). Two uses for an objector: a condition that fails a test can be
+challenged; and a condition cannot be *necessary* if it papers over a fundamental evidence
+gap — "conditions are not a substitute for adequate assessment" anchors here.
+
+**Planning obligations — para 58.** Obligations must only be sought where they meet the
+three tests of CIL Regulation 122(2): **necessary** to make the development acceptable in
+planning terms, **directly related** to the development, and **fairly and reasonably
+related in scale and kind** to it.
+
+**How this feeds the A/B/C discipline** (see the representation skills, and the companion
+**planning-balance** skill which weighs the assembled case): outcome (A)
+usually means conflict with the development plan and/or a failed NPPF test with the balance
+against approval; outcome (B) means the decision-maker cannot yet lawfully strike that
+balance; outcome (C) lives inside the para 57/58 tests — the ask must itself pass them.
+
+## Scope and limitations
+
+- **Not legal advice, and no warranty.** A reference layer for lay representations; not a
+  substitute for a solicitor; provided "as is". **Human review required** before relying on
+  any citation.
+- **England-focused.** The NPPF/PPG are England; the devolved nations have their own
+  frameworks — flag and adjust when outside England.
+- **Time-sensitive by nature.** Everything here decays at the next NPPF revision — the
+  verification protocol is the skill; the register is only a snapshot.

--- a/nppf-2024-12/planning-balance/CHANGELOG.md
+++ b/nppf-2024-12/planning-balance/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog — planning-balance
+
+Design decisions per revision, newest first. See `../CLAUDE.md` for the format and the
+house rules. The **_Why_** lines record the rationale so a future editor understands the
+intent.
+
+## Unreleased
+
+### Changed
+- **"What you need first" now accepts the `policy-compliance-assessment` output** — the plan
+  register, the scored policy table, the weight tiers and the accordance statement — with two
+  cautions carried into the balance: the -2 to +2 scores are never totalled or averaged, and
+  every `?` (policy requirement that cannot be assessed) is a **(B)**. _Why:_ the new skill
+  produces the plan-conflict input this skill previously had to reconstruct from triage. The two
+  cautions travel with the data deliberately: a numeric table is exactly the kind of input that
+  invites a shortcut, and "accordance with the development plan read as a whole" is the judgement
+  this skill exists to make — an average would pre-empt it, and treating a `?` as harm would
+  weigh an evidence gap as if it were demonstrated impact.
+
+## 0.1.0 — 2026-08-16 — Initial release
+
+### Added
+- **The skill itself: a final planning-balance ("so-what") stage** run after triage and
+  the representation skills — governing-framework identification (plan-led vs tilted
+  balance, footnote 7 disapplication), ground-specific gateways (Habitats Regulations
+  hard stop, Green Belt VSC, heritage harm tests, flood Sequential Test, transport
+  "severe" bar), an honest harms-vs-benefits weighing, and a four-outcome recommendation
+  (refuse / do not determine yet / conditions / balance favours approval). _Why:_ reviewer
+  feedback — a planning decision is not the sum of technical defects, and without a final
+  balance question the system can produce an impressive list of valid criticisms that
+  would not change the decision. Framed as *anticipating* the decision-maker's balance
+  because an objector is not the decision-maker.
+- **Benefits scrutinised with the same evidence discipline as harms** (unquantified
+  economic claims, unsecured affordable housing → reduced weight). _Why:_ the balance has
+  two pans; engaging with benefits honestly is both more credible and a source of
+  representation material in its own right.
+- **Kept to a single SKILL.md, deferring citations to `national-planning-policy` and the
+  topic catalogues.** _Why:_ two-layers house rule — this skill owns the *procedure* of
+  the balance; the instruments and current paragraph numbers live in the companion skills.

--- a/nppf-2024-12/planning-balance/LICENSE
+++ b/nppf-2024-12/planning-balance/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ian Howard
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/nppf-2024-12/planning-balance/README.md
+++ b/nppf-2024-12/planning-balance/README.md
@@ -1,0 +1,22 @@
+# planning-balance
+
+The final "so-what" test in the planning-skills chain. A planning decision is not the sum
+of technical defects — after `application-triage` has ranked the grounds and the
+representation skills have evidenced them, this skill anticipates the decision-maker's
+**planning balance**:
+
+- which framework governs (plan-led under s.38(6), or the NPPF para 11(d) tilted balance —
+  and whether footnote 7 disapplies it);
+- the ground-specific gateways (Habitats Regulations hard stops, Green Belt very special
+  circumstances, the heritage harm tests, the flood Sequential Test, the transport
+  "severe" bar);
+- an honest weighing of the surviving harms against the scheme's claimed benefits;
+- and the recommended ask: **refusal**, **do not determine yet**, **conditions** — or
+  advice that the balance favours approval and an objection is not sustainable.
+
+It exists to stop an impressive list of technically valid criticisms being mistaken for a
+case for refusal.
+
+> **Not legal advice. No warranty. England only.** The balance is the decision-maker's
+> judgement; this anticipates it. Output requires human review; see the repo README for
+> the full disclaimer.

--- a/nppf-2024-12/planning-balance/SKILL.md
+++ b/nppf-2024-12/planning-balance/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: planning-balance-nppf-2024-12
+description: >-
+  ARCHIVED - December 2024 NPPF edition (superseded 17 August 2026). Use only when the user explicitly asks to work under the pre-August-2026 framework and has confirmed they want the archived skills; outputs must state they cite a superseded framework. 
+  The final "so-what" test for a planning representation: given the assembled,
+  evidenced grounds against a UK planning application, anticipate the
+  decision-maker's planning balance — identify the governing statutory/policy
+  tests (s.38(6), the tilted balance, heritage great weight, Green Belt very
+  special circumstances, the transport and flood tests), weigh harms against
+  the scheme's benefits honestly, and recommend what the representation should
+  actually ask for: refusal, deferral for information, or conditions — or
+  advise that the balance favours approval. Run after application-triage and
+  the representation skills. England-focused. Not legal advice; no warranty;
+  output requires human review.
+license: MIT
+---
+
+# Planning balance — the "so-what" test
+
+A planning decision is not the sum of technical defects. This skill runs **last**, after
+the grounds have been assembled and evidenced, and answers the question every strong
+representation must survive:
+
+> Even if these harms and deficiencies exist, are they sufficient — under the tests that
+> actually govern this application — to justify refusal?
+
+The objector is not the decision-maker. What this skill does is **anticipate the balance
+the case officer must strike**, so the representation asks for the outcome the balance can
+actually support — which is what makes it liftable into the officer report rather than
+filed as noise.
+
+## When to use
+
+- As the **final step** of the chain: `application-triage` has ranked the grounds, the
+  representation skills have evidenced them, and each point carries its A/B/C
+  classification. Run this before anything is drafted into a final ask.
+- Directly, when the user asks: "would this actually be refused?", "is our case strong
+  enough?", "should we push for refusal or for conditions?"
+
+## What you need first
+
+- The **evidenced grounds**, each classified **(A)** demonstrated unacceptable impact /
+  **(B)** insufficient evidence / **(C)** conditionable (the representation skills produce
+  this), and the **development-plan policies** each ground conflicts with.
+- The **policy compliance assessment** from the companion **policy-compliance-assessment**
+  skill, where it has run — the plan register, the policy-by-policy accordance scores (-2 to
+  +2, with `?` where a policy requirement cannot be assessed), the weight tiers, and its
+  accordance statement. Two cautions carry through to the balance: the scores are **never
+  totalled or averaged** — accordance with the plan **read as a whole** is the judgement made
+  here, and one significant conflict with the plan's strategy can outweigh many compliances on
+  matters of detail; and every `?` is a **(B)**, so it bears on whether the balance can lawfully
+  be struck at all rather than weighing as harm.
+- The **scheme's claimed benefits** — from the Planning Statement and application forms:
+  housing numbers (market and affordable), economic claims, regeneration, BNG, public
+  realm. The balance has two pans; a representation that never engages with the benefits
+  is not doing the exercise.
+- The **site constraints** that switch tests on or off (Green Belt, designated heritage,
+  flood zone, habitats sites — triage records these).
+- The **consultee positions** — an unresolved statutory-consultee objection changes what
+  the balance can conclude.
+- The companion **national-planning-policy** skill for the current citations: s.38(6) and
+  plan primacy, whether the **tilted balance** is engaged (most-important policies
+  out-of-date / housing land supply) or **disapplied by footnote 7**, and the
+  conditions/obligations tests.
+
+## The integrity principle (read first)
+
+**The balance is where over-claiming goes to die.** Inflating a (B) evidence gap into an
+(A) refusal case, dismissing real benefits, or demanding refusal where conditions would
+plainly do, hands the case officer a reason to discount the whole representation. The
+honest outputs of this skill include: "the balance favours approval — don't object",
+"object, but ask for conditions, not refusal", and "the only sound ask is that the
+application not be determined until X is before the Council." Each of those is a success,
+not a failure. Credibility spent here is spent for every future representation too.
+
+## Workflow
+
+### Step 1 — Identify the governing framework
+Start from s.38(6): does the assembled case amount to **conflict with the development plan
+read as a whole**, or only with fragments of it? Then establish which balance applies:
+
+- **Plan-led (the default):** determine in accordance with the plan unless material
+  considerations indicate otherwise. Plan conflict + no outweighing considerations →
+  refusal is the plan-led outcome.
+- **Tilted balance (NPPF para 11(d)):** engaged only where there are no relevant policies
+  or the most important ones are out-of-date (check housing land supply / Housing Delivery
+  Test via the national-planning-policy skill). If engaged, harm must **significantly and
+  demonstrably** outweigh benefits — a materially harder target for an objector — *unless*
+  **footnote 7** disapplies it (habitats sites, SSSIs, Green Belt, National Landscapes,
+  designated heritage, flood risk…). Getting this switch right is often the single most
+  strategic fact in the case.
+
+### Step 2 — Apply the ground-specific gateways
+Some grounds carry their own test that must be run *before* the general weighing — take
+the current citations from the topic skills and the national-planning-policy skill:
+
+- **Habitats Regulations** — not a balance at all: if adverse effect on a European site's
+  integrity cannot be ruled out, permission cannot lawfully be granted (a hard stop; also
+  the EPS derogation tests). These outrank everything else raised.
+- **Green Belt** — inappropriate development requires **very special circumstances**; the
+  applicant carries that burden, not the objector.
+- **Heritage** — characterise the harm level honestly, then apply the statutory
+  **considerable importance and weight** and the NPPF great-weight/public-benefit tests.
+- **Flood** — the **Sequential Test** is a gateway: if it fails, the balance is not
+  reached; the development must also be safe for its lifetime without increasing risk
+  elsewhere.
+- **Transport** — refusal on capacity/safety alone needs a **severe** residual cumulative
+  impact or an unacceptable safety impact; otherwise the ground argues policy
+  non-compliance, which weighs but rarely decides alone.
+
+### Step 3 — Weigh honestly
+Set the surviving harms (with their statutory/policy weightings) against the benefits —
+and scrutinise the benefits with the same evidence discipline the representation skills
+apply to harms: unquantified economic claims, double-counted open space, or "affordable
+housing" without a secured obligation attract reduced weight, and saying so (with the
+applicant's own document quoted) is itself good representation material. Note which
+harms are (B)-class: an unresolved evidence gap does not weigh as demonstrated harm — it
+means the balance **cannot yet lawfully be struck**, which is its own conclusion.
+
+### Step 4 — Conclude and recommend the ask
+One of four honest outcomes, driving what the representation requests:
+
+1. **Refusal** — (A) grounds sufficient under the governing tests: say which test fails
+   and why the benefits don't save it.
+2. **Do not determine yet** — (B) grounds dominate: the ask is the missing information
+   before determination, put as "the Council cannot presently conclude X".
+3. **Approve-with-conditions posture** — the harms resolve to (C): the ask is the precise
+   conditions/obligations (which must themselves pass the para 57/58 tests).
+4. **The balance favours approval** — say so, and advise not objecting (or a short
+   representation supporting conditions only).
+
+Output a **short balance statement** (a paragraph, two at most) the user can lift into the
+representation's opening or closing: the framework that governs, the decisive harms with
+their weights, the benefits acknowledged, and the conclusion with the ask. Then hand back
+to a human with the standard warnings: **review before use, and anything submitted is
+normally published on the council's portal in the submitter's name.**
+
+## Scope and limitations
+
+- **Not legal advice, and no warranty.** The balance is ultimately the decision-maker's
+  planning judgement; this skill anticipates it to sharpen a lay representation, is not a
+  substitute for a solicitor or planning consultant, guarantees no outcome, and is
+  provided "as is".
+- **Human review is necessary before use.** A person must check the tests invoked and the
+  weights claimed against the actual documents and current policy.
+- **England-focused.** The tests cited are the England framework; flag and adjust outside
+  England.
+- **Evidence-bound.** Weigh only harms that survived the representation skills' evidence
+  discipline and benefits actually claimed in the application; invent neither.
+- **The honest answer is sometimes "the balance favours approval."** Treat that as a
+  valid, valuable output.

--- a/nppf-2024-12/policy-compliance-assessment/CHANGELOG.md
+++ b/nppf-2024-12/policy-compliance-assessment/CHANGELOG.md
@@ -1,0 +1,117 @@
+# Changelog — policy-compliance-assessment
+
+Design decisions per revision, newest first. See `../CLAUDE.md` for the format and the house
+rules. The **_Why_** lines record the rationale so a future editor understands the intent.
+
+## 0.1.2 — 2026-08-18 — Evidence disciplines from officer-practice benchmarking
+
+### Added
+- **Seven "evidence disciplines" in Step 4**, matching observed officer practice: a
+  window-by-window openings audit; a planning-history sweep with delta-assessment against
+  any extant fallback permission; amenity geometry measured relative to the neighbour, not
+  just the plot; multi-source verification of basic site facts including the council's own
+  GIS layers; a representations sweep; treating consultee positions as evidence to
+  re-derive rather than conclusions to adopt; and a condition-versus-refusal discipline for
+  separable detail and missing documents on minor schemes. _Why:_ five blind runs of this
+  skill against decided applications (major and householder) matched the real outcome every
+  time, and the residual divergences from the officers' delegated/committee reports were
+  concentrated in exactly these habits — a missed new opening that the officer conditioned;
+  an unswept history that held the controlling fallback or refusal precedent; a
+  procedural gap escalated to a refusal reason the officer handled as a condition.
+  Codifying them keeps the next assessment's misses from repeating the benchmarked ones,
+  while the existing integrity rules (missing evidence is (B), unsecured mitigation is (C))
+  already carry the classification these disciplines feed.
+
+## 0.1.1 — 2026-08-18 — Designated-area scoring uplift
+
+### Changed
+- **Conservation areas (and other designated heritage assets) now carry an explicit scoring
+  uplift.** Step 4 gains a "designated areas raise the bar" discipline, the rubric's -2
+  signals and the -1/-2 calibration test gain a designated-area limb, and "under-scoring a
+  designated-area conflict" joins the common-errors list. The rule: measure the **cumulative
+  volume of physical change** quantitatively from the drawings, and score a character/scale
+  criterion failure in a designated area at full strength rather than discounting it to a
+  tension because only one limb fails or each alteration looks modest. Citations (s.66/s.72,
+  NPPF heritage tests) stay with `heritage-representation` per the no-duplication rule.
+  _Why:_ benchmarking a blind run of this skill against a real decided application showed the
+  assessment converging with the officer on the operative policies and outcome but scoring the
+  design/overdevelopment conflict on a conservation-area building -1 where the officer ran it
+  as a standalone full-strength refusal reason grounded in plot metrics taken off the
+  drawings. The user's diagnosis — conservation-area status was underweighted — matches how
+  decision-makers actually behave: the statutory duty makes cumulative change in a designated
+  area refusal material on its own, and the skill's calibration should reflect observed
+  officer practice, not treat the designation as one criterion among many.
+
+## 0.1.0 — 2026-08-17 — Initial release
+
+### Added
+- **The skill itself: a policy-compliance stage between triage and drafting** — identify and
+  verify the adopted development plan, select the relevant policies, assess each against the
+  application, score accordance, and conclude on the plan read as a whole. _Why:_ the repo
+  could evaluate a *topic's technical evidence* (the four representation skills) and could
+  anticipate the *final balance* (`planning-balance`), but nothing owned the step in between —
+  the systematic policy-by-policy assessment that s.38(6) makes the starting point of every
+  determination. Triage gestured at it in a four-item step; that is enough to route, not enough
+  to do the work.
+- **Identifying the adopted development plan as an explicit, gated first step**, with its own
+  reference file, a plan register output, and a table of what is *not* the development plan
+  (SPDs, design guides, draft plans, council strategies, unmade neighbourhood plans). _Why:_
+  "adopted" is a formal term and the most common lay error in this area is assessing against
+  the wrong document — a consultation draft, a superseded policy, or an SPD treated as policy.
+  An assessment built on the wrong plan is not weak, it is void, and a case officer spots it
+  immediately. Gating the workflow on this makes the failure mode hard to reach.
+- **The superseded/saved-policies and draft-numbering traps called out explicitly.** _Why:_ a
+  new plan usually replaces only *some* of its predecessor's policies, and policy numbers
+  routinely change between the publication draft and adoption. Both produce citations that look
+  authoritative and are wrong, which is worse than citing nothing.
+- **A -2 to +2 accordance score with anchored bands and calibration tests** ("if this were the
+  only policy in the plan, would the proposal fail on it?" for -1 versus -2). _Why:_ the score
+  makes a long analysis scannable and lets the drafting skill lead on what carries weight. The
+  anchors and calibration tests exist because an unanchored scale drifts into expressing
+  strength of feeling rather than accordance.
+- **A separate `?` "cannot be assessed" flag, explicitly not a negative score**, mapped to the
+  repo's **(B)** classification. _Why:_ the repo's central discipline is that an evidence gap
+  is not demonstrated harm. Folding "the applicant didn't submit the survey" into a -1 or -2
+  would smuggle a (B) into an (A) — the classic credibility mistake the representation skills
+  are built to avoid — and it also supports the wrong ask ("refuse" instead of "do not
+  determine yet").
+- **A weight-tier column kept separate from the score**, with a "reduced weight" tier for
+  out-of-date adopted policies and separate tiers for national policy, emerging plans and
+  guidance. _Why:_ how a proposal stands against a policy and how much that matters are
+  different questions. Merging them into a single number hides exactly the reasoning a decision
+  turns on — and an out-of-date policy still generates real conflict, just at less weight, so
+  silently discounting it would be as wrong as ignoring its status.
+- **A "most important policies for determining the application" flag.** _Why:_ that phrase is
+  what the national presumption turns on, so the analysis should surface the set explicitly
+  rather than leaving a reader to infer it.
+- **An explicit no-aggregation rule, with a worked demonstration.** _Why:_ a -2 to +2 scale
+  invites a total or a mean, and the arithmetic actively misleads: eight `+1`s on detailed
+  standards and one `-2` on the settlement-boundary policy averages positive while the proposal
+  is very likely contrary to the plan as a whole. Recording the temptation and the counter-example
+  in the rubric is the only way to stop a future editor "improving" the skill by adding a total.
+- **National policy and emerging plans assessed in a second, explicitly lower-weight table.**
+  _Why:_ the user requirement is that these are considered but subordinate to the adopted plan;
+  putting them in a physically separate table makes the hierarchy visible on the page instead of
+  relying on a column a reader may skim past.
+- **`references/policy-families.md`, keyed by proposal type, using descriptive family names and
+  never example policy numbers.** _Why:_ plans differ in numbering and structure, so the
+  transferable knowledge is *which families of policy to expect and when they bite*. Printing
+  plausible-looking policy references would invite exactly the from-memory citation the skill
+  exists to prevent.
+- **Explicit "the plan is silent" and "don't stretch a policy" guidance.** _Why:_ a missing
+  policy family is a real finding (and may show the plan is out-of-date on the topic), whereas
+  pressing an unrelated policy into service is easy to rebut and costs credibility on the
+  policies that do fit.
+
+### Changed
+- **No citations of its own: the statutory and NPPF layer defers wholly to
+  `national-planning-policy`.** _Why:_ two-layers house rule — this skill owns the *procedure*,
+  that skill owns the *instruments* and the current paragraph numbers. It also keeps the skill
+  intact through the pending NPPF revision, which will renumber everything.
+- **s.38 cited without sub-paragraph precision, with a ⏳ run-time verification flag**, and the
+  pending national-development-management-policies and supplementary-plans reforms flagged as
+  *not assumed to be in force*. _Why:_ house rule 3 — primary sources were unreachable from the
+  build environment (legislation.gov.uk and gov.uk were egress-blocked), so the composition of
+  the development plan is stated functionally and flagged for verification rather than pinned to
+  subsection letters from memory. A note also warns that older reproductions of s.38 circulating
+  online still carry the spent regional-strategy reference.

--- a/nppf-2024-12/policy-compliance-assessment/LICENSE
+++ b/nppf-2024-12/policy-compliance-assessment/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ian Howard
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/nppf-2024-12/policy-compliance-assessment/README.md
+++ b/nppf-2024-12/policy-compliance-assessment/README.md
@@ -1,0 +1,43 @@
+# policy-compliance-assessment
+
+Assess a UK planning application against the policies that actually govern it — starting, as
+the statutory framework does, with the **formally adopted development plan**.
+
+The skill works in three moves:
+
+1. **Identify and verify the adopted development plan** for the relevant local planning
+   authority — the adopted local plan (often several documents), any **made** neighbourhood
+   plan, the minerals and waste plans, and in London the spatial development strategy — with
+   the adoption dates, the schedule of superseded and saved policies, and the site's position
+   on the policies map. "Adopted" is a formal term: a draft, submitted or examined plan is not
+   adopted, and neither is a supplementary planning document.
+2. **Assess** the proposal against each relevant policy, quoting the requirement and pointing
+   at the evidence in the application documents.
+3. **Score and conclude** — a policy-by-policy table scored from **-2** (significant conflict)
+   to **+2** (strongly aligned), with `?` where the application lacks the evidence the policy
+   requires, plus a reasoned conclusion on accordance with the development plan **read as a
+   whole**.
+
+Adopted policies are the **local authority's own** — written, examined, adopted and published by
+the council, on its own website, under its own numbering — and they carry **primacy** in the
+decision. National policy (NPPF/PPG) and any **emerging** plan are assessed in a separate,
+explicitly lower-weight tier: material considerations that inform the decision without
+displacing the plan.
+
+Two rules do most of the work:
+
+- **The scores are never totalled or averaged.** Accordance with the plan read as a whole is a
+  planning judgement; one significant conflict with the spatial strategy can outweigh eight
+  compliances on matters of detail, and an average would invert the answer.
+- **Missing evidence is not conflict.** Where the application does not contain what a policy
+  requires, the honest output is "cannot be assessed" — which supports a different ask.
+
+Feeds **`policy-representation`** (which drafts the representation, in support or objection)
+and **`planning-balance`** (which weighs the case). Takes its NPPF/PPG citations from
+**`national-planning-policy`** and leaves topic-specific technical evaluation to the
+`heritage-`, `transport-`, `flood-` and `ecological-representation` skills.
+
+> **Not legal advice. No warranty. England only.** Policy interpretation is ultimately for the
+> decision-maker. Plans are adopted and superseded continuously, so the plan must be
+> re-resolved and every policy re-quoted at run time. Output requires human review; see the
+> repo README for the full disclaimer.

--- a/nppf-2024-12/policy-compliance-assessment/SKILL.md
+++ b/nppf-2024-12/policy-compliance-assessment/SKILL.md
@@ -1,0 +1,294 @@
+---
+name: policy-compliance-assessment-nppf-2024-12
+description: >-
+  ARCHIVED - December 2024 NPPF edition (superseded 17 August 2026). Use only when the user explicitly asks to work under the pre-August-2026 framework and has confirmed they want the archived skills; outputs must state they cite a superseded framework. 
+  Assess a UK planning application against the policies that govern it, starting
+  with the formally **adopted** development plan published by the local planning
+  authority — which has primacy. Identify and verify that plan first (adoption
+  dates, superseded policies, the policies map), then score the proposal policy
+  by policy from -2 (significant conflict) to +2 (strongly aligned), assess
+  NPPF/PPG and any emerging plan separately at lower weight, and conclude on
+  accordance with the plan read as a whole. Use for "does this comply with the
+  local plan", "which policies does this application breach", "assess this
+  against adopted policy", "policy analysis". England-focused. Not legal advice;
+  no warranty; output requires human review.
+license: MIT
+---
+
+# Policy compliance assessment
+
+Work out **which planning policies govern an application, and whether it accords with each
+one**. The skill does three things:
+
+1. **Identify the adopted development plan** for the relevant local planning authority, and
+   verify it — the essential first step, because determination starts there and nothing
+   downstream is safe if this is wrong.
+2. **Assess** the proposal against each relevant policy, on the evidence in the application
+   documents and the policy's own words.
+3. **Score and report** — a policy-by-policy table with an accordance score from **-2 to
+   +2**, then a reasoned conclusion on accordance with the development plan **read as a
+   whole**.
+
+National policy (NPPF/PPG) and any **emerging** plan are assessed too, but as material
+considerations carrying **less weight than the adopted plan** — never as a substitute for it.
+
+## When to use
+
+The user asks: "does this comply with the local plan?", "which policies does this application
+breach?", "assess this against the adopted policies", "what does the local plan say about
+this site?", "is this development plan compliant?" — or a representation needs a policy
+foundation before it is drafted.
+
+Use it **after** `application-triage` has identified which considerations are engaged (or
+alongside it — triage's decision-framework step hands off to this skill), and **before**
+`policy-representation` drafts anything.
+
+Not this skill: the deep technical evaluation of a topic's evidence base (the
+`ecological-`, `transport-`, `heritage-` and `flood-representation` skills own that), the
+current NPPF edition and paragraph numbers (`national-planning-policy` owns those), or the
+final harms-vs-benefits weighing (`planning-balance`).
+
+## Two layers, no duplication
+
+This skill owns the **procedure**: how to find and verify an adopted development plan, how
+to read a policy, and how to score accordance. It owns **no citations of its own**. The
+current NPPF/PPG edition register, the verify-before-citing protocol, s.38(6) and plan
+primacy, the paragraph-11 presumption, emerging-plan weight and the conditions/obligations
+tests all live in the companion **national-planning-policy** skill — take them from there.
+The policies themselves are **per-instance data**: they come from the council's adopted plan
+at run time, and are quoted, never remembered.
+
+## The integrity principle (read first)
+
+- **The adopted plan is the local authority's own document, and it has primacy.** Adopted
+  policies are made and published by the **local planning authority** — on its own website,
+  under its own numbering, adopted on its own date. They are not published by central
+  government, and they are not the NPPF. This matters twice over: it tells you **where to
+  look** (the council's planning-policy pages, never a national source), and it fixes the
+  **hierarchy** — the development plan is the statutory starting point, and national policy is
+  a material consideration that informs the decision without displacing the plan. An
+  assessment that leads on the NPPF and treats the local plan as background has the
+  hierarchy upside down.
+- **"Adopted" is a formal term — establish it, don't assume it.** A plan is adopted when the
+  council has formally resolved to adopt it following independent examination. A published,
+  submitted, consulted-on or examined-but-not-yet-adopted plan is **not** adopted, and neither
+  is a supplementary planning document. Getting this wrong is the single most damaging error
+  available here: an assessment against draft policy numbers, or against policies that a
+  later plan superseded, is worthless and visibly so.
+- **Quote the policy; never recall it.** Policy wording and numbering vary between councils
+  and between editions of the same plan, and draft numbering rarely survives adoption. Every
+  policy in the output must be quoted from the adopted document, with the document name,
+  adoption date and policy reference recorded.
+- **A score is a reasoned judgement, not a measurement.** It is a shorthand for an argument
+  that must be stated alongside it. A score with no quoted requirement and no evidence from
+  the application is not an assessment.
+- **Never total or average the scores.** Section 38(6) requires accordance with the
+  development plan **read as a whole**, which is a planning judgement, not arithmetic. One
+  -2 against a policy central to the proposal can outweigh five +1s on peripheral ones; the
+  reverse is also true. Presenting a sum or a mean would manufacture false objectivity —
+  and would let a genuinely fatal conflict be averaged away.
+- **Missing evidence is not conflict.** Where a policy requires something the application
+  has not supplied, the honest output is "cannot be assessed" (flagged `?`), not a negative
+  score. That distinction is what separates "the proposal conflicts with Policy X" from "the
+  Council cannot yet conclude whether it complies with Policy X" — a different ask entirely.
+- **Score the proposal against the policy, not against a preference.** Record accordance
+  where it exists, at full strength. An analysis that finds only conflict will be read as
+  advocacy and discounted.
+
+## Workflow
+
+### Step 1 — Identify and verify the adopted development plan (do this first)
+
+Work through
+[`references/finding-the-development-plan.md`](references/finding-the-development-plan.md).
+In outline:
+
+1. **Confirm the local planning authority.** Usually the district, borough or unitary
+   council — but a **National Park authority** or the Broads Authority is the LPA for its
+   own area, and a development corporation may be. In two-tier areas, **minerals and waste**
+   policy sits with the county council. The wrong LPA means the wrong plan.
+2. **Assemble the development plan.** Under s.38 of the Planning and Compulsory Purchase Act
+   2004 it comprises the **adopted development plan documents taken as a whole** plus any
+   **made** neighbourhood plan for the area; in Greater London it also includes the Mayor's
+   spatial development strategy (the London Plan). It is often **several documents** — a core
+   strategy plus a site-allocations and/or development-management document, sometimes a joint
+   plan, plus the county minerals and waste plans. ⏳ *Verify the composition against the
+   current statute at run time — see the reference file's note on pending reforms.*
+3. **Record the adoption date and status of each document**, and find the **schedule of
+   superseded and saved policies** — a new plan usually replaces only *some* of its
+   predecessor's policies. Never cite a policy without checking it has not been superseded.
+4. **Read the policies map** for the site: settlement boundary, allocations, designations
+   and constraints. The map is part of the plan and often decides which policies apply.
+5. **Note what is *not* the development plan** but may still be a material consideration:
+   supplementary planning documents, design guides and codes, conservation area appraisals,
+   council strategies, and emerging or withdrawn plans. Keep these in a separate tier.
+
+Output a short **plan register** — document, adoption date, status, where obtained — before
+assessing anything.
+
+### Step 2 — Fix the plan's status
+Record the plan's **age and review position**: its adoption date, the plan period, whether a
+review or replacement is underway, and whether the council can demonstrate the required
+housing land supply. This governs how much weight a conflict carries, and whether the
+**tilted balance** is engaged or disapplied — take that test from the
+**national-planning-policy** skill rather than restating it here. A conflict with a policy
+that is out-of-date still counts, but at reduced weight; say so rather than silently
+discounting it.
+
+### Step 3 — Select the relevant policies
+Use [`references/policy-families.md`](references/policy-families.md) to work from the proposal
+and site to the policy families that ought to exist in any local plan, then find each one in
+*this* plan. Two disciplines:
+
+- **Relevance, not volume.** Include a policy because it applies to this development, on this
+  site, at this scale — not to lengthen the list. Check each policy's own scope: many apply
+  only to a development type, size threshold or designated area.
+- **Flag the "most important" policies** for determining this application — the handful the
+  decision turns on (typically the spatial strategy or settlement-boundary policy, the
+  site-specific allocation or designation, and the principal topic policies). This phrase
+  matters: it is what the presumption in national policy turns on.
+
+### Step 4 — Assess each policy
+For each policy: quote the **requirement** in its own words, then state what the
+**application documents show**, then conclude. Reading discipline:
+
+- **Distinguish mandatory from permissive wording.** "Will not be permitted", "must" and
+  "will be required" are requirements; "should", "will be encouraged", "where possible" and
+  "have regard to" are weaker. The strength of the wording sets the ceiling on the score.
+- **Criterion-based policies are assessed criterion by criterion.** Where a policy permits
+  development only if a list of criteria is met, failing one is conflict with the policy even
+  if the rest are met — identify *which* criterion and why.
+- **Read the whole policy**, including any exception or flexibility limb the proposal might
+  rely on. Supporting text and the reasoned justification are not policy, but are legitimate
+  aids to interpreting it — label them as such.
+- **Designated areas raise the bar — score them that way.** In a conservation area, or where
+  a listed building or other designated heritage asset (or its setting) is affected, the
+  plan's character, design and scale policies are not ordinary detail policies: a statutory
+  duty and national policy's "great weight" stand behind them (take the citations and the
+  harm framework from the **heritage-representation** skill — s.66/s.72 and the NPPF heritage
+  tests live there). Two consequences for this skill's procedure: **(a)** assess the
+  **cumulative volume of physical change** quantitatively from the drawings — footprint,
+  depth, height, plot coverage, extensions and alterations taken together, measured against
+  the plot and its neighbours, not merely described; **(b)** where that change fails a
+  character or scale criterion of a policy applying to the designated area, treat the
+  conflict as going to the heart of the policy (-2 territory, and normally one of the "most
+  important" policies) rather than softening it to a tension because only one limb fails or
+  because each individual alteration looks modest.
+- **Mitigation that is not yet secured is not compliance.** If a policy's requirement is met
+  only by something a condition or obligation would have to secure, say so — that is a (C)
+  point, and it belongs in the score's reasoning.
+
+Evidence disciplines — habits observed in officer practice that the assessment must match:
+
+- **Audit the openings window-by-window.** Compare existing and proposed elevations opening
+  by opening: every new or altered window and door, which neighbour it faces, and whether it
+  creates overlooking a condition (obscure glazing, non-opening) would have to control. A
+  narrative read of the elevations misses exactly the opening the decision turns on.
+- **Sweep the site's planning history first, and assess against any fallback.** Check the
+  register for the site's (and close precedents') history before assessing: an extant
+  permission is the controlling baseline, and the assessment narrows to the **delta**
+  between it and the current proposal; past refusals and appeals on the site or its
+  immediate context are weight-bearing precedent.
+- **Measure against the neighbour as well as the plot.** Amenity geometry is relative:
+  projection beyond the neighbour's rear building line, orientation to their windows and
+  garden, and relative levels — computed from the drawings, not asserted.
+- **Verify the basic site facts from more than one source.** Attachment status (detached /
+  semi / terrace), plot orientation and constraints — state them with their evidence, and
+  check the council's own GIS/policies-map layers as well as national datasets; local
+  designations (minerals belts, ecology zones) often appear only on the council's layers.
+- **Read the representations.** Consultee responses and neighbour/third-party comments are
+  part of the evidence: they surface issues, site knowledge and precedents the application
+  documents omit (handle any personal data minimally).
+- **Consultee positions are evidence, not conclusions.** Re-derive each element's assessment
+  from the documents; decision-makers routinely depart from their own specialists in both
+  directions, and a consultee's general dispensation still has to survive the policy's own
+  wording at this site's scale.
+- **Prefer a condition to a refusal reason for separable detail.** Where an element is
+  acceptable in principle and only its detail is missing, the officer's instinct is to
+  reserve it by condition — a (C) point — not to refuse; reserve refusal reasons for harm.
+  Likewise a missing supporting document on a minor scheme is a proportionate-information
+  ask (B), not automatically a refusal reason.
+
+### Step 5 — Score
+Apply the rubric in [`references/scoring-rubric.md`](references/scoring-rubric.md):
+
+| Score | Meaning |
+|---|---|
+| **+2** | **Strongly aligned** — the proposal actively delivers what the policy seeks; every criterion met. |
+| **+1** | **Accords** — meets the policy's requirements; no material tension. |
+| **0** | **Neutral** — engaged but the proposal neither advances nor offends it. |
+| **-1** | **Tension / partial conflict** — fails part of a criterion-based policy, or is contrary to its aim in a limited or mitigable way. |
+| **-2** | **Significant conflict** — breaches a mandatory requirement, or a criterion central to the policy's purpose; conflict goes to the heart of the policy. |
+| **?** | **Cannot be assessed** — the policy is engaged but the application lacks the evidence the policy itself requires. **Not a negative score.** |
+
+Alongside each score record the **weight tier** (adopted development plan / reduced —
+out-of-date plan policy / national policy / emerging plan / guidance) and, where the
+downstream skills need it, the **A/B/C** classification the repo uses: **(A)** demonstrated
+unacceptable impact, **(B)** insufficient evidence, **(C)** resolvable by condition or
+obligation. Every `?` is a (B).
+
+### Step 6 — Add national and emerging policy, at their proper weight
+Assess the relevant **NPPF/PPG** policies and any **emerging plan** policies the same way,
+in a **separate section** of the table, explicitly marked as material considerations that
+carry **less weight than the adopted plan**:
+
+- **National policy** — a material consideration, influential but not above the plan. Verify
+  every edition and paragraph reference through the **national-planning-policy** skill before
+  citing; ⏳ the framework is under revision and paragraph numbers will not survive it.
+- **Emerging plans** — weight depends on the stage of preparation, the extent of unresolved
+  objections, and consistency with national policy. Record the stage and reason the weight;
+  an emerging policy at early consultation carries very little, and saying so is part of the
+  assessment.
+- **Guidance** (SPDs, design codes, technical standards) — weight as guidance that
+  supplements plan policy; it cannot create policy the plan does not contain.
+
+### Step 7 — Conclude on the plan read as a whole
+Write a short **accordance statement** (a paragraph or two): the plan documents that govern,
+the policies the proposal conflicts with and how seriously, the policies it accords with, the
+matters that cannot yet be assessed, and a reasoned conclusion on whether the proposal
+accords with the development plan **read as a whole** — with no arithmetic. Then say what
+follows: whether material considerations (national policy, emerging policy, the scheme's
+benefits) might indicate a decision otherwise than in accordance with the plan, and hand off
+to **planning-balance** for that weighing and to **policy-representation** for drafting.
+
+## Output format
+
+1. **Plan register** — the development plan documents, adoption dates, status, source.
+2. **Site's plan status** — designations from the policies map; allocation or settlement
+   position; plan age and review position.
+3. **Policy table** — one row per policy: reference · source document · weight tier · quoted
+   requirement · assessment (with the document evidence) · **score** · most-important flag ·
+   A/B/C.
+4. **A second table** for national and emerging policy, marked as lower-weight material
+   considerations.
+5. **Accordance statement** — the reasoned whole-plan conclusion, no totals.
+6. **Verification note** — what was checked, when, and what needs re-checking at run time.
+
+## Reference files
+
+- [`references/finding-the-development-plan.md`](references/finding-the-development-plan.md)
+  — how to identify and verify the adopted plan: what counts, where to look, the traps
+  (superseded policies, draft numbering, SPDs, the wrong LPA), and emerging-plan stages.
+- [`references/scoring-rubric.md`](references/scoring-rubric.md) — the -2 to +2 anchors with
+  worked illustrations, the evidence-gap flag, the weight tiers, and the no-aggregation rule.
+- [`references/policy-families.md`](references/policy-families.md) — the policy families to
+  look for by proposal type, and which skill owns each one's technical evaluation.
+
+## Scope and limitations
+
+- **Not legal advice, and no warranty.** Policy interpretation is ultimately for the
+  decision-maker, and contested wording is a matter for a planning professional or a
+  solicitor; provided "as is", with no guaranteed outcome.
+- **Human review is necessary before use.** A person must check every quoted policy against
+  the adopted document and every assessment against the application documents.
+- **England-focused.** The development-plan framework cited is England's; Wales, Scotland and
+  Northern Ireland differ — flag and adjust outside England.
+- **Evidence-bound.** Quote policies and application documents; never invent a policy
+  reference, a plan date or a requirement. Where the plan is unclear, say it is unclear.
+- **Time-sensitive.** Plans are adopted, superseded and reviewed continuously, and the
+  national framework is under revision — re-resolve the plan and re-verify every citation at
+  run time.
+- **A UK planning representation is public and in the submitter's name** — this skill produces
+  an analysis rather than a submission, but carry that warning through to
+  **policy-representation** or whichever skill drafts from it.
+- **"It complies" is a valid, valuable output.** So is "the plan is silent on this."

--- a/nppf-2024-12/policy-compliance-assessment/references/finding-the-development-plan.md
+++ b/nppf-2024-12/policy-compliance-assessment/references/finding-the-development-plan.md
@@ -1,0 +1,182 @@
+# Finding and verifying the adopted development plan
+
+The first step of the assessment, and the one that invalidates everything downstream if it is
+wrong. The goal is a short, sourced **plan register**: which documents make up the development
+plan for this site, when each was adopted, which policies in them are still live, and what the
+policies map says about the site.
+
+**Start from the right place.** Adopted policies are written, examined, adopted and published
+by the **local planning authority itself** — they live on that council's own website, and
+nowhere else is authoritative for them. Central government publishes the NPPF and PPG, which
+are *national* policy and a material consideration; they are not part of the development plan
+and cannot be substituted for it. So: the council's planning-policy pages for the policies that
+have primacy, and gov.uk only for the national tier that sits alongside them.
+
+## 1. What "adopted" means
+
+A development plan document is **adopted** when the local planning authority has formally
+resolved to adopt it, following submission, independent examination by an inspector, and any
+main modifications. Adoption is a dated, minuted event, and the council publishes the adopted
+document.
+
+**None of these is an adopted development plan policy:**
+
+| Not the development plan | What it is instead |
+|---|---|
+| A draft, "publication", submission or examination-stage plan | An **emerging** plan — a material consideration whose weight depends on its stage (see §6) |
+| A supplementary planning document (SPD) | Guidance that supplements adopted policy; it cannot create new policy |
+| A design guide or design code adopted as an SPD | Guidance (a code's status depends on how it was adopted — check) |
+| A conservation area appraisal / management plan | Evidence and guidance |
+| A masterplan, development brief or village design statement | Guidance, unless adopted as a DPD |
+| A council strategy (housing, climate, economic) | Corporate policy; at most a material consideration |
+| A neighbourhood plan not yet **made** | Emerging; weight rises after a successful referendum |
+| A withdrawn or superseded plan | Nothing — but check the saved-policies schedule (§4) |
+| The NPPF / PPG | National policy: a material consideration, not part of the plan |
+
+⏳ **Pending reform — check at run time.** Reforms to the plan-making system provide for
+**national development management policies** and for **supplementary plans** (intended to
+replace SPDs and to form part of the development plan). Whether either is in force, and what
+it does to the table above, must be checked at run time; do not assume the position stated
+here still holds. Confirm the current framework through the **national-planning-policy**
+skill.
+
+## 2. Confirm the local planning authority
+
+Get this right before searching for a plan:
+
+- Normally the **district, borough, city or unitary council** for the site.
+- A **National Park authority** or the **Broads Authority** is the LPA within its boundary —
+  its own local plan applies, not the surrounding district's.
+- A **development corporation** or similar body may be the LPA for a designated area.
+- In **two-tier areas**, the **county council** is the minerals and waste planning authority:
+  those plans are part of the development plan even though the district determines the
+  application.
+- In **Greater London**, the borough is the LPA and the Mayor's **spatial development
+  strategy** also forms part of the development plan; large schemes may be referable to the
+  Mayor.
+
+Where a site sits on or near a boundary, confirm which authority determines it — the
+application reference and the portal that hosts it are the practical answer.
+
+## 3. Assemble the plan — expect several documents
+
+Under s.38 of the Planning and Compulsory Purchase Act 2004 the development plan for an area
+is the **adopted development plan documents taken as a whole**, together with any
+**made** neighbourhood plan; in Greater London it also includes the spatial development
+strategy. ⏳ *Verify the current statutory wording at run time — and note that older
+reproductions of s.38 found online still carry a spent reference to regional strategies,
+which were revoked.*
+
+In practice, look for:
+
+- the **adopted local plan** — one volume, or a **core strategy / strategic policies**
+  document plus a **site allocations** and/or **development management policies** document;
+- an **older plan with saved policies** still in force alongside a partial replacement;
+- a **joint or strategic plan** covering several authorities;
+- the **minerals local plan** and **waste local plan** (county or unitary);
+- any **made neighbourhood plan** for the parish or neighbourhood area — check whether the
+  site falls inside a neighbourhood area at all;
+- in London, the **spatial development strategy**.
+
+Record each as a register row: *document name · adopted (date) · status · where obtained*.
+
+## 4. The two traps that break assessments
+
+**Superseded and saved policies.** When a council adopts a new plan it usually replaces only
+*some* of the predecessor's policies; the rest are "saved" and remain part of the development
+plan. The adopted plan carries a **schedule or appendix of superseded / saved policies** —
+find it and use it. Symptoms of getting this wrong: citing a policy the plan itself abolished,
+or missing a saved policy that is the only one addressing the point.
+
+**Draft numbering versus adopted numbering.** Policy numbers routinely change between the
+consultation and publication drafts and the adopted plan, and two plans in the same area can
+each contain a "Policy H1". Always take the reference from the **adopted** document, and
+record the document name alongside the number so the citation is unambiguous.
+
+Two lesser traps worth a check: policies can be **quashed or modified by the courts**, and a
+plan can be **partially superseded** by a later strategic plan.
+
+## 5. Read the policies map for the site
+
+The **policies map** (formerly the proposals map) is part of the plan and often determines
+which policies apply at all. For the application site, record:
+
+- whether it is **inside or outside the settlement boundary** / urban area;
+- any **allocation** (housing, employment, mixed use, safeguarded land) and its policy
+  reference and requirements;
+- **designations and constraints**: conservation area, Green Belt, National Landscape, local
+  green space, green wedge/gap, open space, employment area, town-centre boundary and primary
+  shopping area, local wildlife site, minerals safeguarding area, flood-risk policy area;
+- **neighbourhood plan** designations, which may sit on a separate map.
+
+Interactive map viewers are common; where one exists, prefer it for the site check but confirm
+the designation's policy reference in the adopted written document. National datasets
+(for example the public planning-data service and the flood map for planning) usefully
+corroborate designations but are **not** the plan.
+
+## 6. Emerging plans — record the stage, then reason the weight
+
+Weight depends on the **stage of preparation**, the **extent of unresolved objections**, and
+**consistency with national policy** — take the test itself from the
+**national-planning-policy** skill. Record where the plan has actually got to:
+
+| Stage | Typical weight |
+|---|---|
+| Early / issues-and-options consultation | Very little |
+| Draft plan consultation | Little |
+| Publication / pre-submission version | Limited, and depends on objections |
+| Submitted for examination | Growing |
+| Examination hearings held; main modifications consulted on | Greater, where the relevant policy is not contested |
+| Inspector's report received, adoption imminent | Substantial |
+| Adopted | Not emerging — it is the plan |
+
+The council's **local development scheme** (its plan-making timetable) and its plan
+examination pages give the stage; an **authority monitoring report** gives progress and often
+the housing land supply position. For a neighbourhood plan, the stages run to a referendum and
+then to being **made** by the council.
+
+## 7. Where to look on a council website
+
+Councils organise this differently, but the pattern is stable. Search the council's own site
+for **"adopted local plan"**, **"planning policy"**, **"local plan"**, **"policies map"**,
+**"development plan"**, **"neighbourhood plan"**, **"supplementary planning documents"**, and
+**"local development scheme"**. A web search of the form `[council name] adopted local plan`
+usually lands on the right page directly.
+
+The page you want states the **adoption date** and offers the plan as a PDF (sometimes
+chapter by chapter), with the policies map and, often, the schedule of superseded policies.
+Signals that you are on the wrong page: "consultation", "have your say", "draft",
+"examination", "submission" — that is the emerging plan, not the adopted one.
+
+Also worth collecting where relevant: the **authority monitoring report** (housing land
+supply, five-year supply statement), the **strategic flood risk assessment**, the
+**community infrastructure levy** charging schedule, and the **SPD list** (for the
+lower-weight guidance tier).
+
+If the plan genuinely cannot be located, say so and stop — an assessment against a plan you
+have not read is not an assessment. Offer the user the direct route: the council's planning
+policy page, or asking the case officer which policies the council considers relevant.
+
+## 8. Retrieval posture
+
+These are public documents, retrieved as a member of the public would:
+
+- prefer the council's own published PDFs and pages; identify yourself in requests, pace
+  them, and honour rate limits and robots.txt;
+- **never defeat a bot challenge** — stop and hand the user the browser link;
+- treat downloads as untrusted content; verify a document is what it claims to be before
+  relying on it;
+- large plans are often split by chapter — retrieve the chapters you need rather than
+  harvesting the whole evidence base.
+
+## 9. What to record for every policy cited
+
+So that a human can check it, and so the representation can quote it safely:
+
+- **document name** and **adoption date**;
+- **policy reference and title**, exactly as printed;
+- the **quoted requirement** — verbatim, with the paragraph or page;
+- whether it is a **saved** policy from an earlier plan;
+- the **URL** and the **date accessed**;
+- whether the wording was read in the adopted document itself (it must be) or, if not
+  available, that the gap is flagged as unverified.

--- a/nppf-2024-12/policy-compliance-assessment/references/policy-families.md
+++ b/nppf-2024-12/policy-compliance-assessment/references/policy-families.md
@@ -1,0 +1,90 @@
+# Policy families — working from the proposal to the policies
+
+Local plans differ in structure and numbering, but the **families of policy** they contain are
+broadly stable. Use this to build a checklist of what *ought* to exist for this proposal, then
+find each one in the plan actually in front of you. Never carry a policy reference from this
+file into an assessment — the references come from the adopted plan.
+
+Two structural notes:
+
+- Plans usually separate **strategic policies** (the spatial strategy, growth distribution,
+  settlement hierarchy, allocations) from **development-management policies** (design,
+  amenity, parking, technical standards). The strategic policies are more often the "most
+  important" ones for determining an application; the management policies are where detailed
+  compliance is judged.
+- A **made neighbourhood plan** sits alongside these with equal statutory standing, and often
+  contains the most site-specific policies of all — local character, protected views, local
+  green space, housing mix, and design detail. Always check whether the site is in a
+  neighbourhood area.
+
+## Start from the proposal type
+
+| Proposal | Families almost always engaged |
+|---|---|
+| Householder extension / alteration | Design and character · residential amenity · parking · trees · (heritage if designated) |
+| New dwelling(s) — minor | Spatial strategy / settlement boundary · housing mix · design · amenity · access and parking · drainage · biodiversity |
+| Major housing | All of the above plus affordable housing · housing density and mix · open space and play · education and infrastructure contributions · transport assessment and travel plan · flood risk and drainage · biodiversity net gain · climate and energy · self-build where the plan requires it |
+| Change of use | Spatial strategy · the policy protecting the existing use (employment land, retail frontage, community facility, agricultural land) · amenity · parking · town-centre policies |
+| Employment / industrial | Employment land allocation and protection · access and servicing · amenity (noise, hours, lighting) · design · drainage · biodiversity |
+| Retail / town centre | Town-centre hierarchy and the sequential and impact approach · frontage and use-mix policies · shopfront design · parking and servicing |
+| HMO / student / build-to-rent | Any concentration or mix policy · amenity and standards · waste storage · parking · design |
+| Rural / agricultural | Countryside protection · agricultural land quality · rural workers' dwellings · farm diversification · landscape character · dark skies where the plan has one |
+| Renewable energy | Climate and renewable energy policies · landscape and visual impact · heritage setting · biodiversity · residential amenity |
+| Telecommunications / advertisements | The specific policy family · amenity · heritage and design |
+| Minerals or waste | The county or unitary minerals and waste plans (a separate part of the development plan) · safeguarding areas |
+| Listed building consent / conservation area | Heritage policies, with the statutory duties — see the heritage skill |
+
+Also check, for any proposal: whether the site is **allocated** (the allocation policy's own
+requirements are directly engaged, and often detailed), and whether any **site-specific** or
+area-based policy applies from the policies map.
+
+## The families
+
+| Family | Typically titled / covers | Engaged when | Technical evaluation owned by |
+|---|---|---|---|
+| **Spatial strategy / settlement boundary** | Development strategy, settlement hierarchy, growth distribution, "development in the countryside" | Almost always — and decisive where the site is outside a defined boundary | This skill (the plan question) |
+| **Site allocations** | Allocation policies with site-specific requirements and capacities | Site is allocated, or is being developed contrary to an allocation | This skill |
+| **Housing supply, mix and density** | Housing requirement, mix of types and tenures, density, specialist and older persons' housing, space standards | Any residential proposal | This skill |
+| **Affordable housing** | Proportion, tenure split, thresholds, off-site or commuted sums, viability | Residential above the plan's threshold | This skill (delivery and securing → obligation tests) |
+| **Design and local character** | Design quality, character and appearance, scale, massing, materials, layout, local design codes | Almost always | This skill; design guides sit in the guidance tier |
+| **Residential amenity** | Overlooking, privacy, overshadowing, overbearing impact, noise, light, hours, outlook and daylight standards | Development near existing homes, or creating homes | This skill |
+| **Heritage** | Listed buildings, conservation areas, scheduled monuments, archaeology, non-designated assets, setting | Designated asset or its setting affected; archaeological potential | **heritage-representation** |
+| **Transport, access and parking** | Sustainable transport, highway safety, access standards, parking and cycle standards, travel plans, servicing | Any development generating movement | **transport-representation** |
+| **Flood risk and drainage** | Flood zones, sequential approach, surface-water drainage and SuDS, water quality, foul drainage | Site in a flood-risk area, or any material increase in impermeable area | **flood-representation** |
+| **Biodiversity and green infrastructure** | Protected species and habitats, designated wildlife sites, net gain, green corridors, trees and hedgerows | Almost always for greenfield; frequently for brownfield | **ecological-representation** |
+| **Trees and landscape** | Protected trees, hedgerows, landscape character, important views, gaps between settlements | Trees on or adjoining the site; sensitive landscape | This skill (with the ecology skill on habitat value) |
+| **Open space, sport and recreation** | Provision standards, protection of existing open space, play space, allotments | Residential of any scale; any loss of open space | This skill |
+| **Green Belt** | Inappropriate development, openness, exceptions, very special circumstances | Site within the Green Belt — a gateway, not a balance | This skill (test) with **planning-balance** |
+| **Designated landscapes** | National Landscapes / National Parks, local landscape designations | Site within or affecting the setting of a designation | This skill |
+| **Employment land** | Protection and allocation of employment sites, loss of employment floorspace, rural employment | Loss or provision of employment use | This skill |
+| **Town centres and retail** | Centre hierarchy, sequential and impact approach, primary frontages, use mix, hot food and betting policies where present | Retail, leisure or main town-centre uses outside a centre | This skill |
+| **Community facilities** | Protection of pubs, shops, halls, schools, health facilities | Loss of, or need for, a facility | This skill |
+| **Climate change, energy and sustainable construction** | Carbon reduction, renewable energy, energy efficiency, overheating, water efficiency, electric vehicle charging | Increasingly, any new build | This skill |
+| **Pollution, contamination and land stability** | Air quality, noise, light, contaminated land, agricultural land quality | Sensitive receptors, previously developed land, air-quality management areas | This skill |
+| **Infrastructure and developer contributions** | Contributions, the levy, education, health, transport infrastructure, viability | Development generating infrastructure need | This skill (with the obligation tests) |
+| **Advertisements, shopfronts, telecoms** | Signage and shopfront design, mast siting | The relevant application type | This skill |
+| **Minerals and waste** | Safeguarding areas, waste capacity, restoration | Site in a safeguarding area, or a minerals/waste proposal | This skill |
+
+## Applying the checklist
+
+1. **Build the expected list** from the proposal type and the site's designations.
+2. **Find each family in the plan** — search the plan's contents and policy index for the
+   family's usual language. Record the actual policy reference and title.
+3. **Test each for scope** before including it: many policies apply only above a size
+   threshold, to a use class, or within a designated area. A policy that does not bite is
+   omitted, with a line in the verification note.
+4. **Note the gaps.** Where the plan has **no policy** in a family the proposal plainly
+   engages, that is a finding in itself: national policy and any guidance then carry the
+   argument, and the absence may be a sign the plan is out-of-date on that topic. Say so
+   rather than stretching an unrelated policy to cover it.
+5. **Do not stretch a policy.** Using an amenity policy as a proxy for a topic the plan does
+   not address invites the reply that the policy does not say what is claimed — and costs
+   credibility on the policies that do fit.
+
+## Boundary with the topic skills
+
+For the four families with a dedicated skill — heritage, transport, flood, ecology — this
+skill establishes **which policy applies and what it requires**, and the topic skill evaluates
+**whether the applicant's technical evidence satisfies it**. Run both: a policy conflict
+asserted without the technical evaluation is thin, and a technical criticism with no policy
+hook is weaker than it needs to be. Do not duplicate the topic catalogues here.

--- a/nppf-2024-12/policy-compliance-assessment/references/scoring-rubric.md
+++ b/nppf-2024-12/policy-compliance-assessment/references/scoring-rubric.md
@@ -1,0 +1,185 @@
+# Scoring rubric — accordance from -2 to +2
+
+The score is a **shorthand for an argument**, not a measurement. It exists so a reader can see
+at a glance where the proposal stands against each policy, and so the drafting skill can lead
+on the points that carry weight. It never replaces the reasoning, and it is never added up.
+
+## The scale
+
+### +2 — Strongly aligned
+The proposal actively delivers what the policy seeks, not merely avoids offending it. Every
+criterion is met, and the policy's own objective is advanced.
+
+*Signals:* the proposal is the type of development the policy positively promotes, on a site
+the plan allocated for it; it exceeds a policy standard (a higher affordable-housing
+proportion, biodiversity gain above the required minimum); the policy's supporting text
+describes the very outcome proposed.
+
+*A +2 needs:* the quoted policy aim, and the evidence from the application that the aim is
+delivered — a figure, a plan reference, a commitment capable of being secured.
+
+### +1 — Accords
+The proposal meets the policy's requirements. There is no material tension; it simply complies.
+
+*Signals:* each criterion is satisfied on the submitted evidence; a technical standard is met;
+a statutory consultee is content on the matter the policy addresses.
+
+*Note:* most policies in a competent application score +1. Recording that honestly is what
+makes the negatives credible.
+
+### 0 — Neutral
+The policy is relevant enough to list, but the proposal neither advances nor offends it.
+
+*Signals:* the policy is a general or strategic statement the proposal is indifferent to; the
+policy's requirement is not triggered at this scale but the policy is worth recording as
+considered.
+
+*Do not use 0 as a hiding place.* If a policy is genuinely not engaged, leave it out and say
+why in the verification note. If it is engaged but unassessable, use `?`.
+
+### -1 — Tension or partial conflict
+The proposal fails part of what the policy requires, or is contrary to its aim in a limited
+way, but the conflict is not central to the policy's purpose or is capable of being resolved.
+
+*Signals:* one criterion of a multi-criterion policy is not met while the rest are; the policy
+uses permissive wording ("should", "will be encouraged") and the proposal falls short of it;
+compliance depends on mitigation that is not yet secured; the shortfall is against a standard
+rather than a principle.
+
+*A -1 needs:* the specific criterion or expectation identified, quoted, and the document
+evidence of the shortfall.
+
+### -2 — Significant conflict
+The conflict goes to the heart of the policy: a mandatory requirement is breached, or a
+criterion central to the policy's purpose is failed, or the proposal is of a type the policy
+says will not be permitted in this location.
+
+*Signals:* "will not be permitted" / "must" / "will be refused" wording engaged directly;
+development outside a settlement boundary where the policy restricts it and no exception limb
+applies; a use the plan protects being lost; an allocation's core requirement not delivered;
+a designated area's protective policy engaged with no policy exception met; a character or
+scale criterion failed **within a conservation area** or affecting another designated
+heritage asset, where the statutory duty and national "great weight" policy stand behind the
+plan policy.
+
+*A -2 needs:* the mandatory wording quoted, the applicable exception limbs examined and shown
+not to apply, and the document evidence of the breach. **If the exception limbs have not been
+checked, the score is not yet a -2.**
+
+### `?` — Cannot be assessed
+The policy is engaged, but the application does not contain the evidence the policy itself
+requires, so compliance can be neither confirmed nor denied.
+
+*Signals:* the policy requires an assessment, statement or survey that is absent; the
+submitted document does not address the policy's test; a consultee has asked for information
+that has not yet been provided.
+
+**`?` is not a negative score, and must never be presented as one.** It supports a different
+ask — that the application not be determined until the information is before the council. Every
+`?` is a **(B)** in the repo's A/B/C classification.
+
+## Calibration tests
+
+Two decisions cause most of the error. Apply these:
+
+**-1 or -2?** Ask: *if this were the only policy in the plan, would the proposal fail on it?*
+If yes — the conflict alone would justify refusal under that policy — it is a -2. If the
+policy would be pressed but not defeated, or mitigation could resolve it, it is a -1. Also
+check the wording ceiling: a policy expressed as encouragement can rarely support a -2.
+
+*Designated-area uplift:* run this test **with the statutory context in**. In a conservation
+area (or affecting a listed building or other designated heritage asset), a character or
+scale policy carries a statutory duty and national "great weight" behind it, so a conflict
+that would read as a pressed-but-not-defeated -1 on an undesignated site is routinely
+refusal-strength there — decision-makers regularly refuse on such a conflict alone. Judge the
+**cumulative volume of change** from measured drawings, not the modesty of each element, and
+do not discount to -1 merely because only one criterion of the policy fails.
+
+**0 or +1?** Ask: *did the proposal have to do something to satisfy this policy?* If yes and it
+did, that is +1. If the policy simply does not bite, 0 — or omit it.
+
+**-1 or `?`** Ask: *am I saying the proposal falls short, or that I cannot tell?* If the
+shortfall is shown in the documents, score it. If the documents are silent on a matter the
+policy requires them to address, that is `?`.
+
+**+1 or +2?** A +2 is for positive delivery of the policy's objective, not for competent
+compliance. If the honest description is "complies", it is +1.
+
+## Weight tiers — record alongside every score
+
+A score says how the proposal stands against a policy; the tier says how much that matters.
+Keep them in separate columns and never merge them.
+
+| Tier | What it covers | Standing |
+|---|---|---|
+| **Development plan** | Adopted local plan (and saved policies), made neighbourhood plan, minerals and waste plans, London's spatial development strategy | The statutory starting point — determination in accordance with it unless material considerations indicate otherwise |
+| **Development plan — reduced** | An adopted policy that is out-of-date (time-expired, or overtaken in substance by national policy) | Still part of the plan; conflict still counts, at reduced weight — state the reason for the reduction |
+| **National policy** | NPPF / PPG | Material consideration; influential, not above the plan. Verify edition and references through the **national-planning-policy** skill |
+| **Emerging plan** | Plan or neighbourhood plan not yet adopted / made | Material consideration; weight per stage, unresolved objections and consistency with national policy — record the stage |
+| **Guidance** | SPDs, design guides and codes, technical standards, appraisals | Supplements adopted policy; cannot create policy the plan does not contain |
+
+The order of that table is the hierarchy, and it is not negotiable: the **local authority's own
+adopted policies come first** and carry primacy, and the nationally published tiers sit beneath
+them as material considerations. A `-2` against an adopted plan policy is a more serious finding
+than a `-2` against an emerging or national one, and the output must make that visible rather
+than leaving a reader to weigh the rows equally.
+
+Also flag, per policy, whether it is one of the **most important policies for determining the
+application**. That set — usually the spatial strategy or settlement-boundary policy, the site
+allocation or designation, and the principal topic policies — is what the national presumption
+turns on, so mark it rather than leaving it implicit.
+
+## The no-aggregation rule
+
+**Do not total, average, or weight-and-sum the scores.** Section 38(6) asks whether the
+proposal accords with the development plan **read as a whole** — a planning judgement about
+the plan's strategy and the significance of each conflict, not a calculation.
+
+Why it matters, concretely: a proposal scoring `+1` on eight detailed policies (parking
+standards, refuse storage, boundary treatment, materials…) and `-2` on the settlement-boundary
+policy has a positive mean and is very likely contrary to the plan as a whole, because the
+one conflict defeats the plan's spatial strategy while the eight compliances are matters of
+detail. An arithmetic summary would invert the answer, and any planning officer reading it
+would discount the whole analysis.
+
+What to produce instead: an **accordance statement** naming the conflicts that matter, why
+they matter to the plan's strategy, what the proposal complies with, and what cannot yet be
+assessed — with a reasoned conclusion. It is legitimate to say "the position is finely
+balanced" where it is.
+
+Counting is allowed only as description ("three policies are engaged, two of them
+significantly in conflict"), never as the conclusion.
+
+## Output table
+
+One row per policy. Quote requirements; keep the assessment to a sentence or two with its
+evidence.
+
+| Policy | Source (adopted) | Tier | Requirement (quoted) | Assessment (evidence) | Score | Most important | A/B/C |
+|---|---|---|---|---|---|---|---|
+| `[Policy ref]` *settlement boundary* | `[Plan name]`, adopted `[date]` | Development plan | "Development outside the settlement boundary will not be permitted unless …" | Site lies outside the boundary on the policies map; none of the exception limbs (a)–(e) is engaged — see Planning Statement §`[x]` | **-2** | Yes | (A) |
+| `[Policy ref]` *design and character* | `[Plan name]`, adopted `[date]` | Development plan | "Proposals must respond to the character of the area in scale, form and materials" | Three storeys against a two-storey street frontage; Design and Access Statement §`[x]` does not address scale | **-1** | Yes | (A)/(C) |
+| `[Policy ref]` *biodiversity* | `[Plan name]`, adopted `[date]` | Development plan | "Development must deliver a measurable net gain in biodiversity" | No biodiversity metric submitted; the policy's requirement cannot be tested | **?** | No | (B) |
+| `[Policy ref]` *affordable housing* | `[Plan name]`, adopted `[date]` | Development plan | "Schemes of `[n]` or more dwellings will provide `[x]`% affordable housing" | `[x]`% offered, matching the requirement; not yet secured by obligation | **+1** | Yes | (C) |
+| `[Policy ref]` *parking* | `[Plan name]`, adopted `[date]` | Guidance-backed standard | "Parking will be provided in accordance with the adopted standards" | Provision meets the standard for the proposed mix | **+1** | No | — |
+
+Keep national and emerging policy in a **second table** with the same columns, so the
+lower-weight tier is visible on the page rather than mixed into the plan's rows.
+
+## Common scoring errors
+
+- **Averaging** — the error the rule above exists to prevent.
+- **Scoring an evidence gap as a conflict** — inflates the case and collapses under scrutiny.
+- **A -2 without checking the exception limbs** — most restrictive policies have them.
+- **Under-scoring a designated-area conflict** — softening a character/scale breach in a
+  conservation area (or affecting another designated heritage asset) to -1 because only one
+  criterion fails or each alteration looks small; the statutory duty makes the cumulative
+  change the test.
+- **Citing a superseded policy** — check the saved/superseded schedule first.
+- **Scoring the supporting text** — the policy is what is in the policy box.
+- **Listing every policy in the plan** — relevance, not volume; a padded table hides the
+  points that matter.
+- **All-negative tables** — if nothing scores positive, check whether the assessment has
+  become advocacy.
+- **Scores without quotes** — an unquoted requirement cannot be checked by a human, which is
+  the whole point of the table.

--- a/nppf-2024-12/policy-representation/CHANGELOG.md
+++ b/nppf-2024-12/policy-representation/CHANGELOG.md
@@ -1,0 +1,72 @@
+# Changelog — policy-representation
+
+Design decisions per revision, newest first. See `../CLAUDE.md` for the format and the house
+rules. The **_Why_** lines record the rationale so a future editor understands the intent.
+
+## 0.1.0 — 2026-08-17 — Initial release
+
+### Added
+- **The skill itself: a policy-led representation drafter taking `policy-compliance-assessment`'s
+  scored table as input.** _Why:_ the four topic representation skills draft on a *technical*
+  ground (ecology, transport, heritage, flood) and each owns its own deficiency catalogue. None
+  of them drafts the **policy case** — conflict with, or accordance with, named adopted
+  development-plan policies — which is the strongest kind of point a representation can make and
+  the one a case officer must address in the report. Splitting the analysis (previous skill) from
+  the drafting (this skill) also lets the user review the policy findings before any letter
+  exists.
+- **Support as a first-class stance, not an afterthought.** Both skeletons, both worked examples
+  and the house-style rules cover support and objection at the same standard. _Why:_ the repo
+  had only ever drafted objections, and a support letter is not an objection with the polarity
+  flipped — it needs a declaration of interest, an "objections answered" section, and asks for
+  conditions that *secure the benefits relied on*. Treating support as a trivial inversion would
+  produce the kind of content-free "I think this is a good scheme" letter that councils rightly
+  disregard.
+- **The stance/evidence split as the governing principle:** the stance is the user's to choose,
+  the evidence is not. Includes a mismatch check before drafting and three honest routes when the
+  requested stance runs against the analysis (draft the supportable points only; adopt a fitting
+  hybrid stance; the opposite stance). _Why:_ a representation belongs to the person submitting
+  it, so refusing to draft a stance would be the wrong call — but so would inventing a policy
+  case to fit it. Naming the tension and resolving it procedurally keeps both the user's autonomy
+  and the repo's evidence discipline intact. It also mirrors the existing skills' posture that
+  "don't object" is a valid output, extended to "the policies don't support the letter you want".
+- **A rule that no point may overstate its score**, with `?` (cannot be assessed) never written
+  as a demonstrated breach and `-1` never written as a mandatory-requirement failure. _Why:_ the
+  scoring rubric's honesty is only worth having if it survives the trip into prose; this is where
+  a careful analysis would otherwise be inflated at the last step.
+- **A "declare an interest" rule for support letters** (applicant, agent, relative, employee,
+  prospective purchaser, competitor, campaign involvement) and an explicit instruction to write in
+  the user's own words rather than submit a circulated template. _Why:_ undisclosed interests and
+  identical form letters are the recognised failure modes of support campaigns, and both get the
+  representation discounted when noticed. Declaring the interest costs nothing and protects the
+  weight of everything else in the letter.
+- **A "the other side, answered" section required in both stances.** _Why:_ a representation that
+  argues only one way reads as advocacy. In objection, engaging the claimed benefits (and noting
+  which are unsecured or unquantified) is itself strong material; in support, answering the
+  objections is the only thing that makes the letter useful to the officer.
+- **The three-to-six point limit, with `0`s and peripheral `-1`s dropped.** _Why:_ the analysis is
+  deliberately comprehensive; the letter must not be. Filler dilutes the points that decide the
+  application, and a padded representation signals that the writer cannot tell which policies
+  matter.
+- **Development plan policies lead; national policy supports; emerging policy leads only where
+  nothing adopted covers the point.** _Why:_ the adopted plan has primacy, and a representation
+  that opens on the NPPF while the local plan sits in the background inverts the statutory
+  hierarchy — and invites the reply that the writer has not read the plan.
+- **The ask table mapped onto `planning-balance`'s outcomes** (grant / grant with conditions /
+  refuse / do not determine yet). _Why:_ the two skills must not give the user different
+  vocabularies for the same conclusion, and the A/B/C classification already flows from the
+  analysis through to the ask.
+
+### Changed
+- **No citations of its own: NPPF/PPG references, the presumption and the conditions and
+  obligations tests are taken from `national-planning-policy` at run time.** _Why:_ two-layers
+  house rule, and the drafting stage is exactly where a stale paragraph number would do the most
+  damage — the check list requires run-time verification before the draft leaves the skill.
+- **Reference files kept to two (`house-style.md`, `representation-templates.md`) rather than
+  cloning the four-file topic-skill layout.** _Why:_ this skill has no deficiency catalogue and no
+  topic guidance catalogue to own — the policies come from the council's plan as per-instance data
+  and the national layer lives elsewhere, so a `deficiency-catalogue.md` and a
+  `national-guidance.md` would have nothing legitimate in them.
+- **`representation-templates.md` (plural) rather than the family's `objection-template.md`.**
+  _Why:_ the file holds two skeletons and two worked examples because the skill has two stances;
+  the singular name would have understated the support path and invited a future editor to treat
+  it as secondary.

--- a/nppf-2024-12/policy-representation/LICENSE
+++ b/nppf-2024-12/policy-representation/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ian Howard
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/nppf-2024-12/policy-representation/README.md
+++ b/nppf-2024-12/policy-representation/README.md
@@ -1,0 +1,40 @@
+# policy-representation
+
+Draft the representation that actually gets sent — **in support or in objection, as the user
+chooses** — built on the policy analysis from
+[`policy-compliance-assessment`](../policy-compliance-assessment/).
+
+It takes the scored policy table and turns the policies that carry weight into a concise,
+evidenced letter:
+
+- **each point anchored twice** — to a quoted requirement from the **adopted** development plan
+  (named, with its adoption date), and to the application's own documents for the facts;
+- **led by the policies that decide applications** — the spatial strategy or settlement-boundary
+  policy, the site's allocation or designation, the principal topic policies — with national
+  policy in support rather than in the lead, and any emerging policy at its stated weight;
+- **the other side acknowledged and answered** — in objection, the policies complied with and the
+  benefits claimed; in support, the objections made and the conflicts the analysis found;
+- **a clear ask** — grant, grant subject to specified conditions, refuse, or *do not determine
+  yet* where a policy requirement cannot be assessed on the evidence submitted.
+
+This is the only skill in the repo that drafts **support** as well as objection, and it holds
+both to the same standard.
+
+## Stance and integrity
+
+**The stance is the user's to choose; the evidence is not.** The skill drafts what the user asks
+for, using only what the analysis supports. It will not manufacture policy compliance or
+conflict, overstate a score, misquote a policy, or present a gap in the evidence as a
+demonstrated breach. Where the requested stance runs against the analysis it says so plainly and
+offers the honest routes — draft on the supportable points only, adopt a stance that fits
+(*support subject to conditions*, *no objection but requesting conditions*, *objection limited to
+named policies*), or the opposite stance — then follows the user's decision.
+
+Support letters carry two extra rules: **declare any interest** (applicant, agent, relative,
+employee, prospective purchaser, competitor, campaign involvement), and **write in your own
+words** — circulated identical letters are recognised and given little weight.
+
+> **Not legal advice. No warranty. England only.** Output requires human review before
+> submission, and a UK planning representation is normally **published on the council's portal in
+> the submitter's name** and kept on the record — so it should contain only personal details the
+> user is content to make public. See the repo README for the full disclaimer.

--- a/nppf-2024-12/policy-representation/SKILL.md
+++ b/nppf-2024-12/policy-representation/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: policy-representation-nppf-2024-12
+description: >-
+  ARCHIVED - December 2024 NPPF edition (superseded 17 August 2026). Use only when the user explicitly asks to work under the pre-August-2026 framework and has confirmed they want the archived skills; outputs must state they cite a superseded framework. 
+  Draft a policy-led representation on a UK planning application — in **support**
+  or in **objection**, as the user chooses — from a policy compliance assessment.
+  Each point is anchored to a quoted adopted development-plan policy and to the
+  application's own documents, the other side is acknowledged, and the ask is
+  clear (grant, grant subject to conditions, refuse, or do not determine yet). Will
+  not manufacture policy compliance or conflict to fit a stance, and flags any
+  mismatch between the stance and the evidence. Use for "write a letter of
+  support", "draft an objection based on the policies", "write my representation".
+  England-focused. Not legal advice; no warranty; output requires human review,
+  and a representation is normally published in the submitter's name.
+license: MIT
+---
+
+# Policy representation — support or objection
+
+Turn a policy analysis into the letter that actually gets sent. This skill takes the scored
+policy table from **policy-compliance-assessment** and drafts a representation that a case
+officer can lift into the officer report — **in support or in objection, according to the
+user's choice**.
+
+It is the only skill in this repo that drafts **support** as well as objection, and the
+discipline is the same either way: every point anchored to a quoted policy and to the
+application's own documents, the other side acknowledged, and an ask the analysis can carry.
+
+## When to use
+
+The user has a policy analysis (or the material for one) and asks: "write my representation",
+"draft a letter of support for this application", "draft an objection based on the local plan
+policies", "put this into a letter I can send to the council".
+
+Run **after** `policy-compliance-assessment`. If no policy analysis exists yet, run that skill
+first — this one does not assess policy, and a representation asserting policy conclusions that
+have not been worked through is precisely the thing councils discount.
+
+Not this skill: the four topic representation skills (`ecological-`, `transport-`, `heritage-`,
+`flood-representation`) draft **objections on their own technical grounds** and own the
+deficiency analysis for those topics. Where they have run, integrate their points here rather
+than restating them — or let them stand as their own representation and use this skill for the
+policy case.
+
+## What you need first
+
+- The **policy analysis** — the plan register, the scored policy table (with quoted
+  requirements, the evidence, the weight tiers and the A/B/C classification), and the
+  accordance statement. This is the skill's raw material.
+- The **user's chosen stance** — support or objection (see the next section before accepting
+  it).
+- The **application details** — reference, site address, proposal description, council, and the
+  case officer's name if known.
+- The **application documents** for the facts each point relies on, quoted.
+- The **consultation deadline** and the **submission route** — normally the comment form on the
+  council's planning portal, or an email quoting the application reference. Note that material
+  considerations can be raised at any time before the application is determined, so a missed
+  consultation deadline is not necessarily the end.
+- **Anything from `planning-balance`**, if it has run — its four outcomes map directly onto the
+  ask this skill states.
+- What the user is willing to make **public** (see the publication warning below).
+
+## Stance and integrity (read before drafting)
+
+**The stance is the user's to choose. The evidence is not.**
+
+A representation is the user's own; they are entitled to support or oppose an application for
+their own reasons, and this skill drafts what they ask for. What it will not do is invent the
+policy case for it.
+
+- **Only make points the analysis supports.** Every point must trace to a policy in the table,
+  with its quoted requirement and its evidence. No point may overstate a score — a `-1` tension
+  is not written as a breach, and a `+1` compliance is not written as a positive benefit.
+- **Never manufacture compliance or conflict**, misquote a policy, quote a requirement out of
+  its exception limbs, or present an unassessable point (`?`) as a demonstrated one.
+- **Where the requested stance runs against the analysis, say so plainly, then offer the
+  honest routes.** Set out which points do and do not support the stance, and offer:
+  1. draft on the supportable points only, with the mismatch stated to the user (and, where
+     integrity requires, acknowledged in the letter itself);
+  2. a stance that fits the evidence better — *support subject to conditions*, *no objection but
+     requesting conditions*, or *objection limited to named policies*;
+  3. the opposite stance.
+  Then follow the user's decision, and draft it properly.
+- **Do not hide the other side.** An objection that ignores the policies the scheme complies
+  with, or a letter of support that ignores a `-2` conflict, invites the reply that the writer
+  has not read the plan. Acknowledging and answering the contrary point is what makes a
+  representation credible.
+- **Declare an interest.** If the user is the applicant, their agent, a relative, an employee, a
+  competitor, a prospective purchaser, or is writing as part of an organised campaign, the
+  representation should say so. Undisclosed interests and identical template letters are
+  discounted when spotted — and rightly.
+- **Write in the user's own words.** The templates are skeletons, not text to submit verbatim.
+  A representation in the writer's own voice, on this application's facts, carries weight that a
+  circulated form letter does not.
+- **A representation is public.** In the UK it is normally **published on the council's portal
+  in the submitter's name** and kept on the record. Names are usually published; addresses,
+  emails and signatures are usually redacted, but practice varies — so include only personal
+  detail the user is content to see published, and say this before they send.
+
+## Workflow
+
+### Step 1 — Intake and confirm the stance
+Take the policy analysis and the stance. Before drafting, run the **mismatch check**: does the
+weight of the analysis point the same way as the requested stance? If not, apply the integrity
+routes above and settle the stance with the user before writing.
+
+### Step 2 — Select the points to lead on
+A representation is not the policy table restated. Choose **three to six points**, ordered by
+force:
+
+- lead with the highest-magnitude scores (`-2` / `+2`) on policies flagged **most important**;
+- include a `?` point where the gap is material — it carries the "do not determine yet" ask;
+- drop `0`s, and drop `-1`s on peripheral policies. Filler dilutes; a short letter making three
+  policy points well beats a long one making eleven.
+- prefer **development plan** policies to national or emerging ones. Where the plan carries the
+  point, national policy is support, not the lead — and an emerging policy leads only where
+  nothing adopted covers the matter, with its limited weight stated.
+
+### Step 3 — Build each point
+One point per numbered section, each with the same anatomy (see
+[`references/house-style.md`](references/house-style.md)):
+
+1. **The conclusion as the heading** — "The proposal conflicts with Policy `[ref]`…" or "The
+   proposal accords with Policy `[ref]`…".
+2. **The policy requirement, quoted**, with the plan name and adoption date.
+3. **The fact, from the application's own documents** — quoted, with the document, author, date
+   and paragraph or drawing reference.
+4. **The conclusion, reasoned** — why the fact does or does not satisfy the requirement.
+5. **The ask**, if the point carries one.
+
+### Step 4 — Answer the other side
+- **In objection:** acknowledge the policies the scheme complies with and the benefits it
+  claims, then explain why the conflicts nevertheless outweigh them. Where a benefit is
+  unsecured or unquantified, say so — with the applicant's own document quoted.
+- **In support:** acknowledge the principal objections and the conflicts the analysis found,
+  then explain why they are outweighed, are matters of detail, or can be secured by condition.
+  Support that engages with the objections is far more useful to a case officer than support
+  that does not.
+
+Frame both against the statutory starting point — determination in accordance with the
+development plan unless material considerations indicate otherwise — and take the current
+citations, including whether the presumption in national policy is engaged, from the
+**national-planning-policy** skill. Do not cite an NPPF paragraph number that has not been
+verified at run time.
+
+### Step 5 — State the ask
+The ask must be one the analysis can carry, and consistent with **planning-balance** where it
+has run:
+
+| Stance | Available asks |
+|---|---|
+| **Support** | Grant permission · grant subject to specified conditions or obligations securing the benefits relied on |
+| **Objection** | **Refuse**, where the analysis shows demonstrated conflict (A) · **do not determine yet**, where material policy requirements cannot be assessed on the submitted evidence (B) · **grant only subject to specified conditions**, where the point is resolvable (C) |
+
+Conditions and obligations asked for must themselves be capable of meeting the statutory tests
+— take those from the **national-planning-policy** skill. Over-asking (refusal where a
+condition would plainly do) weakens the whole representation.
+
+### Step 6 — Draft
+Draft to [`references/house-style.md`](references/house-style.md) and the matching skeleton in
+[`references/representation-templates.md`](references/representation-templates.md): header →
+RE line → opening (consultation status, stance, request to be placed on the file) → the policy
+framework as a short bulleted list → numbered points → the other side answered → numbered
+**summary of requests** → the stance sentence → sign-off.
+
+### Step 7 — Check before sending
+- Every policy quoted is from the **adopted** document, with its name, adoption date and
+  reference — and matches the analysis.
+- Every fact is quoted from an application document, correctly referenced.
+- No point overstates its score; no `?` is written as demonstrated; no `-1` is written as a
+  breach.
+- The other side is acknowledged and answered.
+- The stance, the points and the ask are consistent with each other.
+- Any **interest is declared**; the text is in the user's own words, not a form letter.
+- The ask is concrete, correctly timed ("before determination"), and passes the conditions and
+  obligations tests where it asks for them.
+- Any NPPF/PPG citation has been verified at run time against the current edition.
+- The **submission route and deadline** are given to the user.
+- **Hand back to a human, with the two warnings:** the draft must be read and checked, and
+  submitting it puts a **public document in the user's name** on the council's portal.
+
+## Reference files
+
+- [`references/house-style.md`](references/house-style.md) — how a strong policy-led
+  representation reads, in either stance: voice, structure, the anatomy of a policy point, and
+  the moves specific to support and to objection.
+- [`references/representation-templates.md`](references/representation-templates.md) — two
+  skeletons (objection and support) with condensed, annotated worked examples.
+
+## Scope and limitations
+
+- **Not legal advice, and no warranty.** A drafting aid for a lay representation; not a
+  substitute for a solicitor or a planning consultant; guarantees no outcome; provided "as is".
+- **Human review is necessary before submitting.** A person must check every quotation, policy
+  reference and figure against the actual documents.
+- **A UK planning representation is a public document in the submitter's name** — normally
+  published on the council's portal and kept on the record. Include only personal details the
+  user is content to make public.
+- **England-focused.** The policy framework cited is England's; flag and adjust elsewhere.
+- **Evidence-bound and stance-honest.** The user chooses the stance; the skill does not bend
+  the evidence to it, and says so when the two do not match.
+- **"The policies don't support the letter you want" is a valid, valuable output** — as is
+  advising a narrower stance than the one requested.

--- a/nppf-2024-12/policy-representation/references/house-style.md
+++ b/nppf-2024-12/policy-representation/references/house-style.md
@@ -1,0 +1,120 @@
+# House style — how a strong policy-led representation reads
+
+The goal is a representation a busy case officer can act on: **concise, specific, evidenced,
+and easy to lift into the officer report.** These are the writing rules applied at the drafting
+stage. They match the other representation skills in this repo, with the policy-led and
+support-specific moves flagged.
+
+## Voice and stance
+
+- **Measured, specific, and framed in policy.** The force comes from the plan's own words set
+  against the application's own documents — not from adjectives. "The scheme is unacceptable" is
+  an opinion; "Policy `[ref]` permits development outside the settlement boundary only where
+  (a)–(e) apply, and the Planning Statement engages none of them" is an argument.
+- **One voice, either stance.** A letter of support is written to the same standard as an
+  objection: policies quoted, facts referenced, the contrary case answered. Support that reads
+  as enthusiasm carries no weight; support that resolves a policy question for the officer does.
+- **Concede what is true.** In objection, say which policies the scheme complies with. In
+  support, say where the analysis found conflict and why it does not defeat the scheme. A
+  representation that only argues one way reads as advocacy and is discounted accordingly.
+- **Material considerations only.** Policy compliance, the evidence base, the effects the plan
+  addresses. Not property values, not a private view, not the applicant's identity or motives,
+  not competition with an existing business.
+- **Never overstate the analysis.** A tension is a tension; a gap in the evidence is a gap, not
+  a breach. The credibility of the strong points depends on the weak ones being described
+  accurately.
+
+## The policy-led spine
+
+- **The development plan leads.** Open on the statutory starting point — determination in
+  accordance with the development plan unless material considerations indicate otherwise — and
+  make the adopted plan's policies the backbone. National policy supports the point; it does not
+  usually lead it.
+- **Quote the policy, then the document.** Requirement first, fact second, conclusion third. The
+  officer can then verify both in seconds.
+- **Name the plan and its adoption date** the first time you cite it, so every reference is
+  unambiguous — plans are replaced, and saved policies from earlier plans are common.
+- **Lead with the most important policies.** The spatial strategy or settlement-boundary policy,
+  the site's allocation or designation, and the principal topic policies decide applications;
+  parking standards and refuse storage do not.
+- **Weight, honestly signalled.** If a policy is out-of-date, or a plan is only emerging, say so
+  and say what weight it should carry. Claiming full weight for an emerging policy is the
+  quickest way to lose the reader.
+- **Distinguish the three asks.** Demonstrated conflict → refusal. A policy requirement that
+  cannot be assessed on the submitted evidence → do not determine yet. A resolvable point →
+  the specific condition. Mixing them up is the most common failure in lay representations.
+
+## Structure
+
+1. **Header block**; **RE line** (application reference and site); **opening** — consultation
+   status, the stance in one sentence, the request that the representation be placed on the
+   file, and any **declaration of interest**.
+2. **Framework list** — a short **bulleted** list of the development plan documents and the
+   policies engaged, with national policy noted separately and at lower weight.
+3. **Numbered sections** — one policy point per numbered sub-section, each a **bold conclusion
+   heading** then one to three tight paragraphs.
+4. **The other side** — a short section acknowledging and answering the contrary case.
+5. **Summary of requests** — numbered and concrete.
+6. **Stance sentence** + sign-off.
+
+## Each point: the anatomy
+
+1. **State the conclusion in the heading** — naming the policy.
+2. **Quote the policy requirement**, with the plan name, adoption date and policy reference.
+3. **Quote or cite the application's own document** for the fact — document, author, date, and
+   the paragraph or drawing number.
+4. **Reason the conclusion** — why the fact does or does not satisfy the requirement, including
+   any exception limb relied on and why it does or does not apply.
+5. **State the ask** on a **Request:** line, with its timing.
+
+## Formatting discipline (keep it scannable)
+
+- **Shorter is stronger.** One point per paragraph; short sentences in preference to long ones
+  chained with semicolons.
+- **Break dense material out — don't run it into prose.**
+  - list the policies engaged, the criteria failed, or the missing documents as a **bulleted
+    list**;
+  - use **bold lettered sub-points** `(a)/(b)` for multi-limb policy tests and criterion-based
+    policies;
+  - present the framework list as bullets.
+- **Quote policy wording in italics or quotation marks**, and never paraphrase a requirement you
+  are relying on.
+- Bold each heading as a conclusion; end each point that carries one with a **Request:** line.
+- British spelling and a plain, formal register. Spell out an acronym once (NPPF, SPD, LPA).
+
+## Objection-specific moves
+
+- **Lead with the policy the proposal most clearly fails**, especially where it is a strategic
+  or settlement-boundary policy — a conflict there can be decisive on its own.
+- **Work through the exception limbs** of any restrictive policy and show why none applies. A
+  bare assertion of conflict invites the reply that limb (c) is met.
+- **Where the evidence is missing, argue the absence as such** — the Council cannot conclude
+  compliance with the policy, therefore the application should not be determined yet. Do not
+  dress it up as demonstrated harm.
+- **Engage the benefits.** Note where a claimed benefit is unquantified, unsecured, or already
+  required by policy, quoting the applicant's document.
+
+## Support-specific moves
+
+- **Be specific about what the scheme delivers, in policy terms.** "It provides `[n]` homes,
+  of which `[x]`% affordable, meeting the requirement of Policy `[ref]`" is worth more than any
+  amount of general approval.
+- **Answer the objections that have actually been made** where they are visible on the portal,
+  and the conflicts the analysis found — briefly, and on policy grounds.
+- **Ask for conditions that secure the benefits you are relying on.** Supporting a scheme
+  because of its affordable housing or public open space, while asking that both be secured, is
+  a stronger and more useful letter than unconditional support.
+- **Declare any interest** — applicant, agent, relative, employee, prospective purchaser,
+  competitor, or campaign involvement.
+- **Do not submit a circulated template.** Identical letters are recognised and discounted; the
+  letter should be in the writer's own words and on their own knowledge of the site.
+
+## What to leave out
+
+- Anything you cannot evidence from the plan or the application documents.
+- Non-material concerns — property values, loss of a private view, competition, the applicant's
+  identity, boundary or covenant disputes.
+- Policy references carried from memory, from a draft plan, or from a superseded plan.
+- An NPPF paragraph number that has not been verified against the current edition at run time.
+- Campaign- or consultant-specific framing — argue each point on this application's own facts.
+- Personal detail the user is not content to see published.

--- a/nppf-2024-12/policy-representation/references/representation-templates.md
+++ b/nppf-2024-12/policy-representation/references/representation-templates.md
@@ -1,0 +1,281 @@
+# Representation templates — objection and support
+
+Two **skeletons** to fill, and a condensed **worked example** of each showing the house style in
+practice. Match the examples' density, tone and layout — but every policy, quotation and figure
+must come from the adopted plan and the application documents in front of you. All references in
+square brackets are placeholders.
+
+---
+
+## Skeleton A — objection
+
+```
+[Your name]
+[Your address]
+[Email]
+
+[Date]
+
+[Planning department / Council name / address]
+[For the attention of [Case Officer], if known]
+
+RE: Application [ref] — [site address]
+[One-line description of the proposal]
+
+Dear [Sir or Madam / Mr/Ms Name],
+
+REPRESENTATION ON PLANNING POLICY GROUNDS — OBJECTION
+
+[Opening: that you are responding to the consultation; that you object; the request that this
+representation be placed on the application file. Any declaration of interest.]
+
+[The statutory starting point: the application falls to be determined in accordance with the
+development plan unless material considerations indicate otherwise. Name the development plan
+documents and their adoption dates.]
+
+The policies principally engaged are: [short bulleted list — the adopted plan policies, with
+national policy noted separately and at lower weight].
+
+## 1. [Conclusion naming the policy]
+[Quote the policy requirement. Quote the application document. Reason the conclusion. Request.]
+
+## 2. [Next point]
+…
+
+## [Matters relied on by the applicant]
+[Acknowledge the policies complied with and the benefits claimed; explain why the conflicts
+nevertheless outweigh them.]
+
+## Summary of requests
+[Numbered, concrete, each correctly timed.]
+
+For these reasons the proposal does not accord with the development plan read as a whole, and
+I object to the grant of planning permission.
+
+Yours [sincerely/faithfully],
+[Name]
+```
+
+---
+
+## Skeleton B — support
+
+```
+[Your name]
+[Your address]
+[Email]
+
+[Date]
+
+[Planning department / Council name / address]
+[For the attention of [Case Officer], if known]
+
+RE: Application [ref] — [site address]
+[One-line description of the proposal]
+
+Dear [Sir or Madam / Mr/Ms Name],
+
+REPRESENTATION ON PLANNING POLICY GROUNDS — SUPPORT
+
+[Opening: that you are responding to the consultation; that you support the application; the
+request that this representation be placed on the application file.]
+
+[Declaration of interest — state plainly if you are the applicant, their agent, a relative,
+an employee, a prospective purchaser, a competitor, or writing as part of a campaign. If you
+have no interest, a single sentence saying so is worth including.]
+
+[The statutory starting point: determination in accordance with the development plan unless
+material considerations indicate otherwise. Name the development plan documents and dates.]
+
+The policies principally engaged are: [short bulleted list, as above].
+
+## 1. [Conclusion naming the policy the scheme accords with]
+[Quote the policy requirement. Quote the application document showing it is met. Reason the
+conclusion. Any condition needed to secure it.]
+
+## 2. [Next point]
+…
+
+## [Objections and conflicts, answered]
+[Acknowledge the principal objections and any policy conflict the analysis found; explain why
+they are outweighed, are matters of detail, or can be secured or resolved by condition.]
+
+## Summary of requests
+[Numbered — normally that permission be granted, and the conditions that should secure the
+benefits relied on.]
+
+For these reasons the proposal accords with the development plan read as a whole, and I
+support the grant of planning permission[, subject to the conditions set out above].
+
+Yours [sincerely/faithfully],
+[Name]
+```
+
+---
+
+## Worked example A — objection (condensed; annotations in ⟨…⟩)
+
+> ⟨Header, RE line and opening omitted — see the skeleton. The opening states the stance in one
+> sentence and asks that the representation be placed on the file.⟩
+
+This application falls to be determined in accordance with the development plan unless material
+considerations indicate otherwise. The development plan comprises the **[Plan name]** (adopted
+**[date]**) and the **[Neighbourhood Plan name]** (made **[date]**). ⟨Name and date the plan —
+it makes every later reference unambiguous.⟩
+
+**The policies principally engaged are:** ⟨a bulleted list, not a semicolon-run⟩
+
+- Policy `[ref]` — development outside defined settlement boundaries;
+- Policy `[ref]` — design and local character;
+- Policy `[ref]` — biodiversity net gain;
+- Policy `[ref]` of the Neighbourhood Plan — `[local character / protected view]`;
+- national policy (NPPF) as a material consideration, at less weight than the adopted plan.
+
+### 1. Conflict with Policy `[ref]`: development outside the settlement boundary, no exception engaged
+⟨Lead with the strategic conflict — it can be decisive on its own.⟩
+
+Policy `[ref]` provides that *"development outside the defined settlement boundaries will not be
+permitted unless it falls within one of the exceptions at (a) to (e)"*. The site lies wholly
+outside the boundary shown on the adopted policies map. The Planning Statement (`[author]`,
+`[date]`, §`[x]`) relies on exception **(c)**, which applies only to `[the exception's terms]`;
+the proposal is not `[that]`, and no other exception is engaged. **Request:** that the
+application be refused as contrary to Policy `[ref]`.
+
+### 2. Conflict with Policy `[ref]`: scale and form not responsive to local character
+⟨A criterion-based policy — identify the criterion.⟩
+
+Policy `[ref]` requires proposals to *"respond to the character of the area in scale, form and
+materials"*. The submitted elevations (drawing `[no.]`, rev `[x]`) show a three-storey frontage
+on a street of two-storey dwellings; the Design and Access Statement (§`[x]`) addresses
+materials but not scale. Criterion `[(b)]` is therefore not met. **Request:** that the scale of
+the frontage be reduced to two storeys, or the application refused as contrary to Policy
+`[ref]`.
+
+### 3. Compliance with Policy `[ref]` (biodiversity) cannot presently be assessed
+⟨An evidence gap, argued as a gap — not as demonstrated harm.⟩
+
+Policy `[ref]` requires development to *"deliver a measurable net gain in biodiversity"*. No
+biodiversity metric or ecological appraisal has been submitted, so the Council has nothing
+against which to test the policy's requirement. This is not an assertion that the scheme fails
+the policy; it is that compliance cannot be concluded on the material before the Council.
+**Request:** that the application **not be determined** until a completed biodiversity metric
+and ecological appraisal have been submitted and consulted upon.
+
+### Matters relied on by the applicant
+⟨Engage the other side — this is what makes the rest credible.⟩
+
+I accept that the scheme complies with the adopted parking standards and with Policy `[ref]`
+on `[matter]`, and that it would deliver `[n]` dwellings, which carries weight. The affordable
+housing relied on at §`[x]` of the Planning Statement is not, however, secured by any
+completed obligation, and the economic benefits at §`[x]` are asserted without quantification.
+Neither outweighs a conflict with the plan's spatial strategy, which Policy `[ref]` exists to
+deliver.
+
+### Summary of requests
+
+1. That the application be **refused** as contrary to Policies `[ref]` and `[ref]` of the
+   `[Plan name]`;
+2. Alternatively, if the Council is minded to approve, that the frontage scale be reduced to
+   two storeys by condition;
+3. That the application **not be determined** until a biodiversity metric and ecological
+   appraisal are before the Council and have been consulted upon;
+4. That any affordable housing relied on be secured by a completed obligation before permission
+   is issued.
+
+For these reasons the proposal does not accord with the development plan read as a whole, and I
+object to the grant of planning permission.
+
+Yours faithfully,
+`[Name]`
+
+---
+
+## Worked example B — support (condensed; annotations in ⟨…⟩)
+
+> ⟨Header, RE line and opening omitted — see the skeleton.⟩
+
+I am writing in support of this application. I have no interest in the application or the site
+beyond living at the address given above. ⟨Declare the interest, or its absence, in one
+sentence — it is the first thing a reader wonders about a support letter.⟩
+
+The application falls to be determined in accordance with the development plan unless material
+considerations indicate otherwise. The development plan comprises the **[Plan name]** (adopted
+**[date]**).
+
+**The policies principally engaged are:** Policy `[ref]` (housing allocation for this site),
+Policy `[ref]` (affordable housing), Policy `[ref]` (design and local character), and Policy
+`[ref]` (open space provision).
+
+### 1. The proposal delivers the site's allocation under Policy `[ref]`
+⟨Lead with the strongest positive — accordance with an allocation is about as strong as support
+gets.⟩
+
+The site is allocated for residential development by Policy `[ref]`, which identifies an
+indicative capacity of `[n]` dwellings and requires `[the allocation's requirements]`. The
+proposal is for `[n]` dwellings and the Planning Statement (`[author]`, `[date]`, §`[x]`)
+demonstrates each of the allocation's requirements is addressed: `[list briefly]`. The proposal
+is therefore the development the plan envisaged on this site.
+
+### 2. The affordable housing exceeds the requirement of Policy `[ref]`
+⟨Specific, quantified, and tied to the policy — with the securing point made.⟩
+
+Policy `[ref]` requires `[x]`% affordable housing on schemes of `[n]` dwellings or more. The
+scheme offers `[y]`%, above the policy requirement, in the tenure split sought by the policy
+(Planning Statement §`[x]`). **Request:** that this be secured by a completed obligation, so
+that the benefit I rely on in supporting the application is delivered.
+
+### 3. The design responds to local character as Policy `[ref]` requires
+⟨Support on a design policy needs to be as evidenced as an objection would be.⟩
+
+Policy `[ref]` requires proposals to respond to the character of the area in scale, form and
+materials. The street elevations (drawing `[no.]`) show a two-storey frontage matching the
+prevailing height, and the materials schedule at §`[x]` of the Design and Access Statement uses
+`[materials]`, consistent with the `[local]` palette described in the policy's supporting text.
+
+### Objections and conflicts, answered
+⟨The section that distinguishes a useful support letter from a useless one.⟩
+
+I am aware that objections have been made on `[traffic / parking]` grounds, and that a
+`[shortfall against the open space standard in Policy [ref]]` has been identified. On the
+first, the Transport Statement (§`[x]`) shows the access geometry meets the adopted standard and
+the highway authority has raised no objection. On the second, the shortfall is `[extent]` and
+Policy `[ref]` itself allows for a commuted sum where on-site provision is not practicable;
+that is a matter capable of resolution by obligation rather than a reason to refuse a scheme
+that delivers an allocated site.
+
+### Summary of requests
+
+1. That planning permission be **granted**;
+2. That the affordable housing at `[y]`% and the tenure split be secured by a completed
+   obligation before permission is issued;
+3. That the materials and boundary treatments shown in the Design and Access Statement be
+   secured by condition;
+4. That any open space shortfall be addressed by a commuted sum under Policy `[ref]`.
+
+For these reasons the proposal accords with the development plan read as a whole, and I support
+the grant of planning permission, subject to the conditions and obligations set out above.
+
+Yours faithfully,
+`[Name]`
+
+---
+
+## Notes on adapting the examples
+
+- **Lead with the most important policy** — the spatial strategy or settlement-boundary policy,
+  or the site's allocation. Detailed standards belong further down or not at all.
+- **Three to six points.** Both examples make three and answer the other side. A longer letter
+  is usually a weaker one.
+- **Keep the three asks distinct** — refusal for demonstrated conflict, "do not determine yet"
+  for an unassessable policy requirement, and a condition where the point is resolvable. Example
+  A deliberately does all three, on different points.
+- **Support letters carry the declaration of interest and the "objections answered" section.**
+  Without them a support letter is easy to discount.
+- **Do not submit either example as a form letter.** Rewrite in the user's own words, on the
+  facts of the application in front of them; circulated identical letters are recognised and
+  given little weight.
+- **Before submitting:** a person must read and check the draft — every policy quotation against
+  the adopted plan, and every figure against the application documents — and be aware the
+  representation is normally **published on the council's portal in the submitter's name** and
+  kept on the record, so it should contain only personal details the user is content to make
+  public. This is a draft aid provided with no warranty; it is not legal advice.

--- a/nppf-2024-12/transport-representation/CHANGELOG.md
+++ b/nppf-2024-12/transport-representation/CHANGELOG.md
@@ -1,0 +1,91 @@
+# Changelog — transport-representation
+
+Design decisions per revision, newest first. See `../CLAUDE.md` for the format and the
+house rules. The **_Why_** lines record the rationale so a future editor understands the
+intent.
+
+## Unreleased
+
+### Fixed
+- **Conditions six-tests citation corrected from NPPF para 56 to para 57.** _Why:_ para 56
+  was the December 2023 number; the December 2024 edition renumbered the chapter (as this
+  file's own edition note records). Caught by the verification pass that built the
+  `national-planning-policy` skill — the drift it exists to prevent.
+
+### Changed
+- **`national-guidance.md` now defers to the companion `national-planning-policy` skill**
+  for the NPPF/PPG edition register, the verify-before-citing protocol, and the shared
+  decision-making core; this file keeps only the topic layer. _Why:_ reviewer feedback —
+  per-skill NPPF snapshots drift out of sync as editions change; one register, checked
+  first, keeps the citations consistent (two-layers house rule).
+
+### Added
+- **A/B/C outcome discipline:** every point must be classified as **(A)** demonstrated
+  unacceptable impact (refusal reason), **(B)** insufficient evidence to reach the necessary
+  conclusion (do-not-determine-yet ask), or **(C)** controllable by condition/obligation
+  (mitigation ask) — plus a pre-send checklist item that no point asks for refusal where a
+  condition would lawfully and satisfactorily do. _Why:_ reviewer feedback — an inadequate
+  assessment does not necessarily mean the development is unacceptable, only that the LPA
+  cannot presently be satisfied that it is; conflating the two (or over-asking for refusal
+  on conditionable points) is the classic credibility mistake in lay objections.
+
+### Changed
+- **Enforced the bullet / lettered-sub-point drafting discipline** in `house-style.md` and
+  the `objection-template.md` worked example (bulleted framework list; bulleted list of
+  omissions in the worked point 1; explicit rule to use `(a)/(b)/(c)` for multi-limb points
+  and to avoid semicolon-chained lists). _Why:_ a live test draft came out noticeably denser
+  than the ecology skill's output — long paragraphs, semicolon-run lists, no bullets. The
+  house style always intended "break dense material out," but the template's worked example
+  modelled the denser style, so the skill reproduced it. Fixing the exemplar and the rule
+  makes the cleaner layout the default, not a matter of luck.
+- **"What you need first" now says uploaded/pasted/already-downloaded documents work
+  directly, and `planning-document-search` is only needed when the user doesn't have
+  them.** _Why:_ the old wording ("get them from the council's planning portal") read as
+  an instruction to fetch, risking a retrieval detour when the user has already supplied
+  the files; it also completes the retrieval skill's fail-fast handover (stop → download
+  manually → feed the files back in here).
+
+## 0.1.0 — 2026-08-14 — Initial release
+
+First version, built to the same pattern as the ecological-representation skill: a skill that
+(1) evaluates the transport/highways evidence submitted with a UK planning application,
+(2) maps each deficiency to the national/local transport policy and guidance it engages, and
+(3) drafts a concise representation — or advises that none is warranted. Structure:
+`SKILL.md` + `references/` (`deficiency-catalogue.md`, `national-guidance.md`,
+`house-style.md`, `objection-template.md`). Key design decisions:
+
+### Added
+- **The integrity principle plus two transport-specific framing rules.** _Why:_ (a) only
+  object where the evidence is genuinely inadequate — "don't object" is a valid output; (b)
+  **don't fight the settled parts** — on reserved-matters/s73 the principle and access are
+  fixed, so the fight is over *delivery* of the secured mitigation; (c) **pick the winnable
+  test** — capacity/congestion refusal needs a "severe" residual cumulative impact (a high
+  bar), so aim at sustainable-transport, active-travel, inclusive-design and evidence-
+  adequacy grounds instead. These three rules are what keep transport objections credible.
+- **Deficiency catalogue** distilled from worked representations: accessibility measured from
+  the access not the dwellings; inflated walking benchmarks; no route-quality or external
+  connectivity audit; no LTN 1/20 analysis / no forecast flows; public transport unassessed;
+  dated/selective trip data and monitoring from part-built sites; cycle parking double-counted
+  with car parking; opportunistic and inequitable parking; shared-surface/inclusive-design
+  gaps; failure to deliver outline mitigation; s73 loosening of banked infrastructure
+  triggers; internal inconsistencies; and the decision-maker's own duty.
+- **The "spine" argument as a distinct, reusable ground:** a highway-authority "no objection"
+  addresses safety and capacity only; transportational sustainability is the LPA's
+  responsibility as decision-maker. _Why:_ this recurs across strong representations and is
+  the point most often missing from officer reports.
+- **House style + annotated template** matching the ecology skill: measured expert voice,
+  material-considerations-only, quote-the-assessment-against-itself, accept the settled parts,
+  numbered summary of requests, and an optional "if minded to approve" set of enforceable
+  safeguards (milestone-linked caps, works secured up front, monitoring with teeth, committee
+  determination).
+
+### Changed / Security
+- **Scoped to transport, England-focused, explicitly not legal advice; no warranty; human
+  review required; public-document-in-your-name flag.** _Why:_ honest bounds and the same
+  user-protection disclaimers carried by the other skills — the tool drafts something a user
+  may submit to a public body in their own name.
+- **Built generic and public-safe from the start.** No case-, campaign-, consultant- or
+  place-specific fingerprints; local policy references left as `[insert …]` placeholders and
+  any "named inquiry against the same applicant/consultancy" framing kept only as generic
+  *guidance to exclude* it. _Why:_ per the repo house rules, the skill must be a reusable,
+  neutral tool that identifies no real dispute, applicant or consultant.

--- a/nppf-2024-12/transport-representation/LICENSE
+++ b/nppf-2024-12/transport-representation/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ian Howard
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/nppf-2024-12/transport-representation/README.md
+++ b/nppf-2024-12/transport-representation/README.md
@@ -1,0 +1,58 @@
+# Transport Representation
+
+A skill for producing a rigorous, credible representation on the **transport/highways**
+merits of a UK planning application — or advising that no sustainable objection exists.
+England-focused.
+
+> **Not legal advice. No warranty.** Output is a draft aid provided "as is". **A human must
+> review and check it before submitting.** Note that a UK planning representation is
+> normally **published on the council's portal in the submitter's name** and kept on the
+> record — include only personal details you're content to make public.
+
+It does three things:
+
+1. **Evaluate** the applicant's transport evidence (Transport Assessment/Statement, Travel
+   Plan, parking schedules, street-layout drawings, and the mitigation secured at outline)
+   against current policy and design guidance, and identify the material deficiencies.
+2. **Map** each deficiency to the specific national and local transport policy and guidance
+   it engages.
+3. **Draft** the representation in clear, precise, concise language — to the house style of
+   a strong representation.
+
+## Contents
+
+| File | What it is |
+|---|---|
+| `SKILL.md` | The skill: workflow, the integrity principle and two transport framing rules, and pointers to the references. **Start here.** |
+| `references/deficiency-catalogue.md` | Function 1 — the evaluation checklist: recurring, defensible grounds, each with the tell, why it matters, what it breaches, and the ask. |
+| `references/national-guidance.md` | Function 2 — the policy/guidance catalogue with citations and superseded-edition traps. |
+| `references/house-style.md` | Function 3 — how a strong representation reads. |
+| `references/objection-template.md` | Skeleton + annotated worked example. |
+| `CHANGELOG.md` | Design decisions and their rationale, per revision. |
+
+## Two things that define this skill
+
+- **Aim at the winnable tests.** Refusal on capacity/congestion needs a **"severe"** residual
+  cumulative impact (a high bar); the stronger, usually-weaker-evidenced grounds are
+  sustainable-transport and active-travel compliance, inclusive design, and the adequacy of
+  the evidence — and the point that a highway-authority "no objection" is not an assessment of
+  transportational sustainability, which is the LPA's job.
+- **Don't fight the settled parts.** On reserved-matters or s73 applications, accept the
+  principle of development and the site access; press whether the layout *delivers* the
+  mitigation secured at outline.
+
+## Pairs with
+
+The **planning-document-search** skill retrieves the application documents (from a reference +
+council) that this skill then critiques.
+
+## Freshness
+
+The guidance catalogue was web-verified **August 2026**. Policy and design-guidance editions
+change (NPPF paragraph numbers, Manual for Streets, LTN status, Active Travel England's role);
+items flagged ⏳ in `national-guidance.md` are time-sensitive — **re-verify at the point of
+drafting.**
+
+## License
+
+MIT — see [`LICENSE`](LICENSE). Provided as-is, with no warranty; not legal advice.

--- a/nppf-2024-12/transport-representation/SKILL.md
+++ b/nppf-2024-12/transport-representation/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: transport-representation-nppf-2024-12
+description: >-
+  ARCHIVED - December 2024 NPPF edition (superseded 17 August 2026). Use only when the user explicitly asks to work under the pre-August-2026 framework and has confirmed they want the archived skills; outputs must state they cite a superseded framework. 
+  Evaluate the transport/highways evidence submitted with a UK planning
+  application (Transport Assessment/Statement, Travel Plan, parking schedules,
+  street-layout drawings, and mitigation secured at outline), identify the
+  national and local transport policy/guidance it engages, and draft a concise,
+  well-founded objection (or advise that no sustainable objection exists).
+  England-focused. Not legal advice; no warranty; output requires human review.
+license: MIT
+---
+
+# Transport representation on a planning application
+
+Help a member of the public produce a rigorous, credible representation on the
+**transport/highways** merits of a planning application — the kind a case officer can act
+on and lift into the officer report. The skill does three things:
+
+1. **Evaluate** the applicant's transport evidence against current policy and design
+   guidance and identify the material deficiencies.
+2. **Map** each deficiency to the specific national (and local) transport policy and
+   guidance it engages.
+3. **Draft** the representation in clear, precise, concise language — or advise that the
+   evidence is sound and no sustainable objection exists.
+
+## When to use
+
+The user has a planning application and wants to object (or find out whether they *can*
+object) on transport/highways grounds — walking and cycling connectivity, public transport,
+the Transport Assessment/Statement, trip generation and junction modelling, parking, street
+layout and inclusive design, or the delivery of transport mitigation secured at outline.
+Trigger phrases: "object on transport grounds", "is this Transport Assessment any good",
+"critique this TA / Travel Plan", "the cycling/walking assessment looks thin", "they're
+watering down the access road" (s73).
+
+Not this skill: ecology, heritage, flooding, general amenity — separate matters. This skill
+is transport only.
+
+## What you need first
+
+- The **application reference and council** (and, ideally, the documents).
+- The **transport documents themselves** — you cannot critique what you have not read.
+  Uploaded, pasted, or already-downloaded files work directly; the companion
+  **planning-document-search** skill is only needed when you don't have them (it retrieves
+  them from the reference + council). Prioritise: the Transport Assessment or
+  Transport Statement, the Travel Plan, parking schedules, the street-layout and visibility
+  drawings, and the **highway authority's consultation response** (often decisive — see the
+  integrity/spine points). On reserved-matters or s73 cases, also the **outline permission's
+  transport conditions and s106 obligations** (what mitigation was secured).
+- The **local plan's** transport and design policies and any local design guide (e.g. a
+  "healthy streets" guide) — cite these alongside national policy.
+
+## The integrity principle and two framing rules (read before drafting)
+
+**Only object where the evidence is genuinely inadequate or the impact genuinely
+unacceptable.** If the assessment measures from the right place, uses current data and
+current guidance, audits route quality, and the layout delivers the walking, cycling and
+public-transport provision policy expects, there is **no sustainable objection** — say so.
+Don't manufacture points from typos when the substance is sound; treat "don't object" as a
+valid output.
+
+Two rules specific to transport:
+- **Don't fight the settled parts.** On a reserved-matters application, the principle of
+  development and the site access are usually fixed by the outline — don't reopen them. The
+  reserved-matters stage is where the layout *delivers or designs out* the mitigation
+  secured at outline; that is the battleground.
+- **Pick the winnable test.** Refusal on *capacity/congestion* alone requires a **"severe"**
+  residual cumulative impact, or an **unacceptable** impact on highway safety (a high bar).
+  Objections are usually far stronger on **sustainable-transport and active-travel
+  compliance, inclusive design, and the adequacy of the evidence.** Aim there.
+
+**Classify every point's ask — (A) refuse, (B) don't determine yet, or (C) condition it.**
+An evidential deficiency is not itself a reason for refusal. For each confirmed point, be
+explicit about which outcome it supports: **(A)** the evidence *demonstrates* an unacceptable
+impact (the "severe"/safety bar, or clear policy conflict) → a refusal reason; **(B)** the
+evidence is *insufficient* for the Council to reach the necessary conclusion (no route audit,
+no forecast flows, stale trip data) → the application should **not be determined** until the
+information is provided; **(C)** the issue can be adequately controlled → ask for the
+*specific* condition or obligation (Travel Plan securing, cycle-parking details, delivery of
+the outline mitigation). Most deficiency findings are (B), not (A) — claiming (A) on (B)
+evidence is the classic credibility mistake. And test every point against (C): if a condition
+or s106 obligation would lawfully and satisfactorily resolve it, ask for that rather than
+refusal — over-asking weakens the whole representation.
+
+## Workflow
+
+### Step 1 — Intake and read
+Gather the documents (above). Identify: the proposal and its **stage** (outline / reserved
+matters / full / s73 variation — this changes what is still open and what "deliver the
+mitigation" means); the transport receptors and destinations (schools, shops, centre, stops,
+network); whether an **outline mitigation package** exists to be delivered; and whether the
+**highway authority** has objected, said "no objection", or asked for more information. Read
+the highway authority's response first.
+
+### Step 2 — Evaluate against the deficiency catalogue (function 1)
+Work through [`references/deficiency-catalogue.md`](references/deficiency-catalogue.md)
+against the documents. For each candidate deficiency, confirm it is **actually present** and
+**material**, and capture the *specific* evidence — the document, author, date, and the
+paragraph/table/figure. Quote the assessment's own words (and where its scope promises
+something its body never delivers). Grade findings (decision-critical vs minor) and lead with
+the decision-critical. Apply the integrity principle; drop anything you cannot evidence.
+
+Key cross-cutting tests: Are distances measured **from the dwellings**, not the site access?
+Are walking benchmarks within **guidance**? Is there a **route-quality audit** and **external
+connectivity**? Is cycling tested against **LTN 1/20** with **forecast flows**? Is **public
+transport** actually assessed? Is trip generation on **current data** and representative
+comparators? Is **cycle parking additional** (not double-counted)? Is **inclusive design**
+addressed? Does the layout **deliver the outline mitigation**? And has the **LPA** been asked
+to assess sustainability itself, rather than defer to the highway authority's remit?
+
+### Step 3 — Map to policy and guidance (function 2)
+For every confirmed deficiency, attach the precise instrument from
+[`references/national-guidance.md`](references/national-guidance.md) — NPPF sustainable-
+transport paragraphs and the "severe"/safety tests, PPG, Manual for Streets, LTN 1/20,
+Inclusive Mobility, the National Design Guide / National Model Design Code, Active Travel
+England's role, the Equality Act duty — plus the **local plan** transport/design policies and
+the outline conditions/obligations. Cite specifically, never "best practice" in the abstract.
+Verify a citation you are unsure of rather than guessing.
+
+### Step 4 — Draft (function 3)
+Draft to [`references/house-style.md`](references/house-style.md) and
+[`references/objection-template.md`](references/objection-template.md): header → RE line (note
+the application stage) → opening (consultation status; material considerations; on RM/s73
+state you don't reopen principle/access) → framework list → numbered conclusion-headed points
+(quoted evidence, why it matters, the ask and its timing) → numbered **Summary of requests**
+(include "officers to assess sustainability directly and record it in the report") → optional
+"if minded to approve" safeguards → objection sentence → sign-off. Keep it concise; lead with
+the decision-critical points; aim at the winnable tests.
+
+### Step 5 — Check before sending
+- Every point is evidenced from the documents or cited guidance; nothing asserted.
+- Quotes are accurate and referenced (§/Table/Figure).
+- It reads as material considerations, not "congestion" complaint (unless severity is
+  actually evidenced).
+- On RM/s73, it accepts the settled principle/access and targets delivery.
+- Consultant-/campaign-specific framing excluded unless the user asked and it is defensible
+  on this application's own facts.
+- Requests are concrete and correctly timed to the stage.
+- Every point is classified **(A) demonstrated harm / (B) insufficient evidence / (C)
+  conditionable** — and no point asks for refusal where a condition or obligation would
+  lawfully and satisfactorily do.
+- Deadline: note if consultation has closed; representations remain material while the
+  application is undecided.
+- **Hand back to a human, with the two warnings:** the draft must be read and checked by a
+  person before submission, and submitting it puts a **public document in the user's name**
+  on the council's portal — confirm they're content with the content and the personal
+  details included.
+
+## Reference files
+
+- [`references/deficiency-catalogue.md`](references/deficiency-catalogue.md) — the evaluation
+  checklist: recurring, defensible grounds, each with the tell, why it matters, what it
+  breaches, and the ask.
+- [`references/national-guidance.md`](references/national-guidance.md) — the policy/guidance
+  catalogue, with citations, to map deficiencies to instruments.
+- [`references/house-style.md`](references/house-style.md) — how a strong representation reads.
+- [`references/objection-template.md`](references/objection-template.md) — skeleton +
+  annotated worked example.
+
+## Scope and limitations
+
+- **Not legal advice, and no warranty.** This helps a lay objector marshal evidence and cite
+  policy; it is not a substitute for a solicitor or a transport professional, guarantees no
+  outcome, and is provided "as is" with no warranty of accuracy or fitness for purpose.
+- **Human review is necessary before submitting.** A person must read the draft, check every
+  quote and citation against the actual documents, and confirm the points are correct and
+  fair for this application. Do not submit skill output unread.
+- **A UK planning representation is a public document in your name.** Comments and objections
+  are normally published on the council's planning portal, typically including the submitter's
+  name (and sometimes address), and kept on the record. Tell the user before they submit and
+  let them choose what personal details to include.
+- **England-focused.** The NPPF, PPG and most design guidance cited are England; devolved
+  policy differs in Wales/Scotland/NI — flag when the application is outside England and adjust
+  the citations.
+- **Evidence-bound.** Every point stands or falls on the submitted documents and the cited
+  guidance. Do not invent flows, distances or survey results; where information is missing,
+  that *absence* is itself the point ("no forecast flows are presented"), argued as such.
+- **The honest answer is sometimes "don't object."** Treat that as a valid, valuable output.

--- a/nppf-2024-12/transport-representation/references/deficiency-catalogue.md
+++ b/nppf-2024-12/transport-representation/references/deficiency-catalogue.md
@@ -1,0 +1,226 @@
+# Transport submission — deficiency catalogue
+
+The recurring, defensible grounds on which a planning application's **transport evidence**
+(Transport Assessment / Transport Statement, Travel Plan, parking schedules, street-layout
+and visibility drawings, and — at reserved matters or on a s73 variation — the delivery of
+the transport mitigation secured at outline) can be challenged. Each entry is a *pattern to
+look for*, not a template sentence: find the specific instance in the documents in front of
+you, quote it, and attach the request.
+
+Use this as the evaluation checklist (skill function 1). Cross-references point to
+[`national-guidance.md`](national-guidance.md); cite the specific instrument, not "best
+practice" in the abstract.
+
+> **Integrity rule (read first).** Only raise a deficiency that is actually present and
+> material. If the assessment measures from the right place, uses current data and current
+> guidance, audits route quality, and the layout delivers the active-travel and public-
+> transport provision the policy expects, there is **no sustainable objection** — say so.
+> Don't manufacture points from typos when the substance is sound.
+>
+> **Two framing rules specific to transport:**
+> - **Don't fight the settled parts.** On a *reserved matters* application the principle of
+>   development and the site access are usually fixed by the outline permission — don't try
+>   to reopen them. The reserved-matters stage is where the layout *delivers or designs out*
+>   the mitigation secured at outline; that is the battleground.
+> - **Pick the right test.** Refusal on *capacity/congestion* alone requires a **"severe"**
+>   residual cumulative impact, or an **unacceptable** impact on highway safety (a high bar
+>   — see national-guidance). Objections are usually far stronger on **sustainable-transport
+>   and active-travel compliance, inclusive design, and the adequacy of the evidence** than
+>   on "there will be more traffic." Aim there.
+
+---
+
+## A. Accessibility measured wrong, or not at all
+
+**A1 — Distances measured from the site access, not the dwellings.**
+- *Tell:* every walking/cycling distance (e.g. "X m to the station") is stated "from the
+  site access."
+- *Why it matters:* residents live *behind* the access, not at it, so every journey is
+  understated — and the whole sustainability case rests on these distances.
+- *Ask:* re-state all distances and conclusions from representative dwelling locations.
+
+**A2 — Walking-distance benchmarks stretched beyond guidance.**
+- *Tell:* the assessment adopts inflated "acceptable" walking distances (e.g. from an
+  observed-behaviour study) well beyond the convenience benchmarks in CIHT/MfS/National
+  Design Guide; sometimes justified as "using judgement to modify guidance."
+- *Why it matters:* observed/tolerated distances describe what *some* people put up with,
+  not what *most* find genuinely attractive; on the assessment's own tables, key
+  destinations often fall beyond every guidance distance.
+- *Ask:* re-assess against the recognised walking-distance benchmarks; where destinations
+  lie beyond them, the case must rest on public transport and cycling (which then must be
+  properly assessed — see B).
+
+**A3 — No distances measured at all / no assessment of key destinations.**
+- *Tell:* the document's own scope promises a connectivity assessment, but the section
+  contains none — no distances "to anything," no routes to school, shops, centre, network.
+- *Ask:* an addendum assessing walking/cycling connectivity to each key destination, with
+  distances from dwellings and a plan of every access point.
+
+---
+
+## B. Route quality and active travel not assessed
+
+**B1 — No route-quality audit.** Distance tables but no audit of the routes themselves:
+footway continuity and width, lighting, crossings on desire lines (are they controlled?),
+gradient, severance, personal security after dark. A route that is not safe and convenient
+*in practice* does not provide a genuine choice of modes.
+- *Ask:* a route-quality audit (lighting, footways, crossings, severance), with mitigation
+  where routes fail.
+
+**B2 — External connectivity not assessed.** Assessment stops at the red line; no routes to
+schools, shops, town centre, employment or the wider walking/cycling network; no pedestrian/
+cycle access points shown or related to desire lines and to the off-site active-travel
+infrastructure expected by policy or secured at outline.
+- *Ask:* an external connectivity plan showing every access point and how it connects.
+
+**B3 — No LTN 1/20 assessment for cycling.** Cycling dismissed in a line ("on-street cycling
+is acceptable") with **no forecast link flows** and no test against the LTN 1/20 thresholds
+for inclusive mixed-traffic cycling (motor-traffic volume and speed limits — see
+national-guidance for the figures). Where the spine street carries the whole development's
+traffic, mixed-traffic cycling may not be appropriate and dedicated provision must be
+designed in *now* (at reserved matters) or it never will be.
+- *Ask:* forecast daily flows for each street type; an LTN 1/20 compliance statement; a
+  cycle-connectivity plan to the external network.
+
+**B4 — Public transport not assessed.** The word "bus" barely appears; no walking routes or
+times to the stops (including any funded by a s106 obligation), no crossing provision to
+reach stops across the carriageway, no demonstration that stop locations relate to the
+site's access points.
+- *Ask:* a plan of walking routes/times to each stop with safe crossings, and confirmation
+  the layout does not prejudice secured public-transport infrastructure.
+
+---
+
+## C. Trip generation, data and modelling
+
+**C1 — Trip generation on dated or selectively-chosen data.** Modal split from the **2011
+Census** (or otherwise out of date) feeding trip generation and junction modelling, while
+current (2021) data is used elsewhere in the same document where it helps; or a "sustainable
+area" claim resting on a high car-driver mode share.
+- *Ask:* re-base modal split on current data and re-run the junction assessments if
+  materially changed.
+
+**C2 — Unrepresentative TRICS comparators.** Trip rates drawn from comparator sites that
+don't match this site's type, size or location (e.g. edge-of-town comparators for an urban
+site), or an unstated/opaque site selection.
+- *Ask:* a transparent, representative comparator set.
+
+**C3 — Monitoring data from a partially-built site treated as robust.** Observed trip rates
+from a partly-occupied, partly-constructed site used to argue generation is low and more
+occupation can be absorbed. Early occupations skew demographically, construction suppresses/
+redistributes trips, and post-pandemic baselines flatter the comparison.
+- *Ask:* the officer report to engage explicitly with these limitations; scrutinise any new
+  survey for seasonality and neutrality of the survey period.
+
+**C4 — Selective use of assessment tools.** Relying on the one favourable output of a tool
+(e.g. a connectivity/accessibility tool) while its other outputs, or the tool's own
+guidance, point the other way.
+- *Ask:* the full tool outputs and an assessment consistent with the tool's own guidance.
+
+---
+
+## D. Parking
+
+**D1 — Cycle parking double-counted with car parking.** A garage counted as a **car space**
+in the parking schedule *and* relied on as the dwelling's **cycle parking** — a garage can't
+store both a car and the household's cycles. Guidance treats cycle parking as *additional*,
+secure and conveniently accessible.
+- *Ask:* a schedule identifying cycle parking that is genuinely additional to car parking,
+  dwelling by dwelling.
+
+**D2 — Parking applied opportunistically; over-provision undermines modal shift.** The site
+is classified as "low accessibility" to justify generous maximum parking, in tension with
+the "sustainable location" case made at outline. Provision well above ~2 spaces/dwelling
+actively undermines the travel-plan and car-club modal-shift objectives and the vision-led
+approach.
+- *Ask:* review whether the overall quantum is consistent with the travel-plan objectives.
+
+**D3 — Below-standard parking for affordable tenure; overspill risk.** Standards applied
+generously to private plots but deficiently to affordable plots; the resulting overspill
+concentrates on the narrowest streets/shared surfaces and the local road.
+- *Ask:* provision meeting the adopted standard for *every* tenure, or a reasoned
+  justification plus an overspill-parking assessment.
+
+---
+
+## E. Inclusive design and specific users
+
+**E1 — Shared surfaces / single-sided footways without inclusive-design assessment.**
+Footways that reduce to one side or to a shared surface, with no inclusive-design review.
+Shared surfaces are recognised as posing serious difficulties for blind and partially-
+sighted people (who lose the kerb line), and the authority has its own Equality Act 2010
+duty in approving these details.
+- *Ask:* an inclusive-design review of all shared-surface and single-sided sections
+  demonstrating compliance with Inclusive Mobility, or conventional footways on desire lines.
+
+**E2 — Peripheral users / rural lanes not assessed.** Parts of the scheme (e.g. plots or
+uses reached off a separate lane) get a swept-path drawing and nothing else — no assessment
+of the lane's width, condition, lighting, forward visibility, passing provision, and **no
+pedestrian provision at all** for those residents (who will then walk in the carriageway in
+the dark). Sustainability obligations apply to every user, not just the main dwellings.
+- *Ask:* a suitability and pedestrian-access assessment for the lane, with a safe route onto
+  the internal footway network and onward to schools/stops.
+
+---
+
+## F. Delivery of what was secured at consent (reserved matters & s73)
+
+**F1 — The layout doesn't demonstrate delivery of the outline mitigation.** Outline
+permission was justified on a package of sustainable-transport mitigation (off-site active-
+travel works, access points for pedestrians/cyclists, public-transport contributions, a
+travel plan, a car club). The reserved-matters layout must *connect to and deliver* that
+package; instead the assessment doesn't address it, risking foreclosing it permanently.
+- *Ask:* demonstrate, on plan, how the layout delivers each secured commitment; resolve
+  before the reserved matters are approved.
+
+**F2 — A s73 / condition variation loosens an infrastructure trigger secured at consent.**
+An application seeks to release occupations from an infrastructure trigger (e.g. an access
+road, active-travel works) that the acceptability of the scheme was predicated on —
+substituting lesser interim mitigation of unstated duration. Where acceptability was
+established on infrastructure commitments and those are loosened application-by-application
+once the principle is banked, *the development consulted on is not the development built.*
+- *Ask:* treat the condition trigger as the safeguard it is; if minded to approve, tie
+  occupation caps to construction milestones of the secured infrastructure (see H).
+
+---
+
+## G. Evidence quality and the decision-maker's role
+
+**G1 — Internal inconsistencies.** Contradictory figures that go to the document's
+reliability: a design speed given as two different values in two sections; two tables with
+the same number; an accommodation or parking schedule whose rows don't sum; unexplained
+fractional space counts. Individually minor, collectively they show a document produced
+without adequate checking.
+- *Ask:* the errors reconciled; an internally contradictory evidence base cannot be relied
+  on.
+
+**G2 — "Highways has no objection" is not an assessment of sustainability (the spine).** A
+highway authority's consultation response typically addresses **safety and capacity** only;
+**transportational sustainability** — whether the layout prioritises sustainable modes,
+delivers the active-travel connections, and complies with NPPF sustainable-transport policy
+— is the **local planning authority's** responsibility as decision-maker. A highway-
+authority "no objection" must not be treated as an assessment of the matters you raise.
+- *Ask:* officers to assess the sustainable-transport matters directly and record that
+  assessment in the officer report, rather than deferring to the highway authority's remit.
+
+**G3 — The highway authority itself found the evidence insufficient.** The highway authority
+recommends "more information" / awaits further surveys before a comprehensive response — so
+the evidence the application was consulted on is, by the body best placed to judge,
+inadequate.
+- *Ask:* no determination until the further material is submitted and assessed; and, because
+  the public consulted on the superseded evidence, **full public re-consultation** on the
+  revised material.
+
+---
+
+## H. "If minded to approve" — fallback safeguards
+
+Where an objection may not prevent approval, ask for enforceable safeguards rather than
+leaving matters to good faith:
+- occupation caps tied to **construction milestones** of the secured infrastructure
+  (commencement, earthworks, base course, opening) — not merely a higher dwelling number;
+- the mitigation works **secured up front**, with completion triggers, before the relevant
+  occupations;
+- a **monitoring-and-review** mechanism with teeth — a defined trip threshold at which
+  further occupations pause;
+- **committee determination** where objection volume and strategic significance warrant it.

--- a/nppf-2024-12/transport-representation/references/house-style.md
+++ b/nppf-2024-12/transport-representation/references/house-style.md
@@ -1,0 +1,109 @@
+# House style — how a strong transport representation reads
+
+The goal is a representation a busy case officer can act on: **concise, specific,
+evidenced, and easy to lift into the officer report.** These are the writing rules the
+skill applies at the drafting stage (function 3). They mirror the approach of a good
+ecological representation; the transport-specific moves are flagged.
+
+## Voice and stance
+
+- **Measured and expert, never emotive.** The force comes from specificity — quoting the
+  applicant's own Transport Assessment against itself — not from volume. You are helping
+  the Council apply the tests correctly.
+- **Material considerations only.** Everything must be a planning material consideration:
+  the adequacy of the transport evidence, compliance with national/local transport policy
+  and design guidance, deliverability of the secured mitigation. Not "there'll be more
+  traffic and I don't like it."
+- **Accept what is settled.** On a reserved-matters or s73 application, say at the outset
+  that you are *not* seeking to reopen the principle of development or the site access —
+  they are fixed by the outline. This buys credibility and focuses the officer on the live
+  question: does the layout deliver the sustainable-transport outcomes the outline relied
+  on?
+- **Concede what is sound; don't manufacture.** If the assessment does something right,
+  don't attack it. If the whole thing is sound, advise *not* objecting.
+- **No personal criticism.** Critique the document and the method, not individuals.
+
+## Aim at the winnable tests
+
+Transport objections are often lost when pitched as "congestion." National policy sets a
+high bar for refusal on capacity (a **"severe"** residual cumulative impact) or safety (an
+**unacceptable** impact). Pitch instead — or as well — at the grounds where the bar is
+lower and the evidence is usually weaker:
+
+- **sustainable-transport / active-travel compliance** (the vision-led approach; walking,
+  cycling and public-transport provision);
+- **inclusive design** (shared surfaces, footways; the Equality Act duty);
+- **the adequacy and internal consistency of the evidence** (measured from the wrong place,
+  dated data, no route audit, no LTN 1/20 analysis);
+- **the decision-maker's own duty** — that a highway-authority "no objection" is not an
+  assessment of transportational sustainability.
+
+## Structure
+
+1. **Header block** — your name/address/email, the Council's address, date, case officer if
+   known.
+2. **RE line** — application reference + site + a one-line description (note if it's outline,
+   reserved matters, full, or a s73 variation — this frames everything).
+3. **Opening** — note consultation status; the matters are material considerations while the
+   application is undecided; ask that the representation be placed on the file. On RM/s73,
+   state you don't seek to reopen principle/access.
+4. **Framework list** — a short bulleted list of the transport policy/guidance engaged (see
+   `national-guidance.md`). Signals rigour and anchors every later point.
+5. **Numbered sections** — one deficiency per numbered sub-section, each with a **bold
+   one-line heading that states the point as a conclusion**, then 1–3 tight paragraphs.
+6. **Summary of requests** — a single numbered list of concrete asks, mostly ending "before
+   determination"; include the "officers to assess sustainability directly and record it in
+   the officer report" ask.
+7. **"If minded to approve"** (optional) — enforceable safeguards as a fallback (occupation
+   caps tied to construction milestones, works secured up front, monitoring with teeth,
+   committee determination).
+8. **Objection sentence** + sign-off.
+
+## Each point: the anatomy
+
+1. **Name the defect** in the heading as a conclusion ("Cycling: a one-sentence assessment
+   with no LTN 1/20 analysis").
+2. **Quote the document** — the applicant's own words with the paragraph/table/figure
+   reference (`§4.3.1`, `Table 4.1`). Quoting the assessment against itself is the strongest
+   move. Note where the document's own *scope* promises something its body never delivers.
+3. **Say why it matters** in planning terms — the consequence for the decision and the
+   specific policy/guidance breached, cited precisely (e.g. NPPF sustainable-transport
+   paragraph; LTN 1/20; Manual for Streets; Inclusive Mobility).
+4. **State the ask** — the specific thing to do and *when* ("before determination", "at
+   reserved matters", "secured by condition/obligation").
+
+## Load-bearing arguments (use where they fit)
+
+- **"Resolve by evidence, not condition / not at a later stage."** Serious gaps go to
+  whether the layout is acceptable now; granting first can foreclose the connections
+  permanently.
+- **"The layout delivers or designs out the outline commitments."** The reserved-matters
+  stage is where secured mitigation is delivered — or quietly lost.
+- **"Highways assesses safety and capacity; sustainability is the LPA's job."** A consultee
+  "no objection" is not an assessment of the matters you raise.
+- **"The development consulted on is not the development built."** For s73/condition
+  variations that loosen infrastructure triggers banked at consent.
+
+## Length, formatting, and what to leave out
+
+- **Shorter is stronger.** One point per paragraph; cut throat-clearing; if a sentence
+  doesn't add a fact or a consequence, delete it. Prefer short sentences to long ones
+  chained with semicolons.
+- **Break dense material out — don't run it into prose.** This is what keeps the
+  representation scannable:
+  - where a point lists several things (missing items, destinations, defects), use a
+    **bulleted list**, not a semicolon-run inside a paragraph;
+  - where a point has two or more distinct limbs, use **bold lettered sub-points**
+    `(a)/(b)/(c)`;
+  - present the framework list as bullets;
+  - keep paragraphs short — a busy officer should see each point's structure at a glance.
+- Bold each sub-section heading as a conclusion; italicise quoted document text; keep bullets
+  parallel and short; end each point with a **Request:** line.
+- British spelling and legal register ("the Council", "determination", "material
+  consideration"). Spell out an acronym once (TA/TS, LTN 1/20, MfS, ATE).
+- Reference documents precisely by author and date the first time ("the Transport Statement
+  ([consultant], [date])").
+- **Leave out:** anything you can't evidence; consultant- or campaign-specific framing (e.g.
+  cross-referencing other live applications or a named inquiry) — default to omitting it and
+  argue each point on this application's own facts; padding and repetition; and "congestion"
+  complaints that don't meet the "severe" test unless you can actually evidence severity.

--- a/nppf-2024-12/transport-representation/references/national-guidance.md
+++ b/nppf-2024-12/transport-representation/references/national-guidance.md
@@ -1,0 +1,252 @@
+# National transport policy and guidance (England)
+
+The framework to cite when mapping a deficiency (skill function 2). **Cite the specific
+instrument and clause, never "best practice" in the abstract.** Each deficiency in
+[`deficiency-catalogue.md`](deficiency-catalogue.md) points here.
+
+The **current NPPF/PPG edition register, the verify-before-citing protocol, and the shared
+decision-making core** (s.38(6) and plan primacy, the para 11 presumption and its footnotes,
+emerging-plan weight, the conditions and obligations tests) live in the companion
+**national-planning-policy** skill — check it first when citing the NPPF/PPG. This file owns
+only the topic-specific layer.
+
+> **Compiled and web-verified 14 August 2026 (England).** Several items are time-sensitive
+> — the NPPF is under review and its paragraph numbers shift between editions, Manual for
+> Streets is being updated, and some exact figures need checking in the source PDF.
+> **Re-verify anything marked ⏳ before relying on it**, and confirm the current NPPF
+> paragraph numbers at the date you draft. This is not legal advice.
+>
+> **Scope:** the NPPF, PPG and most design guidance below are **England**. For Wales /
+> Scotland / NI, substitute the devolved policy and flag it.
+
+---
+
+## Part 1 — National planning policy (NPPF)
+
+**NPPF — December 2024 edition** (MHCLG, published 12 Dec 2024; current). Transport is
+**Chapter 9, "Promoting sustainable transport", paragraphs 109–118.** ⏳ The chapter
+renumbered **+1** from the Dec 2023 edition (it was 108–117), so **older documents and even
+the PPG cite the old numbers** — always confirm the current number. A Dec 2025 consultation
+draft exists but is **not** in force.
+Source: assets.publishing.service.gov.uk/media/67aafe8f3b41f783cca46251/NPPF_December_2024.pdf
+
+- **Para 109 — vision-led approach** *(was 108)*: transport considered from the earliest
+  stages "using a vision-led approach to identify transport solutions that deliver
+  well-designed, sustainable and popular places"; includes **109(d)** realising
+  opportunities from existing/proposed transport infrastructure and **109(e)** promoting
+  walking, cycling and public transport. ("Vision-led" is new Dec 2024 wording.)
+- **Para 111(d) — networks** *(was 110)*: policies should provide attractive, well-designed
+  walking and cycling networks with supporting facilities such as secure cycle parking,
+  drawing on **Local Cycling and Walking Infrastructure Plans (LCWIPs)**.
+- **Para 112–113 — parking** *(numbering shifts between editions — ⏳ verify)*: local parking
+  standards must reflect accessibility, type/mix of development, public-transport
+  availability, car-ownership and EV charging; maximum standards only with clear and
+  compelling justification. (There is **no national maximum** standard.)
+- **Para 115 — considering proposals** *(was 114)*: **115(a)** sustainable transport modes
+  **prioritised**; **115(b)** **safe and suitable access for all users**; **115(c)** the
+  **design of streets/parking reflects current national guidance, including the National
+  Design Guide and National Model Design Code**; **115(d)** significant network/safety
+  impacts cost-effectively mitigated to an acceptable degree via a vision-led approach.
+- **Para 116 — the refusal tests** *(was 115) — the key hook, and the high bar*: verbatim —
+  "Development should only be prevented or refused on highways grounds if there would be an
+  **unacceptable impact on highway safety, or the residual cumulative impacts on the road
+  network, following mitigation, would be severe**, taking into account all reasonable future
+  scenarios." Two distinct tests; **"severe" is undefined**. *Consequence for objections:*
+  a pure capacity/congestion objection must clear the "severe" bar — usually hard — so lead
+  instead on the sustainable-transport, access, design and evidence grounds below.
+- **Para 117 — priority to sustainable modes and disabled users** *(was 116)*: **117(a)**
+  priority **first to pedestrians and cyclists**, second to public transport; **117(b)**
+  **address the needs of people with disabilities and reduced mobility across all modes**;
+  117(c) minimise conflict; 117(d) servicing/emergency access; 117(e) EV charging.
+- **Para 118 — when a TA/TS and Travel Plan are required** *(was 117)*: "All developments
+  that will generate significant amounts of movement should be required to provide a travel
+  plan, and the application should be supported by a **vision-led transport statement or
+  transport assessment** so that the likely impacts… can be assessed and monitored."
+
+The **National Design Guide** (2019, rev. Jan 2021) "**Movement**" theme (well-connected,
+walkable neighbourhoods prioritising walking/cycling/PT) and the **National Model Design
+Code** (Jan 2021) are the design references para 115(c) points to.
+
+---
+
+## Part 2 — Planning Practice Guidance (PPG)
+
+**"Travel plans, transport assessments and statements"** (category ID 42; paras dated
+06-03-2014 — old but current). gov.uk/guidance/travel-plans-transport-assessments-and-statements
+- **Proportionality — 42-007:** assessment must be "proportionate to the size and scope of
+  the proposed development" — a thin document for a high-impact scheme is non-compliant.
+- **TA vs TS — 42-004:** a Transport Assessment is thorough; a Transport Statement is
+  lighter-touch for limited impacts.
+- **Required content — 42-015:** should cover (proportionately) access/layout, public
+  transport data, trip generation/travel characteristics, accident records, environmental
+  impacts, parking and mitigation — a checklist for exposing gaps.
+- **When required — 42-013:** established as early as possible; triggered by "significant
+  amounts of movement", judged case-by-case including **cumulative impacts**.
+- **Travel Plans — 42-003 / -011 / -012:** long-term management strategies with targets,
+  measures, monitoring and review, secured by condition/obligation.
+- **"Conditions are not a substitute for adequate assessment"** — this is **not** in the
+  transport PPG; anchor it to the **six tests for planning conditions** (NPPF para 57 / PPG
+  "Use of planning conditions", category 21): a condition must be *necessary* and cannot cure
+  a fundamental evidence deficiency.
+
+---
+
+## Part 3 — Active Travel England (ATE) — statutory consultee
+- **Statutory basis:** Town and Country Planning (Development Management Procedure) (England)
+  (Amendment) Order **2023 (SI 2023/142)**, amending the DMPO 2015; ATE is a statutory
+  consultee for applications made **on or after 1 June 2023**.
+- **Thresholds** (LPA must consult ATE): **≥150 dwellings**, **or** ≥**7,500 m²**
+  non-residential floorspace, **or** site area ≥**5 hectares**.
+- **ATE Planning Application Assessment Tool** scores proposals against ~31 criteria drawn
+  from **Manual for Streets, the National Model Design Code, Inclusive Mobility and LTN 1/20**
+  (segregation, crossings, junction assessment, minimum widths, walking/cycling distances).
+  A scheme scoring poorly, or departing from LTN 1/20 without justification, is vulnerable;
+  ATE's response is a material consideration. activetravelengland.gov.uk/planning
+
+---
+
+## Part 4 — The decision-maker vs the highway authority (the "spine")
+- The **local highway authority** (county/unitary) is a statutory consultee under the DMPO
+  2015; its remit is the **highway/traffic impact — safety and network capacity**.
+- **Transportational sustainability** — whether the scheme prioritises sustainable modes,
+  delivers active-travel connections, and meets NPPF para 116's tests — is for the **LPA as
+  decision-maker** (and, on appeal, the Inspector).
+- A consultee's response, **including a "no objection", is advice, not determination**: it
+  must be conscientiously weighed but is not binding, and relying on it uncritically —
+  without grappling with the concerns raised — is challengeable.
+- ⏳ *Caveat:* there is **no single codified NPPF/PPG sentence and no single leading named
+  case** squarely stating the "safety = highway authority / sustainability = LPA" split. It
+  is a structural principle (DMPO remit + para 116 being a decision for the decision-maker +
+  the general public-law rule that consultee responses are advisory). Argue it as such, not
+  as a one-case ratio.
+
+---
+
+## Part 5 — Equality Act 2010 / inclusive access
+- **Public Sector Equality Duty — Equality Act 2010, s.149:** in approving a street layout the
+  authority must have **due regard** to the needs of people with protected characteristics
+  (**disability**, **age**) — "in substance, with rigour and with an open mind", **at the
+  time** of the decision (*R (Bracking) v SSWP* [2013] EWCA Civ 1345). A failure genuinely to
+  consider effects on disabled/older/mobility-impaired people is challengeable.
+- **Shared space is paused:** the DfT **Inclusive Transport Strategy (July 2018)** asked
+  authorities to **pause new shared-space schemes with a level surface**; **LTN 1/11 "Shared
+  Space" was withdrawn (Aug 2018)** and not replaced; a joint ministerial letter (Sept 2018)
+  confirmed the pause and stressed formal crossings for visually-impaired people. A proposed
+  level-surface shared-space scheme runs against this.
+
+---
+
+## Part 6 — Other statutory/policy context
+- **National Highways / strategic road network:** DfT **Circular 01/2022** "The strategic road
+  network and the delivery of sustainable development" (supersedes 02/2013) sets the policy
+  National Highways applies; it is a statutory consultee under the DMPO where the SRN
+  (motorways/trunk roads) may be affected (safety, queuing, access).
+- **Speed limits:** DfT **Circular 01/2013 "Setting Local Speed Limits"** (current; 20 mph
+  guidance updated 17 Mar 2024 — ⏳ re-check for later revision) — the framework for local
+  speed limits and design speed.
+- **Active-travel strategy context:** "**Gear Change**" (DfT, July 2020) and the statutory
+  **Cycling and Walking Investment Strategy** (CWIS 2017; **CWIS2 2022**, under the
+  Infrastructure Act 2015), which underpin LCWIPs and LTN 1/20.
+
+---
+
+## Part 7 — Technical design guidance (what "competent" work follows)
+
+Deviation from the current edition — especially citing a **superseded/withdrawn** one — is a
+core objection ground. Traps are consolidated in Part 8.
+
+### Street design
+- **Manual for Streets (DfT, 2007)** + **Manual for Streets 2 (CIHT, 2010)** — **both current
+  and in force.** Design-led, place-based streets: a user hierarchy putting pedestrians first,
+  **design speeds derived from geometry** (not the reverse), justified (not excessive)
+  visibility splays/forward visibility, connected networks over cul-de-sacs, considered use of
+  shared surfaces. ⏳ An update ("MfS3"/"Manual for Streets 2026") is **drafted but NOT yet
+  published**; CIHT confirms the 2007/2010 advice still stands — don't let a report pre-empt an
+  unpublished edition.
+- **National Design Guide (2019, rev. Jan 2021)** — the "Movement" characteristic
+  (well-connected, walkable, active-travel-prioritising layouts).
+- **National Model Design Code (Jan 2021)** — Parts 1 & 2; movement/street types.
+
+### Cycling
+- **LTN 1/20 "Cycle Infrastructure Design" (DfT, July 2020)** — the national cycle-design
+  standard. ⚠ **Supersedes and withdraws LTN 2/08 (2008)** and LTN 1/12 — a report citing
+  LTN 2/08 relies on withdrawn guidance. Key content:
+  - **Mixed-traffic threshold (para 7.1.1):** the upper limits for cycling in mixed traffic
+    are **20 mph and 2,500 motor vehicles/day**; above either, cyclists should generally be
+    separated/protected. Summary Principle 3: cycle routes shown only by markings/symbols
+    should not be used on roads with high traffic volumes/speeds. ⏳ **Figure 4.1** (speed ×
+    volume decision graph) is the visual tool; some sources read it as unprotected lanes being
+    tolerable up to ~5,000 veh/day at 20 mph — 2,500/day is the inclusivity limit, 5,000 a
+    Figure-4.1 zone reading. **Confirm the exact figure/zone in the source PDF before pinning a
+    number.**
+  - **Five core principles:** coherent, direct, safe, comfortable, attractive.
+  - **Tools:** Cycling Level of Service (**CLoS**) and the **Junction Assessment Tool (JAT)** —
+    absence of a CLoS/JAT assessment for a significant scheme is a recognised gap.
+  - **Cycle parking:** secure, accessible/convenient and **additional** (both trip ends,
+    sufficient quantity, incl. non-standard cycles) — not double-counted with car parking.
+  - PDF: assets.publishing.service.gov.uk/media/5ffa1f96d3bf7f65d9e35825/cycle-infrastructure-design-ltn-1-20.pdf
+
+### Walking / inclusive access
+- **IHT "Guidelines for Providing for Journeys on Foot" (2000)** — still cited for
+  walking-distance benchmarks. **Table 3.2 (metres): town centres** 200 desirable / 400
+  acceptable / **800 preferred maximum**; **commuting/school** 500 / 1,000 / **2,000**;
+  **elsewhere** 400 / 800 / 1,200. **CIHT "Planning for Walking" (2015)** — walkable
+  neighbourhoods with facilities within ~**800 m / ~10 min**. *Key nuance:* an "acceptable"/
+  tolerated maximum is **not** an "attractive" distance — quoting a maximum-tolerance figure to
+  claim a site is "within walking distance" misuses the guidance.
+- **Inclusive Mobility (DfT, Dec 2021)** — current; ⚠ **supersedes the 2002 edition**. Footway
+  clear width **2,000 mm normal minimum**, **1,500 mm** acceptable where constrained (with
+  passing places), **1,000 mm** absolute minimum at an isolated obstacle; tactile paving,
+  dropped kerbs/crossings, gradients; and the **difficulties shared/level surfaces pose for
+  blind and partially-sighted people** (loss of the kerb line). Detailed tactile-paving
+  reference: DfT *Guidance on the Use of Tactile Paving Surfaces* (1998, reprinted 2007).
+
+### Assessment methods & tools
+- **Guidance on Transport Assessment (GTA, 2007)** — ⚠ **WITHDRAWN (Oct 2014)**, replaced by
+  the NPPF + PPG. Reports still cite it as current — it is withdrawn national guidance.
+- **TRICS (current version 8)** + the **TRICS Good Practice Guide** — the trip-generation
+  database. Comparator sites must be genuinely comparable in land use, size, location type and
+  PT accessibility; cherry-picked, unrepresentative, too-small or dated comparator sets breach
+  the Good Practice Guide. **The 2021 Census supersedes the 2011 Census** — a modal-split case
+  on 2011 data is out of date.
+- **DfT Connectivity Tool** and the **Propensity to Cycle Tool** — accessibility/cycling-
+  potential tools; misuse = selectively quoting favourable outputs contrary to the tool's own
+  guidance (e.g. presenting a target/"Go Dutch" scenario as current demand).
+- **Parking:** no national maxima (former PPG13 maxima removed); standards are local, per NPPF.
+  Two recurring objection points: the **tension between a "sustainable/accessible location"
+  claim and a "low accessibility" maximum-parking classification** (a site can't be both), and
+  **cycle parking counted separately, not double-counted** with a car space in a garage.
+
+### Travel Plans
+- Framework: NPPF + PPG (2014). A Travel Plan needs measurable **modal-shift targets**, a
+  defined **measures** package, a **monitoring** regime (baseline + re-surveys), a **review/
+  remedial** mechanism, and **funding/securing** (s106/condition, coordinator, monitoring fee/
+  bond). ⚠ A Travel Plan is **not a substitute for good layout** — behavioural measures cannot
+  cure a car-dependent or poorly-connected design.
+
+---
+
+## Part 8 — Superseded / withdrawn quick reference (citing the old one is an objection ground)
+
+| Topic | Current | Superseded / withdrawn (⚠ if cited as current) |
+|---|---|---|
+| Cycle infrastructure design | **LTN 1/20 (July 2020)** | LTN 2/08 (2008), LTN 1/12 — withdrawn |
+| Transport assessment methodology | **NPPF + PPG (2014)** | Guidance on Transport Assessment (2007) — withdrawn Oct 2014 |
+| Inclusive/pedestrian access | **Inclusive Mobility (Dec 2021)** | Inclusive Mobility (2002) |
+| Shared space | **paused; LTN 1/11 withdrawn (2018)** | LTN 1/11 "Shared Space" (2011) |
+| Modal-split / census data | **2021 Census** | 2011 Census |
+| National Design Guide | **2021 revised** | 2019 original |
+| Street design | **MfS (2007) + MfS2 (2010)** | ⏳ "MfS3" not yet published — don't cite as current |
+
+## Part 9 — ⏳ Verify-before-relying (time-sensitive as of Aug 2026)
+
+- **NPPF paragraph numbers** — Dec 2024 edition used here (chapter renumbered +1 from Dec
+  2023; parking-paragraph numbers vary between editions); a Dec 2025 draft exists. Confirm the
+  live edition and number when you draft.
+- **LTN 1/20 Figure 4.1 exact zone boundaries** — the 2,500 vs ~5,000 veh/day reading;
+  confirm in the source PDF before quoting a precise figure.
+- **Manual for Streets update** — "MfS3"/"2026" drafted but not published; re-check gov.uk.
+- **Active Travel England** — role/thresholds current as of the 2023 order; confirm no change.
+- **Circular 01/2013** — 20 mph wording updated Mar 2024; re-check for later revision.
+- **CLoS/JAT and Inclusive Mobility exact figures** — confirm the precise chapter/section in
+  the source before quoting paragraph numbers.

--- a/nppf-2024-12/transport-representation/references/objection-template.md
+++ b/nppf-2024-12/transport-representation/references/objection-template.md
@@ -1,0 +1,180 @@
+# Objection template + annotated worked example
+
+A **skeleton** to fill, and a **worked example** showing the house style in practice. Match
+the example's density and tone, not its exact wording — every point must come from the
+documents actually in front of you.
+
+---
+
+## Skeleton
+
+```
+[Your name]
+[Your address]
+[Email]
+
+[Date]
+
+[Planning department / Council name / address]
+[For the attention of [Case Officer], if known]
+
+RE: Application [ref] — [site]
+[One-line description — note whether outline / reserved matters / full / s73 variation]
+
+Dear [Sir or Madam / Mr/Ms Name],
+
+REPRESENTATION ON TRANSPORT AND HIGHWAYS GROUNDS — OBJECTION UNLESS MATTERS RESOLVED
+
+[Opening: consultation status; matters are material considerations while undecided; ask
+that this be placed on the file. On reserved matters / s73, state you do NOT seek to
+reopen the principle of development or the site access — only whether the layout delivers
+the sustainable-transport outcomes the outline relied on.]
+
+[State which documents you address — the Transport Assessment/Statement (author, date),
+the Travel Plan, the parking schedules, the layout drawings — and, on RM/s73, the
+transport mitigation secured at outline.]
+
+The relevant framework includes: [short bulleted list from national-guidance.md — only
+the instruments actually engaged].
+
+## 1. [Point stated as a conclusion]
+[Quote the document (§/Table/Figure). Why it matters for the decision + the guidance/
+policy breached. The ask and its timing.]
+
+## 2. [Next point]
+…
+
+## Summary of requests
+[Numbered, concrete, grouped, mostly "before determination"; include the ask that officers
+assess sustainability directly and record it in the officer report.]
+
+[Optional] If the Council is nonetheless minded to approve: [enforceable safeguards —
+occupation caps tied to construction milestones, works secured up front, monitoring with
+teeth, committee determination].
+
+Unless and until these matters are resolved, I object to [the grant of permission /
+approval of the reserved matters / this s73 variation].
+
+Yours [sincerely/faithfully],
+[Name]
+```
+
+---
+
+## Worked example (condensed — annotations in ⟨…⟩)
+
+> ⟨Header, RE line and opening omitted for brevity — see the skeleton. On a reserved-matters
+> application the opening accepts that principle and access are settled by the outline, and
+> frames the issue as delivery of the sustainable-transport mitigation the outline relied
+> on.⟩
+
+**The relevant framework includes:** ⟨keep to what is engaged — see national-guidance.md.
+Present it as a short bulleted list, not a semicolon-run.⟩
+
+- the NPPF's sustainable-transport policies — the vision-led approach and the priority to
+  walking, cycling and public transport;
+- Manual for Streets and Manual for Streets 2;
+- LTN 1/20 (Cycle Infrastructure Design);
+- Inclusive Mobility, and the Council's Equality Act 2010 duty;
+- the National Design Guide and National Model Design Code;
+- **[the Local Plan's transport and design policies — insert the specific references]**;
+- the transport conditions and obligations attached to the outline permission.
+
+### 1. The assessment does not assess external walking and cycling connectivity at all
+⟨Point the document's own scope at its empty body; then bullet the omissions — don't run
+them together with semicolons.⟩
+
+The Transport Statement's own scope states that its Section 3 "presents the development
+proposal, *including the pedestrian and cycle connections*." It does no such thing. The
+document nowhere assesses:
+
+- walking and cycling routes from the dwellings to the adjoining school, local shops or the
+  town centre;
+- the directness, gradient, lighting or personal security of any external route;
+- the pedestrian and cycle access points, and how they meet desire lines;
+- crossings of the main road to the bus stops; or
+- **any distances whatsoever, to anything.**
+
+The reserved matters fix the internal layout that must connect to the off-site active-travel
+infrastructure secured at outline. A layout approved without demonstrating those connections
+risks foreclosing them permanently.
+
+**Request:** an addendum assessing connectivity to each key destination — distances from
+representative dwellings, a route-quality and lighting audit, and a plan of every access
+point and how it connects to the secured off-site infrastructure.
+
+### 2. Cycling: a one-sentence assessment with no LTN 1/20 analysis
+⟨Quote the single sentence; contrast it with the guidance thresholds and the missing data.⟩
+
+Cycling is dealt with in a single line — "on-street cycling is acceptable" — with **no
+forecast link flows presented anywhere.** LTN 1/20 sets thresholds for when mixed-traffic
+cycling is appropriate (motor-traffic volume and speed limits — see national-guidance). The
+spine street will carry the traffic of the whole development; if it exceeds those
+thresholds, dedicated provision (or a demonstrated parallel route) is required — and it must
+be designed in *now*, at reserved matters, or it never will be. **Request:** forecast daily
+flows for each street type; an LTN 1/20 compliance statement; and an external cycle-
+connectivity plan.
+
+### 3. Cycle parking double-counted with car parking
+⟨A crisp, self-evident inconsistency.⟩
+
+The schedule counts each garage as a **car parking space** and simultaneously states that
+**cycle parking** is provided "within the garages." A single garage cannot store a car and
+the household's cycles at once; guidance treats cycle parking as *additional*, secure and
+accessible provision, so counting the same floorspace towards both standards overstates
+compliance with each. **Request:** a revised schedule identifying cycle parking that is
+genuinely additional to car parking, dwelling by dwelling.
+
+### 4. The Council must make its own sustainability assessment
+⟨The spine argument — reserve it as a distinct point so the officer records it.⟩
+
+These are planning matters, not highway-engineering matters. A highway-authority "no
+objection" typically addresses safety and capacity only; whether this layout prioritises
+sustainable modes, delivers the active-travel connections secured at outline, and complies
+with the NPPF's sustainable-transport policy is for the Council as decision-maker. I ask
+that officers assess points 1–3 directly and record that assessment in the officer report,
+rather than treating the highway authority's consultation response as sufficient.
+
+### Summary of requests
+⟨Concrete, numbered, timed. What the officer lifts into the report.⟩
+
+Before determination:
+1. A pedestrian and cycle connectivity addendum: distances from representative dwellings
+   (not the site access), a route-quality and lighting audit, and a plan of all access
+   points connecting to the off-site active-travel infrastructure secured at outline;
+2. A public-transport access plan: walking routes and crossings to each funded stop;
+3. Forecast internal link flows and an LTN 1/20 compliance statement for each street type,
+   with an external cycle-connectivity plan;
+4. Cycle parking demonstrated to be additional to, not shared with, car parking;
+5. A direct assessment by the Council of the sustainable-transport matters above, recorded
+   in the officer report — noting that the highway authority's remit (safety and capacity)
+   does not extend to transportational sustainability.
+
+Unless and until these matters are resolved, I object to the approval of the reserved
+matters.
+
+Yours faithfully,
+[Name]
+
+---
+
+### Notes on adapting the example
+
+- **Frame by application type.** Outline: press the strategic sustainable-transport case and
+  the adequacy of the Transport Assessment. Reserved matters: accept principle/access, press
+  *delivery* of the secured mitigation in the layout. s73 / condition variation: press that
+  an infrastructure trigger banked at consent should not be loosened, and ask for milestone-
+  linked caps if approved.
+- **Pick the winnable tests** (see house-style): sustainable-transport/active-travel
+  compliance, inclusive design, and evidence adequacy — not bare "congestion", which needs a
+  **"severe"** residual cumulative impact to found refusal.
+- **Consultant- or campaign-specific framing is excluded by default** — cross-referencing
+  other live applications, or citing a named public inquiry to attack a particular applicant
+  or consultancy. Raise each point on this application's own facts. (The underlying technical
+  points — measuring from the access, inflated walking distances, no route audit, LTN 1/20
+  non-compliance — are free-standing grounds in `deficiency-catalogue.md`.)
+- **Before submitting:** a person must read and check the draft — every quote and citation
+  against the actual documents — and be aware the representation is normally **published on
+  the council's portal in the submitter's name** and kept on the record, so include only
+  personal details the user is content to make public. This is a draft aid provided with no
+  warranty; it is not legal advice.


### PR DESCRIPTION
Closes #31. Implements the agreed design:

- **`nppf-2024-12/`** — frozen snapshot of the nine NPPF-dependent skills from `eadf859` (last pre-remap commit), byte-verified against the git blobs. Only deltas: `-nppf-2024-12` name suffixes + ARCHIVED description prefixes (collision safety). `planning-document-search` excluded (edition-neutral); `appeal-precedent-analysis` excluded (post-dates the remap).
- **Ask-first routing** in `national-planning-policy`'s edition register: explicit request to work under the December 2024 framework → offer the archived skills and confirm; incidental old paragraph numbers → current skills + crosswalk; live applications → always current edition; archived outputs state they cite a superseded framework.
- **Archive README** with scope and caveats (frozen-as-was; predates the #22 style fixes — stated, not backported).
- **Root README** "Older NPPF editions" section; **CLAUDE.md house rule 10**: archives are frozen, and future NPPF editions snapshot-then-remap (rule 9 numbering untouched — existing "house rule 9" references remain valid).

Note: the working tree carried an unrelated uncommitted duplicate of the PR #29 Wealden registry entry (from a parallel session); it is deliberately not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dg62ktGPUauVwt8qNuQHQ8